### PR TITLE
feat: Sentry monitoring, version history, engagement loop (BO 7-12, 36, 38)

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,15 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+export const onRequestError = async (
+  ...args: Parameters<NonNullable<typeof import("@sentry/nextjs").captureRequestError>>
+) => {
+  const { captureRequestError } = await import("@sentry/nextjs");
+  captureRequestError(...args);
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,7 @@ export default withSentryConfig(withBundleAnalyzer(nextConfig), {
   project: process.env.SENTRY_PROJECT,
   silent: !process.env.CI,
   widenClientFileUpload: true,
+  tunnelRoute: "/monitoring",
   disableLogger: true,
   automaticVercelMonitors: true,
 });


### PR DESCRIPTION
## Summary
- **BO #7**: Team Library cross-team feed via /api/drafts/team
- **BO #9**: Version history sidebar with LCS word-diff on crafting page
- **BO #10**: Post-publish engagement tracking form
- **BO #36**: Sentry error monitoring with global-error boundary
- **BO #38**: Seed demo data prisma config

## Test plan
- [ ] `next build` passes with 0 errors
- [ ] Sentry receives test errors
- [ ] `npm run smoke` passes against running backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)