### PR TITLE
feat: frontend API wiring (BO #30-33) + analytics bug fix

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "https://api-production-9bef.up.railway.app/api/:path*",
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -245,7 +245,16 @@ export default function AnalyticsPage() {
               Status
             </span>
           </div>
-          {topTweets.map((tweet, i) => (
+          {(topDrafts.length > 0
+            ? topDrafts.map((d) => ({
+                snippet: d.content.slice(0, 80) + (d.content.length > 80 ? "..." : ""),
+                engagement: d.predictedEngagement
+                  ? `${(d.predictedEngagement / 1000).toFixed(1)}k`
+                  : "—",
+                status: d.status.toLowerCase(),
+              }))
+            : topTweets
+          ).map((tweet, i) => (
             <div
               key={i}
               className="flex flex-col sm:grid sm:grid-cols-[1fr_100px_80px] px-4 sm:px-6 py-4 border-b border-glass-border last:border-0 hover:bg-glass transition-colors gap-1 sm:gap-0"
@@ -276,7 +285,20 @@ export default function AnalyticsPage() {
           Model Learning Log
         </h2>
         <div className="space-y-4">
-          {learningLog.map((entry, i) => (
+          {(logEntries.length > 0
+            ? logEntries.map((e) => ({
+                date: new Date(e.createdAt).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit",
+                }),
+                event: e.event,
+                impact: e.impact,
+                positive: e.positive,
+              }))
+            : learningLog
+          ).map((entry, i) => (
             <div
               key={i}
               className="flex items-center justify-between py-3 border-b border-glass-border last:border-0"

--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/lib/auth";
 import { api, TeamAnalyst, TeamMember } from "@/lib/api";
 
 const days = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
+// TODO: wire to analytics API when available
 const modelTarget = [50, 55, 60, 58, 65, 62, 70];
 const teamActual = [45, 58, 55, 65, 60, 68, 75];
 
@@ -42,12 +43,11 @@ export default function ManagementPage() {
 
   useEffect(() => { loadData(); }, [loadData]);
 
-  // Derive KPIs from real data, fall back to static
-  const totalAnalysts = team.length || 25;
-  const activeThisWeek = team.filter((m) => m._count.sessions > 0).length || 18;
+  const totalAnalysts = team.length;
+  const activeThisWeek = team.filter((m) => m._count.sessions > 0).length;
   const avgEngagement = analysts.length > 0
     ? Math.round(analysts.reduce((sum, a) => sum + a._count.tweetDrafts, 0) / analysts.length)
-    : 2100;
+    : 0;
 
   const kpiCards = [
     { label: "Total Analysts", value: String(totalAnalysts), change: null as string | null },
@@ -55,24 +55,15 @@ export default function ManagementPage() {
     { label: "Avg Drafts/Analyst", value: String(avgEngagement), change: null },
   ];
 
-  // Build table from real team data or use static fallback
-  const tableData = team.length > 0
-    ? team.map((m) => ({
-        name: m.displayName || m.handle,
-        sessions: m._count.sessions,
-        drafts: m._count.tweetDrafts,
-        posts: 0,
-        maturity: m.voiceProfile?.maturity || "BEGINNER",
-        maturityColor: maturityColor(m.voiceProfile?.maturity),
-        stale: m._count.sessions === 0,
-      }))
-    : [
-        { name: "Alex M.", sessions: 142, drafts: 86, posts: 42, maturity: "ADVANCED", maturityColor: "text-atlas-success", stale: false },
-        { name: "Priya K.", sessions: 204, drafts: 112, posts: 98, maturity: "INTERMEDIATE", maturityColor: "text-atlas-teal", stale: false },
-        { name: "Julian R.", sessions: 88, drafts: 24, posts: 12, maturity: "BEGINNER", maturityColor: "text-atlas-warning", stale: true },
-        { name: "Sarah W.", sessions: 156, drafts: 78, posts: 64, maturity: "ADVANCED", maturityColor: "text-atlas-success", stale: false },
-        { name: "Chen L.", sessions: 42, drafts: 12, posts: 4, maturity: "BEGINNER", maturityColor: "text-atlas-warning", stale: true },
-      ];
+  const tableData = team.map((m) => ({
+    name: m.displayName || m.handle,
+    sessions: m._count.sessions,
+    drafts: m._count.tweetDrafts,
+    posts: 0,
+    maturity: m.voiceProfile?.maturity || "BEGINNER",
+    maturityColor: maturityColor(m.voiceProfile?.maturity),
+    stale: m._count.sessions === 0,
+  }));
 
   // Top performers sorted by drafts
   const leaderboard = [...tableData]
@@ -138,17 +129,25 @@ export default function ManagementPage() {
               </tr>
             </thead>
             <tbody>
-              {tableData.map((row) => (
-                <tr key={row.name} className="border-b border-glass-border last:border-0 hover:bg-glass transition-colors">
-                  <td className="px-6 py-4 text-sm text-atlas-text font-medium">{row.name}</td>
-                  <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.sessions}</td>
-                  <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.drafts}</td>
-                  <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.posts}</td>
-                  <td className="px-6 py-4">
-                    <span className={`text-[10px] font-bold uppercase tracking-wide ${row.maturityColor}`}>{row.maturity}</span>
+              {tableData.length === 0 && !loading ? (
+                <tr>
+                  <td colSpan={5} className="px-6 py-12 text-center text-sm text-atlas-text-secondary">
+                    No team members found. Invite analysts to get started.
                   </td>
                 </tr>
-              ))}
+              ) : (
+                tableData.map((row) => (
+                  <tr key={row.name} className="border-b border-glass-border last:border-0 hover:bg-glass transition-colors">
+                    <td className="px-6 py-4 text-sm text-atlas-text font-medium">{row.name}</td>
+                    <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.sessions}</td>
+                    <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.drafts}</td>
+                    <td className="px-6 py-4 text-sm text-atlas-text-secondary">{row.posts}</td>
+                    <td className="px-6 py-4">
+                      <span className={`text-[10px] font-bold uppercase tracking-wide ${row.maturityColor}`}>{row.maturity}</span>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>

--- a/src/app/team-library/page.tsx
+++ b/src/app/team-library/page.tsx
@@ -5,7 +5,7 @@ import AppShell from "@/components/layout/AppShell";
 import GradientButton from "@/components/ui/GradientButton";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/lib/auth";
-import { api, TweetDraft, TeamMember } from "@/lib/api";
+import { api, TweetDraft } from "@/lib/api";
 
 interface StyleCard {
   tweet: string;
@@ -15,46 +15,30 @@ interface StyleCard {
   authorHandle?: string;
 }
 
-const staticStyleCards: StyleCard[] = [
-  { tweet: "DeFi isn't just rebuilding finance; it's architecting a new social contract. Liquidity is the new speech. Exit is the new vote. We are early, but the map is clear.", blend: "70% Analyst + 30% Naval", engagement: "12.4k" },
-  { tweet: "The 10-year yield is screaming. Crypto is whisper-quiet. Historically, this divergence precedes the largest structural shifts in capital allocation we've seen since the 70s.", subtext: "Volatility isn't risk; it's the price of entry for those who can see the cycle before the crowd.", blend: "90% Macro Strategist + 10% Zen", engagement: "8.2k" },
-  { tweet: "Gm to everyone building the future on-chain while the legacy world debates the definition of a spreadsheet. The alpha is in the execution, not the whitepaper.", blend: "50% Builder + 50% Optimist", engagement: "4.1k" },
-  { tweet: "Protocol-market fit is the only metric that matters. TVL is a vanity stat if it's mercenary capital waiting for the next bridge incentive.", blend: "100% Raw Data Analyst", engagement: "22.9k" },
-  { tweet: "1/ Why the ZK-rollup endgame is closer than you think. A thread on the convergence of prover efficiency and decentralized sequencing.", subtext: "Most people focus on L2 fees today. The real story is the cross-chain interoperability layer that turns 100 chains into 1 seamless experience.", blend: "60% Tech Whisperer + 40% Vitalik", engagement: "15.5k" },
-  { tweet: "Stop trading the noise. Start observing the signals. The most successful investors in this space aren't the fastest; they're the ones who can sit still the longest.", blend: "80% Stoic + 20% Balaji", engagement: "6.7k" },
-];
-
 export default function TeamLibraryPage() {
   const { token } = useAuth();
-  const [styleCards, setStyleCards] = useState<StyleCard[]>(staticStyleCards);
+  const [styleCards, setStyleCards] = useState<StyleCard[]>([]);
   const [loading, setLoading] = useState(false);
-  const [totalCount, setTotalCount] = useState(42);
+  const [totalCount, setTotalCount] = useState(0);
 
   const loadData = useCallback(async () => {
     if (!token) { setLoading(false); return; }
     setLoading(true);
     try {
-      const [teamRes, draftsRes] = await Promise.all([
-        api.users.team(token),
-        api.drafts.list(token, "APPROVED"),
-      ]);
-      const team = teamRes.team;
+      const draftsRes = await api.drafts.list(token, "APPROVED");
       const drafts = draftsRes.drafts;
 
-      if (drafts.length > 0) {
-        const teamMap = new Map(team.map((m: TeamMember) => [m.id, m]));
-        const cards: StyleCard[] = drafts.slice(0, 6).map((d: TweetDraft) => ({
-          tweet: d.content,
-          blend: "Team voice",
-          engagement: d.predictedEngagement
-            ? `${(d.predictedEngagement / 1000).toFixed(1)}k`
-            : d.actualEngagement
-            ? `${(d.actualEngagement / 1000).toFixed(1)}k`
-            : "—",
-        }));
-        setStyleCards(cards);
-        setTotalCount(drafts.length);
-      }
+      const cards: StyleCard[] = drafts.slice(0, 6).map((d: TweetDraft) => ({
+        tweet: d.content,
+        blend: "Team voice",
+        engagement: d.predictedEngagement
+          ? `${(d.predictedEngagement / 1000).toFixed(1)}k`
+          : d.actualEngagement
+          ? `${(d.actualEngagement / 1000).toFixed(1)}k`
+          : "—",
+      }));
+      setStyleCards(cards);
+      setTotalCount(drafts.length);
     } catch (e) {
       console.error("Failed to load team library:", e);
     } finally {
@@ -95,6 +79,11 @@ export default function TeamLibraryPage() {
       )}
 
       {/* Masonry Grid */}
+      {styleCards.length === 0 && !loading && (
+        <div className="bg-atlas-surface border border-glass-border rounded-2xl p-12 text-center mb-8">
+          <p className="text-atlas-text-secondary">No approved styles yet. Approve drafts in Crafting to build the library.</p>
+        </div>
+      )}
       <div className="columns-1 md:columns-2 gap-6 space-y-6">
         {styleCards.map((card, i) => (
           <div key={i} className="break-inside-avoid bg-atlas-surface border border-glass-border rounded-2xl p-8">


### PR DESCRIPTION
## Summary
- Add Next.js rewrite proxy for local dev CORS bypass (Railway only whitelists Vercel)
- Fix analytics page bug: Top Tweets and Learning Log sections now render live API data instead of always showing static arrays
- Management page: remove hardcoded fallback KPIs (25, 18, 2100) → show 0 when no data
- Team Library: remove static style cards, show proper empty state

## Verification
All 8 pages tested against live Railway backend:
| Page | Status | Data Source |
|------|--------|-------------|
| Dashboard | ✅ 200 | Live |
| Crafting | ✅ 200 | Live |
| Voice Profiles | ✅ 200 | Live |
| Alerts | ✅ 200 | Live |
| Analytics | ✅ 200 | Live KPIs + fallback for empty log |
| Management | ✅ 403 | Expected (test user not manager) |
| Team Library | ✅ 200 | Live empty state |
| Telegram | ✅ N/A | Static page |

`next build` passes with zero errors.

## Test plan
- [ ] Verify login flow works end-to-end
- [ ] Check dashboard shows live analytics data
- [ ] Confirm analytics page renders API data when available
- [ ] Verify management page gracefully handles non-manager access

🤖 Generated with [Claude Code](https://claude.com/claude-code)