### PR TITLE
feat: remove analytics fallback mocks (BO #55)

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -57,14 +57,7 @@ export default function VoiceProfilesPage() {
     setBlendValues(newValues);
   };
 
-  // Fallback display voices if none from API yet
-  const displayVoices = references.length > 0
-    ? references
-    : ["Cobie", "Hsaka", "Ansem", "Hasu", "DegenSpartan", "Mando"].map((name, i) => ({
-        id: `placeholder-${i}`,
-        name,
-        isActive: true,
-      }));
+  const displayVoices = references;
 
   const displayBlends = blends.length > 0
     ? blends.map((b) => ({ name: b.name, mix: b.voices.map((v) => `${v.percentage}% ${v.label}`).join(" + ") }))
@@ -186,9 +179,14 @@ export default function VoiceProfilesPage() {
           Create or Edit a Blend
         </h3>
         <div className="space-y-4">
-          {["My voice", "Reference A", "Reference B", "Reference C"].map((label, i) => (
+          {[
+            "My voice",
+            ...(references.length > 0
+              ? references.slice(0, 3).map((r) => r.name)
+              : ["Reference A", "Reference B", "Reference C"]),
+          ].map((label, i) => (
             <div key={label} className="flex items-center gap-4">
-              <span className="text-sm text-atlas-text-secondary w-28 shrink-0">{label}</span>
+              <span className="text-sm text-atlas-text-secondary w-28 shrink-0 truncate">{label}</span>
               <input
                 type="range"
                 min={0}
@@ -203,7 +201,7 @@ export default function VoiceProfilesPage() {
         </div>
         <div className="mt-4 bg-atlas-nav rounded-2xl p-4">
           <p className="text-sm text-atlas-text-secondary italic">
-            Preview: &quot;The merge was 18 months ago and we&apos;re still arguing about MEV. Builders are the new miners — and they&apos;re playing a completely different game.&quot;
+            Preview will generate once you save a blend and craft your first draft with it.
           </p>
         </div>
         <p className="text-atlas-text-muted text-xs mt-2">


### PR DESCRIPTION
## Summary
- Replace hardcoded confidence trend sparkline with real engagement accuracy data
- Replace hardcoded growth velocity (dates, progress bar) with real activity data
- Remove fake reference voice names, use actual API data
- Dynamic blend creator labels from real reference voices
- Empty states for all sections when no data available

## Test plan
- [ ] `/analytics` shows empty states when no data, real data when available
- [ ] `/voice-profiles` shows empty state instead of fake names
- [ ] `next build` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)