### PR TITLE
feat: Oracle widget on dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { api, TweetDraft } from "@/lib/api";
 import { PenTool, Bell, BarChart3, Mic2, BookOpen, Send, Users } from "lucide-react";
 import LoopPanel from "@/components/ui/LoopPanel";
 import DashboardSkeleton from "@/components/skeletons/DashboardSkeleton";
+import OracleWidget from "@/components/oracle/OracleWidget";
 
 const navCards = [
   { label: "Crafting Station", href: "/crafting", icon: PenTool },
@@ -148,6 +149,19 @@ export default function DashboardPage() {
       <h1 className="font-heading font-bold tracking-tight text-2xl text-atlas-text">
         Welcome back, {user?.handle || "Analyst"}
       </h1>
+
+      <div className="mt-4">
+        <OracleWidget
+          message={
+            stats.drafts > 0
+              ? `You've crafted ${stats.drafts} draft${stats.drafts === 1 ? "" : "s"} this month — ${stats.posts > 0 ? `${stats.posts} made it to X. Your voice is sharpening.` : "time to post one and see how it lands."}`
+              : "Your voice profile is set up. Head to the Crafting Station and turn some alpha into a tweet."
+          }
+          context="dashboard"
+          actionLabel={stats.drafts === 0 ? "Open Crafting Station" : undefined}
+          onAction={stats.drafts === 0 ? () => router.push("/crafting") : undefined}
+        />
+      </div>
 
       {error && (
         <div

--- a/src/components/oracle/OracleWidget.tsx
+++ b/src/components/oracle/OracleWidget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+interface OracleWidgetProps {
+  message: string;
+  context?: "dashboard" | "crafting" | "alerts" | "voice-profiles";
+  actionLabel?: string;
+  onAction?: () => void;
+  dismissible?: boolean;
+}
+
+export default function OracleWidget({
+  message,
+  context = "dashboard",
+  actionLabel,
+  onAction,
+  dismissible = true,
+}: OracleWidgetProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="relative flex items-start gap-4 rounded-2xl border border-atlas-teal/20 bg-gradient-to-r from-atlas-teal/5 to-transparent p-4">
+      <div className="relative h-10 w-10 flex-shrink-0">
+        <Image
+          src="/images/oracle-avatar.jpg"
+          alt="The Oracle"
+          width={40}
+          height={40}
+          className="rounded-full ring-2 ring-atlas-teal/30"
+        />
+        <div className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-atlas-bg bg-atlas-teal" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-atlas-teal">The Oracle</p>
+        <p className="mt-1 text-sm leading-relaxed text-atlas-text-secondary">
+          {message}
+        </p>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="mt-2 text-xs font-medium text-atlas-teal hover:underline"
+          >
+            {actionLabel} →
+          </button>
+        )}
+      </div>
+
+      {dismissible && (
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss Oracle message"
+          className="flex-shrink-0 text-atlas-text-muted hover:text-atlas-text-secondary"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M10.5 3.5L3.5 10.5M3.5 3.5L10.5 10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `OracleWidget` component — reusable Oracle message card with avatar, dismissible, optional CTA
- Integrated into dashboard with stats-aware messaging
- Shows personalized briefing based on draft/post counts
- New users get CTA to open Crafting Station

## Test plan
- [x] Build passes
- [x] All 184 tests pass
- [ ] Visual check on dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)