### PR TITLE
fix: server-side auth redirect (no more skeleton flash)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,27 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+// Public routes that don't require authentication
+const PUBLIC_PATHS = new Set(["/", "/auth/x/callback"]);
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.has(pathname) || pathname.startsWith("/_next") || pathname.startsWith("/api");
+}
+
 export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Auth redirect: if no token cookie and hitting a protected route, redirect to login
+  const hasToken = request.cookies.has("atlas_access_token");
+  if (!hasToken && !isPublicPath(pathname)) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  // If authenticated user hits login page, redirect to dashboard
+  if (hasToken && pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
   const response = NextResponse.next();
 
   // Prevent clickjacking


### PR DESCRIPTION
## Summary
- Adds auth check to Next.js middleware — redirects unauthenticated users to `/` before page renders
- Eliminates the dashboard skeleton flash for logged-out users (Bug #2 from QA testing)
- Authenticated users hitting `/` auto-redirect to `/dashboard`
- Checks `atlas_access_token` cookie at the edge

## Test plan
- [x] `next build` passes
- [ ] Visit `/dashboard` while logged out → should redirect to `/` instantly (no skeleton)
- [ ] Visit `/` while logged in → should redirect to `/dashboard`
- [ ] Login flow still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)