### PR TITLE
fix: typed error handling — zero any types (CODEX-11)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,8 +39,8 @@ export default function LoginPage() {
         await register(handle.trim(), email.trim(), password, "A");
         router.push("/onboarding/track-a");
       }
-    } catch (err: any) {
-      setError(err.message || "Something went wrong");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- Replace last `catch (err: any)` with `catch (err: unknown)` + `instanceof Error` check in page.tsx
- Zero `: any` annotations remaining across the portal codebase

## Test plan
- [ ] `next build` passes
- [ ] Login/register error handling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)