### PR TITLE
fix: wire Team Library — Use Style, Copy, Preview all functional

### DIFF
--- a/src/app/team-library/page.tsx
+++ b/src/app/team-library/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronDown, ChevronUp, Copy, Sparkles } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useAuth } from "@/lib/auth";
@@ -8,12 +10,15 @@ import { api, TeamDraft } from "@/lib/api";
 
 export default function TeamLibraryPage() {
   const { user } = useAuth();
+  const router = useRouter();
   const [libraryItems, setLibraryItems] = useState<TeamDraft[]>([]);
   const [loading, setLoading] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState("recent");
   const [filterBy, setFilterBy] = useState("all");
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     if (!user) { setLoading(false); return; }
@@ -56,6 +61,19 @@ export default function TeamLibraryPage() {
     if (engagement >= 1000) return `${(engagement / 1000).toFixed(1)}k`;
     return `${engagement.toFixed(1)}k`;
   }
+
+  const handleCopy = async (item: TeamDraft) => {
+    await navigator.clipboard.writeText(item.content);
+    setCopiedId(item.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const handleUseStyle = (item: TeamDraft) => {
+    // Navigate to crafting with the draft content pre-loaded as inspiration
+    const params = new URLSearchParams({ source: item.content });
+    if (item.blendName) params.set("blend", item.blendName);
+    router.push(`/crafting?${params.toString()}`);
+  };
 
   return (
     <AppShell>
@@ -121,79 +139,109 @@ export default function TeamLibraryPage() {
         </div>
       )}
       <div className="columns-1 md:columns-2 gap-6 space-y-6">
-        {visibleItems.map((item) => (
-          <div
-            key={item.id}
-            className="card-interactive flex flex-col rounded-2xl border border-glass-border bg-atlas-surface p-8 break-inside-avoid"
-          >
-            <p className="text-lg text-atlas-text leading-relaxed">{item.content}</p>
-            {item.feedback && (
-              <p className="text-sm text-atlas-text-secondary mt-3 italic">{item.feedback}</p>
-            )}
-            <div className="mt-auto pt-4 border-t border-glass-border">
-              <div className="flex items-center gap-2 mt-3">
-                <div className="h-6 w-6 rounded-full bg-gradient-to-r from-delphi-blue-500 to-atlas-teal flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0">
-                  {item.user?.handle?.[0]?.toUpperCase() || item.user?.displayName?.[0]?.toUpperCase() || "?"}
-                </div>
-                <span className="text-xs text-atlas-text-secondary truncate">
-                  {item.user?.displayName || item.user?.handle || "Unknown"}
-                </span>
-              </div>
-              {item.blendName && (
-                <span className="text-[10px] text-atlas-teal">
-                  via {item.blendName}
-                </span>
+        {visibleItems.map((item) => {
+          const isCopied = copiedId === item.id;
+          const isExpanded = expandedId === item.id;
+
+          return (
+            <div
+              key={item.id}
+              className="flex flex-col rounded-2xl border border-glass-border bg-atlas-surface p-8 break-inside-avoid transition-colors hover:border-atlas-teal/30"
+            >
+              <p className="text-lg text-atlas-text leading-relaxed">{item.content}</p>
+              {item.feedback && (
+                <p className="text-sm text-atlas-text-secondary mt-3 italic">&ldquo;{item.feedback}&rdquo;</p>
               )}
-              <p className="text-sm text-atlas-text-secondary font-medium">Team voice</p>
-              <p className="text-xs text-atlas-teal font-bold mt-1">{formatEngagement(item)} Engagement</p>
+
+              <div className="mt-auto pt-4 border-t border-glass-border">
+                <div className="flex items-center gap-2 mt-3">
+                  <div className="h-6 w-6 rounded-full bg-gradient-to-r from-delphi-blue-500 to-atlas-teal flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0">
+                    {item.user?.handle?.[0]?.toUpperCase() || item.user?.displayName?.[0]?.toUpperCase() || "?"}
+                  </div>
+                  <span className="text-xs text-atlas-text-secondary truncate">
+                    {item.user?.displayName || item.user?.handle || "Unknown"}
+                  </span>
+                </div>
+                {item.blendName && (
+                  <span className="text-[10px] text-atlas-teal">
+                    via {item.blendName}
+                  </span>
+                )}
+                <p className="text-sm text-atlas-text-secondary font-medium">Team voice</p>
+                <p className="text-xs text-atlas-teal font-bold mt-1">{formatEngagement(item)} Engagement</p>
+              </div>
+
+              {/* Expanded preview */}
+              {isExpanded && (
+                <div className="mt-4 rounded-xl border border-glass-border/50 bg-atlas-bg/50 p-4 space-y-2">
+                  <p className="text-[10px] uppercase tracking-wide text-atlas-text-muted font-semibold">Draft Details</p>
+                  <div className="grid grid-cols-2 gap-2 text-xs">
+                    <div>
+                      <span className="text-atlas-text-muted">Status:</span>{" "}
+                      <span className="text-atlas-text">{item.status}</span>
+                    </div>
+                    <div>
+                      <span className="text-atlas-text-muted">Length:</span>{" "}
+                      <span className="text-atlas-text">{item.content.length}/280</span>
+                    </div>
+                    {item.confidence != null && (
+                      <div>
+                        <span className="text-atlas-text-muted">Confidence:</span>{" "}
+                        <span className="text-atlas-text">{Math.round(item.confidence * 100)}%</span>
+                      </div>
+                    )}
+                    {item.sourceType && (
+                      <div>
+                        <span className="text-atlas-text-muted">Source:</span>{" "}
+                        <span className="text-atlas-text">{item.sourceType.replace(/_/g, " ")}</span>
+                      </div>
+                    )}
+                  </div>
+                  {item.blendName && (
+                    <p className="text-xs text-atlas-teal">Voice blend: {item.blendName}</p>
+                  )}
+                  <p className="text-[10px] text-atlas-text-muted">
+                    Created {new Date(item.createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                  </p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="mt-3 flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleUseStyle(item)}
+                  className="flex items-center gap-1.5 text-xs font-bold text-atlas-teal transition-colors hover:text-atlas-text"
+                >
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Use this style
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleCopy(item)}
+                  className="flex items-center gap-1.5 text-xs font-bold text-atlas-text-secondary transition-colors hover:text-atlas-teal"
+                >
+                  {isCopied ? <Check className="h-3.5 w-3.5 text-atlas-success" /> : <Copy className="h-3.5 w-3.5" />}
+                  {isCopied ? "Copied!" : "Copy"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isExpanded ? null : item.id)}
+                  className="flex items-center gap-1 text-xs font-bold text-atlas-text-secondary transition-colors hover:text-atlas-teal"
+                >
+                  {isExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                  {isExpanded ? "Less" : "Preview"}
+                </button>
+              </div>
             </div>
-            <div className="mt-3 flex gap-4">
-              <button
-                type="button"
-                onClick={async () => {
-                  await navigator.clipboard.writeText(item.content);
-                }}
-                className="text-xs font-bold text-atlas-teal hover:underline"
-              >
-                Use this style
-              </button>
-              <button
-                type="button"
-                disabled
-                title="Coming soon"
-                className="text-xs font-bold text-atlas-text-secondary opacity-50 cursor-not-allowed"
-              >
-                Preview
-              </button>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Footer count */}
       <p className="text-sm text-atlas-text-secondary mt-6 text-center">
         {visibleItems.length} styles shown out of {totalCount}
       </p>
-
-      {/* Management Bar */}
-      <div className="mt-8 bg-atlas-surface border border-glass-border rounded-2xl px-4 sm:px-8 py-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0">
-        <button
-          type="button"
-          disabled
-          title="Coming soon"
-          className="text-sm font-bold text-atlas-text transition-colors opacity-50 cursor-not-allowed"
-        >
-          Manage All
-        </button>
-        <button
-          type="button"
-          disabled
-          title="Coming soon"
-          className="gradient-cta px-6 py-3 text-sm opacity-50 cursor-not-allowed"
-        >
-          Push a style to all
-        </button>
-      </div>
     </AppShell>
   );
 }


### PR DESCRIPTION
All three card actions were dead buttons. Now: Use Style navigates to crafting with content pre-loaded, Copy shows 'Copied!' feedback, Preview expands inline detail card. Removed dead management buttons.