### PR TITLE
fix: remove duplicate AnalystPeak interface (BO 54)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -310,12 +310,6 @@ export interface AlertSubscription {
   delivery: string[];
 }
 
-export interface AnalystPeak {
-  name: string;
-  days: number;
-  hasDrafts: boolean;
-}
-
 export interface TeamAnalyst {
   id: string;
   handle: string;


### PR DESCRIPTION
## Summary
- Remove duplicate AnalystPeak interface from api.ts
- Frontend wiring for days-to-peak was already complete (api client + management page)
- Backend endpoint GET /api/analytics/days-to-peak still needed (handoff created)

## Test plan
- [x] `next build` passes with 0 errors
- [ ] Backend endpoint returns real AnalystPeak[] data

🤖 Generated with [Claude Code](https://claude.com/claude-code)