### PR TITLE
feat: Admin QA Test Runner (/admin/qa)

### DIFF
--- a/playwright-qa.config.ts
+++ b/playwright-qa.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://delphi-atlas.vercel.app",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/src/app/admin/qa/page.tsx
+++ b/src/app/admin/qa/page.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import AppShell from "@/components/layout/AppShell";
+import { useAuth } from "@/lib/auth";
+import { api, QaTestRun } from "@/lib/api";
+import { sections, TOTAL_TESTS, type TestCase, type TestSection } from "./test-definitions";
+
+type TestStatus = "pending" | "pass" | "fail" | "skip";
+
+interface TestResult {
+  status: TestStatus;
+  note: string;
+  tester: string;
+  timestamp: string;
+}
+
+type ResultsMap = Record<string, TestResult>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function computeSummary(results: ResultsMap) {
+  let pass = 0;
+  let fail = 0;
+  let skip = 0;
+  for (const r of Object.values(results)) {
+    if (r.status === "pass") pass++;
+    else if (r.status === "fail") fail++;
+    else if (r.status === "skip") skip++;
+  }
+  return { pass, fail, skip, total: TOTAL_TESTS };
+}
+
+function sectionBadge(sectionTests: TestCase[], results: ResultsMap) {
+  let done = 0;
+  let fails = 0;
+  for (const t of sectionTests) {
+    const r = results[t.id];
+    if (r && r.status !== "pending") done++;
+    if (r && r.status === "fail") fails++;
+  }
+  if (done === 0) return { label: "Pending", cls: "bg-white/5 text-atlas-text-muted" };
+  if (fails > 0) return { label: `${fails} fail`, cls: "bg-red-500/15 text-red-400" };
+  if (done === sectionTests.length) return { label: "Done", cls: "bg-emerald-500/15 text-emerald-400" };
+  return { label: `${done}/${sectionTests.length}`, cls: "bg-blue-500/15 text-blue-400" };
+}
+
+function formatRunLabel(run: QaTestRun) {
+  const d = new Date(run.created_at);
+  const date = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const time = d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
+  const done = Object.values(run.results ?? {}).filter((r) => r.status !== "pending").length;
+  return `${date} ${time} -- ${run.tester_initials} (${done}/${TOTAL_TESTS})`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function QaTestRunnerPage() {
+  const { user, loading: authLoading } = useAuth();
+
+  const canEdit = user?.role === "ADMIN" || user?.role === "MANAGER";
+  const testerName = user?.displayName || user?.handle || "Tester";
+  const testerInitials = getInitials(testerName);
+
+  // Runs state
+  const [runs, setRuns] = useState<QaTestRun[]>([]);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [results, setResults] = useState<ResultsMap>({});
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const [loadingRuns, setLoadingRuns] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Debounce save
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestResultsRef = useRef<ResultsMap>(results);
+  latestResultsRef.current = results;
+
+  // ---- Load runs on mount ----
+  useEffect(() => {
+    let cancelled = false;
+    api.qa
+      .listRuns()
+      .then((res) => {
+        if (cancelled) return;
+        const sorted = (res.runs ?? []).sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        );
+        setRuns(sorted);
+        if (sorted.length > 0) {
+          setActiveRunId(sorted[0].id);
+          setResults((sorted[0].results ?? {}) as ResultsMap);
+        }
+      })
+      .catch(() => {
+        // API may not be deployed yet — start with empty state
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingRuns(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ---- Debounced save ----
+  const scheduleSave = useCallback(
+    (nextResults: ResultsMap) => {
+      if (!activeRunId || !canEdit) return;
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        const summary = computeSummary(nextResults);
+        setSaving(true);
+        api.qa
+          .updateRun(activeRunId, { results: nextResults, summary })
+          .catch(() => {})
+          .finally(() => setSaving(false));
+      }, 1000);
+    },
+    [activeRunId, canEdit],
+  );
+
+  // ---- Actions ----
+  const markTest = useCallback(
+    (testId: string, status: TestStatus) => {
+      if (!canEdit) return;
+      setResults((prev) => {
+        const existing = prev[testId];
+        // Toggle off if clicking same status
+        const newStatus = existing?.status === status ? "pending" : status;
+        const next: ResultsMap = {
+          ...prev,
+          [testId]: {
+            status: newStatus,
+            note: existing?.note ?? "",
+            tester: testerInitials,
+            timestamp: new Date().toISOString(),
+          },
+        };
+        scheduleSave(next);
+        return next;
+      });
+    },
+    [canEdit, testerInitials, scheduleSave],
+  );
+
+  const setNote = useCallback(
+    (testId: string, note: string) => {
+      if (!canEdit) return;
+      setResults((prev) => {
+        const existing = prev[testId];
+        const next: ResultsMap = {
+          ...prev,
+          [testId]: {
+            status: existing?.status ?? "pending",
+            note,
+            tester: existing?.tester ?? testerInitials,
+            timestamp: new Date().toISOString(),
+          },
+        };
+        scheduleSave(next);
+        return next;
+      });
+    },
+    [canEdit, testerInitials, scheduleSave],
+  );
+
+  const createRun = useCallback(async () => {
+    if (!canEdit) return;
+    try {
+      const res = await api.qa.createRun({
+        tester_name: testerName,
+        tester_initials: testerInitials,
+      });
+      const newRun = res.run;
+      setRuns((prev) => [newRun, ...prev]);
+      setActiveRunId(newRun.id);
+      setResults({});
+    } catch {
+      // Silently handle — user sees no new run appear
+    }
+  }, [canEdit, testerName, testerInitials]);
+
+  const deleteRun = useCallback(
+    async (id: string) => {
+      if (!canEdit) return;
+      if (!confirm("Delete this test run? This cannot be undone.")) return;
+      try {
+        await api.qa.deleteRun(id);
+        setRuns((prev) => prev.filter((r) => r.id !== id));
+        if (activeRunId === id) {
+          setRuns((prev) => {
+            if (prev.length > 0) {
+              setActiveRunId(prev[0].id);
+              setResults((prev[0].results ?? {}) as ResultsMap);
+            } else {
+              setActiveRunId(null);
+              setResults({});
+            }
+            return prev;
+          });
+        }
+      } catch {
+        // Silently handle
+      }
+    },
+    [canEdit, activeRunId],
+  );
+
+  const switchRun = useCallback(
+    (id: string) => {
+      const run = runs.find((r) => r.id === id);
+      if (!run) return;
+      setActiveRunId(id);
+      setResults((run.results ?? {}) as ResultsMap);
+    },
+    [runs],
+  );
+
+  const exportMarkdown = useCallback(() => {
+    const summary = computeSummary(results);
+    const pct = TOTAL_TESTS > 0 ? Math.round(((summary.pass + summary.fail + summary.skip) / TOTAL_TESTS) * 100) : 0;
+    let md = `# Atlas QA Test Report\n\n`;
+    md += `**Date:** ${new Date().toISOString().slice(0, 10)}\n`;
+    md += `**Tester:** ${testerName} (${testerInitials})\n`;
+    md += `**Progress:** ${pct}% (${summary.pass} pass, ${summary.fail} fail, ${summary.skip} skip / ${TOTAL_TESTS} total)\n\n`;
+    md += `---\n\n`;
+    for (const section of sections) {
+      md += `## ${section.title}\n\n`;
+      for (const test of section.tests) {
+        const r = results[test.id];
+        const status = r?.status ?? "pending";
+        const icon = status === "pass" ? "PASS" : status === "fail" ? "FAIL" : status === "skip" ? "SKIP" : "----";
+        md += `- [${icon}] **${test.id}** ${test.name}`;
+        if (r?.tester) md += ` _(${r.tester})_`;
+        md += `\n`;
+        if (r?.note) md += `  - Note: ${r.note}\n`;
+      }
+      md += `\n`;
+    }
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `atlas-qa-report-${new Date().toISOString().slice(0, 10)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [results, testerName, testerInitials]);
+
+  const toggleSection = useCallback((sectionId: string) => {
+    setCollapsed((prev) => ({ ...prev, [sectionId]: !prev[sectionId] }));
+  }, []);
+
+  // ---- Computed ----
+  const summary = useMemo(() => computeSummary(results), [results]);
+  const pctComplete = TOTAL_TESTS > 0
+    ? Math.round(((summary.pass + summary.fail + summary.skip) / TOTAL_TESTS) * 100)
+    : 0;
+
+  // ---- Render ----
+  if (authLoading || loadingRuns) {
+    return (
+      <AppShell>
+        <div className="flex items-center justify-center py-32">
+          <div className="animate-pulse text-sm text-atlas-text-secondary">
+            Loading QA runner...
+          </div>
+        </div>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 py-2">
+        {/* Header */}
+        <header className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">
+            Admin
+          </p>
+          <h1 className="font-heading text-3xl font-extrabold tracking-tight text-atlas-text sm:text-4xl">
+            QA Test Runner
+          </h1>
+          <p className="max-w-3xl text-sm leading-7 text-atlas-text-secondary">
+            Interactive testing dashboard for Atlas. Mark tests pass/fail/skip, add notes, and export results.
+          </p>
+        </header>
+
+        {/* Tester bar + run selector */}
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-glass-border bg-glass px-4 py-3 backdrop-blur-xl">
+          <span className="text-xs font-semibold uppercase tracking-widest text-atlas-text-muted">
+            Tester
+          </span>
+          <div
+            className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-atlas-teal text-xs font-bold text-atlas-text"
+            style={{ background: "#2563eb" }}
+            title={testerName}
+          >
+            {testerInitials}
+          </div>
+          <span className="text-sm font-semibold text-atlas-teal">{testerName}</span>
+
+          <div className="mx-2 h-5 w-px bg-glass-border" />
+
+          <label className="text-xs uppercase tracking-wider text-atlas-text-muted">Run</label>
+          <select
+            className="rounded-md border border-glass-border bg-[#1a2235] px-2 py-1 text-xs text-atlas-text focus:border-atlas-teal focus:outline-none"
+            value={activeRunId ?? ""}
+            onChange={(e) => switchRun(e.target.value)}
+          >
+            {runs.length === 0 && <option value="">No runs</option>}
+            {runs.map((r) => (
+              <option key={r.id} value={r.id}>
+                {formatRunLabel(r)}
+              </option>
+            ))}
+          </select>
+
+          {canEdit && (
+            <>
+              <button
+                onClick={createRun}
+                className="rounded-md border border-atlas-teal bg-atlas-teal/15 px-3 py-1 text-xs font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/25"
+              >
+                + New Run
+              </button>
+              {activeRunId && (
+                <button
+                  onClick={() => deleteRun(activeRunId)}
+                  className="rounded-md border border-red-500/30 px-3 py-1 text-xs text-red-400 transition-colors hover:bg-red-500/10"
+                >
+                  Delete
+                </button>
+              )}
+            </>
+          )}
+
+          <div className="ml-auto flex items-center gap-2">
+            {saving && (
+              <span className="text-xs text-atlas-text-muted animate-pulse">Saving...</span>
+            )}
+            <button
+              onClick={exportMarkdown}
+              className="rounded-lg bg-gradient-to-r from-atlas-teal to-blue-500 px-4 py-1.5 text-xs font-semibold text-white shadow-lg shadow-atlas-teal/20 transition-transform hover:scale-[1.03]"
+            >
+              Export Markdown
+            </button>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div className="space-y-2">
+          <div className="h-3 overflow-hidden rounded-lg bg-[#111827]">
+            <div
+              className="h-full rounded-lg bg-gradient-to-r from-atlas-teal to-emerald-400 transition-all duration-500"
+              style={{ width: `${pctComplete}%` }}
+            />
+          </div>
+          <div className="flex flex-wrap gap-5 text-xs">
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+              {summary.pass} Pass
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-red-400" />
+              {summary.fail} Fail
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-yellow-400" />
+              {summary.skip} Skip
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-gray-500" />
+              {TOTAL_TESTS - summary.pass - summary.fail - summary.skip} Remaining
+            </span>
+            <span className="ml-auto font-semibold text-atlas-teal">
+              {pctComplete}% complete
+            </span>
+          </div>
+        </div>
+
+        {/* No runs state */}
+        {!activeRunId && (
+          <div className="rounded-2xl border border-glass-border bg-glass p-12 text-center backdrop-blur-xl">
+            <p className="text-atlas-text-secondary">
+              No test runs yet.{" "}
+              {canEdit ? "Create one to get started." : "A manager or admin must create a test run."}
+            </p>
+          </div>
+        )}
+
+        {/* Sections */}
+        {activeRunId &&
+          sections.map((section) => (
+            <SectionCard
+              key={section.id}
+              section={section}
+              results={results}
+              collapsed={!!collapsed[section.id]}
+              onToggle={() => toggleSection(section.id)}
+              onMark={markTest}
+              onNote={setNote}
+              canEdit={canEdit}
+            />
+          ))}
+      </div>
+    </AppShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section card
+// ---------------------------------------------------------------------------
+
+function SectionCard({
+  section,
+  results,
+  collapsed,
+  onToggle,
+  onMark,
+  onNote,
+  canEdit,
+}: {
+  section: TestSection;
+  results: ResultsMap;
+  collapsed: boolean;
+  onToggle: () => void;
+  onMark: (id: string, status: TestStatus) => void;
+  onNote: (id: string, note: string) => void;
+  canEdit: boolean;
+}) {
+  const badge = sectionBadge(section.tests, results);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-glass-border">
+      {/* Header */}
+      <button
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center gap-3 bg-[#111827] px-5 py-4 text-left transition-colors hover:bg-[#1a2235]"
+      >
+        <span className="text-lg font-semibold text-atlas-text">{section.title}</span>
+        <span className={`ml-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${badge.cls}`}>
+          {badge.label}
+        </span>
+        <span className="ml-auto text-xs text-atlas-text-muted">
+          {collapsed ? "+" : "-"}
+        </span>
+      </button>
+
+      {/* Body */}
+      {!collapsed && (
+        <div className="divide-y divide-white/5 bg-glass backdrop-blur-xl">
+          {section.tests.map((test) => (
+            <TestCard
+              key={test.id}
+              test={test}
+              result={results[test.id]}
+              onMark={onMark}
+              onNote={onNote}
+              canEdit={canEdit}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test card
+// ---------------------------------------------------------------------------
+
+function TestCard({
+  test,
+  result,
+  onMark,
+  onNote,
+  canEdit,
+}: {
+  test: TestCase;
+  result?: TestResult;
+  onMark: (id: string, status: TestStatus) => void;
+  onNote: (id: string, note: string) => void;
+  canEdit: boolean;
+}) {
+  const [showNote, setShowNote] = useState(false);
+  const [showSteps, setShowSteps] = useState(false);
+  const status = result?.status ?? "pending";
+
+  const borderClass =
+    status === "pass"
+      ? "border-l-emerald-400"
+      : status === "fail"
+        ? "border-l-red-400"
+        : status === "skip"
+          ? "border-l-yellow-400"
+          : "border-l-transparent";
+
+  return (
+    <div
+      className={`border-l-[3px] px-5 py-4 transition-colors hover:bg-white/[0.02] ${borderClass}`}
+    >
+      {/* Top row */}
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 whitespace-nowrap rounded bg-atlas-teal/10 px-2 py-0.5 font-mono text-[11px] text-atlas-teal">
+          {test.id}
+        </span>
+        <span className="flex-1 text-sm font-medium text-atlas-text">{test.name}</span>
+        {result?.tester && (
+          <span className="rounded bg-purple-500/15 px-1.5 py-0.5 text-[10px] text-purple-400">
+            {result.tester}
+          </span>
+        )}
+        {/* Action buttons */}
+        <div className="flex gap-1">
+          <StatusButton
+            label="Pass"
+            symbol="checkmark"
+            active={status === "pass"}
+            activeClass="bg-emerald-500/15 border-emerald-400 text-emerald-400"
+            onClick={() => onMark(test.id, "pass")}
+            disabled={!canEdit}
+          />
+          <StatusButton
+            label="Fail"
+            symbol="cross"
+            active={status === "fail"}
+            activeClass="bg-red-500/15 border-red-400 text-red-400"
+            onClick={() => onMark(test.id, "fail")}
+            disabled={!canEdit}
+          />
+          <StatusButton
+            label="Skip"
+            symbol="dash"
+            active={status === "skip"}
+            activeClass="bg-yellow-500/15 border-yellow-400 text-yellow-400"
+            onClick={() => onMark(test.id, "skip")}
+            disabled={!canEdit}
+          />
+        </div>
+      </div>
+
+      {/* Steps toggle */}
+      <div className="mt-2 ml-[72px]">
+        <button
+          onClick={() => setShowSteps((p) => !p)}
+          className="text-[11px] text-atlas-text-muted hover:text-atlas-text"
+        >
+          {showSteps ? "Hide steps" : "Show steps"}
+        </button>
+        {showSteps && (
+          <div className="mt-2 space-y-1 text-[13px] text-atlas-text-muted">
+            <ol className="list-decimal space-y-1 pl-4">
+              {test.steps.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
+            <div className="mt-2 rounded-r-md border-l-2 border-blue-500/40 bg-blue-500/[0.06] px-3 py-2 text-xs text-blue-400">
+              <span className="font-semibold">Expected: </span>
+              {test.expected}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Known issue */}
+      {test.knownIssue && (
+        <div className="mt-2 ml-[72px] rounded-r-md border-l-2 border-red-500/40 bg-red-500/[0.06] px-3 py-2 text-xs text-red-400">
+          <span className="font-semibold">Known Issue: </span>
+          {test.knownIssue}
+        </div>
+      )}
+
+      {/* Notes */}
+      <div className="mt-2 ml-[72px]">
+        <button
+          onClick={() => setShowNote((p) => !p)}
+          className="text-[11px] text-atlas-text-muted hover:text-atlas-text"
+        >
+          {showNote ? "Hide note" : result?.note ? "Edit note" : "Add note"}
+        </button>
+        {showNote && (
+          <textarea
+            className="mt-1 w-full resize-y rounded-md border border-glass-border bg-[#111827] px-3 py-2 text-xs text-atlas-text focus:border-atlas-teal focus:outline-none"
+            rows={2}
+            placeholder="Add a note..."
+            value={result?.note ?? ""}
+            onChange={(e) => onNote(test.id, e.target.value)}
+            readOnly={!canEdit}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status button
+// ---------------------------------------------------------------------------
+
+function StatusButton({
+  label,
+  symbol,
+  active,
+  activeClass,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  symbol: "checkmark" | "cross" | "dash";
+  active: boolean;
+  activeClass: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  const icons: Record<string, string> = {
+    checkmark: "\u2713",
+    cross: "\u2717",
+    dash: "\u2014",
+  };
+
+  return (
+    <button
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex h-8 w-8 items-center justify-center rounded-lg border text-sm transition-all ${
+        active
+          ? activeClass
+          : "border-glass-border bg-[#111827] text-atlas-text-muted hover:border-atlas-teal hover:text-atlas-teal"
+      } ${disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer"}`}
+    >
+      {icons[symbol]}
+    </button>
+  );
+}

--- a/src/app/admin/qa/test-definitions.ts
+++ b/src/app/admin/qa/test-definitions.ts
@@ -1,0 +1,685 @@
+export interface TestCase {
+  id: string;
+  name: string;
+  steps: string[];
+  expected: string;
+  knownIssue?: string;
+}
+
+export interface TestSection {
+  id: string;
+  icon: string;
+  title: string;
+  tests: TestCase[];
+}
+
+export const sections: TestSection[] = [
+  {
+    id: "auth",
+    icon: "lock",
+    title: "1. Authentication",
+    tests: [
+      {
+        id: "AUTH-01",
+        name: "Register new account",
+        steps: [
+          "Go to delphi-atlas.vercel.app",
+          'Click "Sign Up" tab or link',
+          "Fill: handle qa_manual_01, email qa_manual@test.com, password TestManual123!",
+          "Click Submit",
+        ],
+        expected: "Account created. Redirected to onboarding or dashboard. No errors.",
+      },
+      {
+        id: "AUTH-02",
+        name: "Register with duplicate email",
+        steps: [
+          "Try registering again with the same email qa_manual@test.com",
+        ],
+        expected:
+          'Error message appears: "Email already registered" or "Handle already taken". Form does NOT submit.',
+      },
+      {
+        id: "AUTH-03",
+        name: "Register with weak password",
+        steps: ["Try registering with password 123"],
+        expected: "Validation error — password too short. Form blocked.",
+      },
+      {
+        id: "AUTH-06",
+        name: "Login with valid credentials",
+        steps: [
+          "Go to login page",
+          "Enter qa_test_0404@test.com / TestPass123!",
+          "Click Sign In",
+        ],
+        expected:
+          "Redirected to /dashboard. Stats cards visible. No error flash.",
+      },
+      {
+        id: "AUTH-07",
+        name: "Login with wrong password",
+        steps: [
+          "Enter valid email, wrong password wrongpass",
+          "Click Sign In",
+        ],
+        expected: 'Error: "Invalid credentials". Stay on login page.',
+      },
+      {
+        id: "AUTH-09",
+        name: "Session persistence",
+        steps: [
+          "Login successfully",
+          "Close the browser tab",
+          "Open delphi-atlas.vercel.app in a new tab",
+        ],
+        expected: "Still logged in. Dashboard loads without re-login.",
+      },
+      {
+        id: "AUTH-11",
+        name: "Logout flow",
+        steps: [
+          "Click your avatar (top-right corner)",
+          "Click Logout",
+        ],
+        expected: "Redirected to login page. Cookies cleared.",
+      },
+      {
+        id: "AUTH-12",
+        name: "Protected route redirect",
+        steps: [
+          "After logout, manually type delphi-atlas.vercel.app/dashboard in address bar",
+        ],
+        expected:
+          "Redirected to login page. Should NOT see dashboard content.",
+        knownIssue:
+          "PF-02: May briefly flash dashboard skeleton before redirect (client-side auth only).",
+      },
+    ],
+  },
+  {
+    id: "dashboard",
+    icon: "layout-dashboard",
+    title: "2. Dashboard",
+    tests: [
+      {
+        id: "DASH-01",
+        name: "Dashboard loads correctly",
+        steps: [
+          "Login with qa_test_0404@test.com / TestPass123!",
+          "You should land on /dashboard",
+        ],
+        expected:
+          "Page renders with: stat cards (Drafts, Posts, Feedback, Reports), recent drafts section, quick action buttons.",
+      },
+      {
+        id: "DASH-02",
+        name: "Stats cards show data",
+        steps: ["Look at the 4 metric cards at the top"],
+        expected:
+          "Numbers displayed (may be 0 for new user). No NaN or undefined.",
+      },
+      {
+        id: "DASH-06",
+        name: "Empty state (new user)",
+        steps: ["Check the recent drafts area"],
+        expected:
+          'Shows empty state message like "No drafts yet" — not a broken/blank layout.',
+      },
+      {
+        id: "DASH-07",
+        name: "Loading skeleton",
+        steps: [
+          'Open DevTools > Network > throttle to "Slow 3G"',
+          "Reload page",
+        ],
+        expected:
+          "Skeleton shimmer animation shows while data loads. No layout shift when data arrives.",
+      },
+      {
+        id: "DASH-05",
+        name: "Navigation works",
+        steps: [
+          "Click each item in the left sidebar/nav: Dashboard, Crafting, Library, Analytics, Team",
+        ],
+        expected:
+          "Each page loads. Active state highlighted in nav. Back button works.",
+      },
+    ],
+  },
+  {
+    id: "crafting",
+    icon: "pen-tool",
+    title: "3. Crafting Station",
+    tests: [
+      {
+        id: "CRAFT-01",
+        name: "Generate tweet from text",
+        steps: [
+          "Navigate to /crafting",
+          "Paste this into the input: Bitcoin just hit $120k as BlackRock ETF inflows reach $2B this week. Institutional adoption is accelerating.",
+          "Click Generate",
+        ],
+        expected:
+          "AI generates a tweet draft within ~5 seconds. Content is relevant, within 280 chars.",
+      },
+      {
+        id: "CRAFT-04",
+        name: "Refine with chips",
+        steps: [
+          "After generating a draft, look for refinement chips/buttons",
+          'Click "Shorter" or "More punchy"',
+        ],
+        expected:
+          "Draft updates with refinement applied. Loading indicator during generation.",
+      },
+      {
+        id: "CRAFT-05",
+        name: "Multiple refinements",
+        steps: ["Apply 3 different refinements in sequence"],
+        expected:
+          "Each builds on the last. Quality doesn't degrade. Version count increments.",
+      },
+      {
+        id: "CRAFT-06",
+        name: "Manual edit",
+        steps: [
+          "Click into the draft text and manually edit some words",
+        ],
+        expected:
+          "Text is editable. Changes stick (don't get overwritten).",
+      },
+      {
+        id: "CRAFT-07",
+        name: "Save draft",
+        steps: [
+          "After generating, click Save (or equivalent)",
+        ],
+        expected:
+          "Draft saved with DRAFT status. Appears in draft list/history.",
+      },
+      {
+        id: "CRAFT-08",
+        name: "Reply mode",
+        steps: [
+          "Switch to Reply mode",
+          "Paste a tweet URL or text to reply to",
+          "Select a reply angle (bullish, contrarian, etc.)",
+          "Generate",
+        ],
+        expected:
+          "Reply generated that contextually matches the original tweet + selected angle.",
+      },
+      {
+        id: "CRAFT-11",
+        name: "News-to-post mode",
+        steps: [
+          "Switch to News mode",
+          "Paste an article URL or article text",
+          "Generate",
+        ],
+        expected: "Tweet generated from article content.",
+      },
+      {
+        id: "CRAFT-13",
+        name: "Thread generation",
+        steps: [
+          "Generate a longer piece of content",
+          "Click Thread button",
+        ],
+        expected:
+          "Content split into numbered thread segments. Each within char limit.",
+      },
+      {
+        id: "CRAFT-16",
+        name: "Post to X (blocked)",
+        steps: ["Click Post to X on a draft"],
+        expected:
+          'Error: "Link your X account first" — since no X account is connected.',
+      },
+      {
+        id: "CRAFT-18",
+        name: "Version history sidebar",
+        steps: [
+          "Check for a version history panel/sidebar after generating + refining",
+        ],
+        expected:
+          "Shows all draft versions with timestamps. Can click to view previous versions.",
+      },
+      {
+        id: "CRAFT-19",
+        name: "Image generation",
+        steps: [
+          "Look for an image/visual concept button on a draft",
+          "Click to generate an image",
+        ],
+        expected:
+          "Image generated and displayed inline with the draft.",
+      },
+    ],
+  },
+  {
+    id: "voice",
+    icon: "mic",
+    title: "4. Voice Profiles",
+    tests: [
+      {
+        id: "VP-01",
+        name: "Voice profile page loads",
+        steps: ["Navigate to /voice-profiles"],
+        expected:
+          "All 12 voice dimensions displayed with sliders. Current values shown (default: 50 each).",
+      },
+      {
+        id: "VP-02",
+        name: "Adjust dimension sliders",
+        steps: [
+          "Move the Humor slider to 80",
+          "Move Formality to 20",
+          "Save changes",
+        ],
+        expected:
+          "Values update visually. Save confirms. Reload shows persisted values.",
+      },
+      {
+        id: "VP-03",
+        name: "Apply preset",
+        steps: [
+          "Find preset buttons (CT Degen, Research Analyst, Balanced)",
+          "Click CT Degen",
+        ],
+        expected:
+          "All 12 dimensions snap to preset values. Visual change is immediate.",
+      },
+      {
+        id: "VP-05",
+        name: "Calibrate from Twitter handle",
+        steps: [
+          "Find the calibration section",
+          "Enter a Twitter handle (e.g. cobie)",
+          "Click Calibrate",
+        ],
+        expected:
+          "Tweets analyzed. Dimensions auto-adjust. tweetsAnalyzed count shown. Confidence score displayed.",
+      },
+      {
+        id: "VP-08",
+        name: "Reference accounts",
+        steps: ["Check the reference voices section"],
+        expected:
+          "16 curated global accounts shown (Ansem, Cobie, Elon, Naval, etc.) with avatars.",
+      },
+      {
+        id: "VP-11",
+        name: "Create a blend",
+        steps: [
+          "Select 2 reference accounts",
+          "Set percentages (e.g. 60/40)",
+          "Name it QA Test Blend",
+          "Save",
+        ],
+        expected:
+          "Blend created. Appears in blend list. Percentages sum to 100%.",
+      },
+    ],
+  },
+  {
+    id: "alerts",
+    icon: "bell",
+    title: "5. Alerts & Signals",
+    tests: [
+      {
+        id: "ALT-01",
+        name: "Alerts page loads",
+        steps: ["Navigate to /alerts"],
+        expected:
+          "Feed renders. May be empty for new user — should show empty state, not broken layout.",
+      },
+      {
+        id: "ALT-05",
+        name: "Subscriptions section",
+        steps: ["Look for a subscriptions tab or section"],
+        expected:
+          "Shows current subscriptions (may be empty). Has option to add new.",
+      },
+      {
+        id: "ALT-06",
+        name: "Add subscription",
+        steps: [
+          "Click add subscription",
+          "Set type: Category, value: crypto",
+          "Save",
+        ],
+        expected:
+          "Subscription created. Appears in list with active toggle.",
+      },
+      {
+        id: "ALT-09",
+        name: "Notification bell",
+        steps: ["Click the bell icon in the top nav bar"],
+        expected:
+          "Dropdown opens showing recent notifications. Dismiss/clear options available.",
+      },
+    ],
+  },
+  {
+    id: "analytics",
+    icon: "bar-chart-3",
+    title: "6. Analytics",
+    tests: [
+      {
+        id: "ANA-01",
+        name: "Analytics page loads",
+        steps: ["Navigate to /analytics"],
+        expected:
+          "Page renders with chart areas and summary stats.",
+      },
+      {
+        id: "ANA-02",
+        name: "Engagement chart renders",
+        steps: ["Look for the main engagement velocity chart"],
+        expected:
+          "Chart renders (may show zeros for new user). Axes labeled. No JS errors.",
+      },
+      {
+        id: "ANA-05",
+        name: "Summary stats",
+        steps: ["Check the 30-day summary numbers"],
+        expected:
+          "Shows drafts created, posted, feedback given, refinements. Numbers match your activity.",
+      },
+      {
+        id: "ANA-07",
+        name: "Empty state handling",
+        steps: ["As a new user, check all chart/data areas"],
+        expected:
+          "Empty states shown gracefully — no broken charts, no NaN, no console errors.",
+      },
+    ],
+  },
+  {
+    id: "briefing",
+    icon: "mail",
+    title: "7. Briefing & Telegram",
+    tests: [
+      {
+        id: "BRF-01",
+        name: "Briefing settings page",
+        steps: ["Navigate to /briefing"],
+        expected:
+          "Preferences form renders: delivery time, topics, sources, channel.",
+      },
+      {
+        id: "BRF-02",
+        name: "Save briefing preferences",
+        steps: [
+          "Set delivery time to 08:00",
+          "Select topics: crypto, defi",
+          "Set channel to Portal",
+          "Save",
+        ],
+        expected: "Saved confirmation. Reload shows persisted values.",
+      },
+      {
+        id: "TEL-01",
+        name: "Telegram setup page",
+        steps: ["Navigate to /telegram"],
+        expected:
+          "Setup guide renders with clear instructions for connecting Telegram bot.",
+      },
+    ],
+  },
+  {
+    id: "team",
+    icon: "users",
+    title: "8. Team Management",
+    tests: [
+      {
+        id: "TM-06",
+        name: "Analyst blocked from management",
+        steps: [
+          "While logged in as ANALYST, navigate to /management",
+        ],
+        expected:
+          "Access denied/redirected — analyst cannot access team management.",
+      },
+      {
+        id: "TM-01",
+        name: "Team Library page",
+        steps: ["Navigate to /team-library"],
+        expected:
+          "Page loads. Shows team drafts, shared blends, or empty state.",
+      },
+    ],
+  },
+  {
+    id: "profile",
+    icon: "user",
+    title: "9. Profile",
+    tests: [
+      {
+        id: "PRO-01",
+        name: "Profile page loads",
+        steps: ["Navigate to /profile"],
+        expected:
+          "Shows current display name, email, bio, avatar fields.",
+      },
+      {
+        id: "PRO-02",
+        name: "Update display name",
+        steps: ["Change display name to QA Tester", "Save"],
+        expected:
+          "Name updated. Reflected in nav bar avatar/menu. Persists on reload.",
+      },
+      {
+        id: "PRO-03",
+        name: "Update bio",
+        steps: ["Add bio: Testing Atlas QA suite", "Save"],
+        expected: "Bio saved and persists.",
+      },
+    ],
+  },
+  {
+    id: "navigation",
+    icon: "compass",
+    title: "10. Navigation & Search",
+    tests: [
+      {
+        id: "NAV-01",
+        name: "Command palette (Cmd+K)",
+        steps: ["Press Cmd+K (or Ctrl+K)"],
+        expected:
+          "Command palette overlay opens. Search input focused.",
+      },
+      {
+        id: "NAV-04",
+        name: "All nav links work",
+        steps: [
+          "Click every item in the navigation bar/sidebar",
+          "Check: Dashboard, Crafting, Voice Profiles, Alerts, Analytics, Briefing, Team Library, Management, Profile",
+        ],
+        expected:
+          "Each page loads. Active state highlighted. No 404s.",
+      },
+      {
+        id: "NAV-05",
+        name: "Mobile responsive nav",
+        steps: [
+          "Open DevTools > toggle device toolbar",
+          "Set to iPhone 14 (390px wide)",
+          "Check navigation",
+        ],
+        expected:
+          "Nav adapts to mobile — hamburger menu or bottom nav. All links accessible.",
+      },
+    ],
+  },
+  {
+    id: "design",
+    icon: "palette",
+    title: "11. Design System & Visual",
+    tests: [
+      {
+        id: "DS-01",
+        name: "Color palette correct",
+        steps: [
+          "Browse all pages, check backgrounds and accents",
+        ],
+        expected:
+          "Dark background (#010411). Teal accents (#4ecdc4). Delphi blue palette. No white backgrounds.",
+      },
+      {
+        id: "DS-02",
+        name: "Typography",
+        steps: ["Check page headings vs body text"],
+        expected:
+          "Headings: Playfair Display (serif). Body: Inter (sans-serif). Consistent hierarchy.",
+      },
+      {
+        id: "DS-03",
+        name: "Glass card effects",
+        steps: [
+          "Check card components on Dashboard, Voice Profiles",
+        ],
+        expected:
+          "Frosted glass effect visible. Backdrop blur. Rounded corners (16px).",
+      },
+      {
+        id: "DS-05",
+        name: "Status pills",
+        steps: ["Check draft cards for status badges"],
+        expected:
+          "Correct colors: DRAFT (neutral), APPROVED (blue/green), POSTED (green), ARCHIVED (gray).",
+      },
+      {
+        id: "DS-10",
+        name: "Responsive at key breakpoints",
+        steps: [
+          "Test at: 320px, 768px, 1024px, 1440px",
+        ],
+        expected:
+          "Layout adapts. No horizontal overflow. No overlapping elements. Touch targets adequate on mobile.",
+      },
+    ],
+  },
+  {
+    id: "a11y",
+    icon: "accessibility",
+    title: "12. Accessibility",
+    tests: [
+      {
+        id: "A11Y-01",
+        name: "Keyboard navigation",
+        steps: [
+          "Starting from the login page, use only Tab, Enter, and Escape to navigate",
+        ],
+        expected:
+          "All interactive elements focusable. Visible focus ring. Logical tab order.",
+      },
+      {
+        id: "A11Y-04",
+        name: "Color contrast",
+        steps: [
+          "Run Lighthouse accessibility audit in DevTools",
+          "Or use browser extension like axe DevTools",
+        ],
+        expected:
+          "All text meets WCAG AA contrast ratio (4.5:1 normal text, 3:1 large text).",
+      },
+      {
+        id: "A11Y-07",
+        name: "Form labels",
+        steps: [
+          "Inspect login form, crafting input, voice sliders",
+          "Check that each input has an associated <label> or aria-label",
+        ],
+        expected:
+          "Every input has a label. Screen readers can identify each field.",
+      },
+    ],
+  },
+  {
+    id: "errors",
+    icon: "alert-triangle",
+    title: "13. Error Handling",
+    tests: [
+      {
+        id: "ERR-03",
+        name: "404 page",
+        steps: [
+          "Navigate to delphi-atlas.vercel.app/nonexistent-page",
+        ],
+        expected:
+          "Shows 404 page or redirects to dashboard. No white screen.",
+      },
+      {
+        id: "ERR-08",
+        name: "Large input handling",
+        steps: [
+          "In Crafting, paste 10,000+ characters into the source input",
+          "Try to generate",
+        ],
+        expected:
+          "Handled gracefully — truncated, warned, or accepted. No crash.",
+      },
+      {
+        id: "ERR-09",
+        name: "XSS prevention",
+        steps: [
+          'In any text input (profile name, draft, etc.), enter: <script>alert("xss")</script>',
+        ],
+        expected:
+          "HTML is escaped. No alert popup. Script does not execute.",
+      },
+    ],
+  },
+  {
+    id: "performance",
+    icon: "zap",
+    title: "14. Performance",
+    tests: [
+      {
+        id: "PERF-01",
+        name: "Lighthouse audit",
+        steps: [
+          "Open DevTools > Lighthouse tab",
+          "Run audit on /dashboard (Performance + Accessibility)",
+        ],
+        expected:
+          "Performance > 70. Accessibility > 80. FCP < 3s.",
+      },
+      {
+        id: "PERF-03",
+        name: "Draft generation speed",
+        steps: [
+          "Time from clicking Generate to seeing the draft",
+        ],
+        expected:
+          "< 15 seconds. Loading indicator visible during generation.",
+      },
+      {
+        id: "PERF-07",
+        name: "Memory leak check",
+        steps: [
+          "Open DevTools > Memory tab",
+          "Take heap snapshot",
+          "Navigate between 5+ pages, generate drafts",
+          "Take another snapshot",
+        ],
+        expected:
+          "No significant memory growth. No detached DOM nodes accumulating.",
+      },
+    ],
+  },
+];
+
+/** Total number of individual tests across all sections */
+export const TOTAL_TESTS = sections.reduce(
+  (sum, s) => sum + s.tests.length,
+  0,
+);
+
+/** All test IDs in order */
+export const ALL_TEST_IDS = sections.flatMap((s) =>
+  s.tests.map((t) => t.id),
+);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -26,6 +26,19 @@ interface BriefingPreferenceInput {
   channel: string;
 }
 
+export interface QaTestRun {
+  id: string;
+  project: string;
+  tester_id: string;
+  tester_name: string;
+  tester_initials: string;
+  created_at: string;
+  updated_at: string;
+  results: Record<string, { status: string; note: string; tester: string; timestamp: string }>;
+  summary: { pass: number; fail: number; skip: number; total: number };
+  status: 'in_progress' | 'completed' | 'abandoned';
+}
+
 class ApiError extends Error {
   statusCode: number;
   constructor(message: string, statusCode: number) {
@@ -322,6 +335,19 @@ export const api = {
       request<{ message: string; affected: number }>("/api/users/send-nudge", { method: "POST" }),
     pushStyle: (blendId?: string) =>
       request<{ message: string; affected: number }>("/api/users/push-style", { method: "POST", body: { blendId } }),
+  },
+
+  qa: {
+    listRuns: () =>
+      request<{ runs: QaTestRun[] }>('/api/qa/runs'),
+    getRun: (id: string) =>
+      request<{ run: QaTestRun }>(`/api/qa/runs/${id}`),
+    createRun: (data: { tester_name: string; tester_initials: string }) =>
+      request<{ run: QaTestRun }>('/api/qa/runs', { method: 'POST', body: data }),
+    updateRun: (id: string, data: { results?: Record<string, unknown>; summary?: Record<string, unknown>; status?: string }) =>
+      request<{ run: QaTestRun }>(`/api/qa/runs/${id}`, { method: 'PATCH', body: data }),
+    deleteRun: (id: string) =>
+      request<{ success: boolean }>(`/api/qa/runs/${id}`, { method: 'DELETE' }),
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `/admin/qa` route — interactive testing dashboard inside Atlas
- 14 sections, 63 test cases covering full product (auth, crafting, voice, analytics, alerts, design system, a11y, performance)
- Supabase-backed persistence via backend QA API endpoints (merged in backend PR #61)
- Clean cherry-pick from original PR #80 (closed due to merge conflicts)

## Test plan
- [x] Build passes
- [x] All 184 tests pass
- [ ] Verify `/admin/qa` loads after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)