### PR TITLE
fix: crafting visual polish — darken drop zone + sidebar

### DIFF
--- a/src/components/crafting/DraftHistorySidebar.tsx
+++ b/src/components/crafting/DraftHistorySidebar.tsx
@@ -71,7 +71,7 @@ export default function DraftHistorySidebar({
       className={mobile ? "w-full" : "hidden w-64 shrink-0 lg:block"}
     >
       <div className={mobile ? "space-y-4" : "sticky top-24 space-y-4"}>
-        <div className="border border-glass-border bg-atlas-surface rounded-2xl p-5">
+        <div className="border border-glass-border bg-atlas-bg/40 rounded-2xl p-5">
           <div className="flex items-center justify-between">
             <div>
               <h2 className="font-heading font-bold text-lg text-atlas-text">Draft History</h2>
@@ -93,7 +93,7 @@ export default function DraftHistorySidebar({
         </div>
 
         {drafts.length === 0 ? (
-          <div className="border border-glass-border bg-atlas-surface rounded-2xl p-4">
+          <div className="border border-glass-border bg-atlas-bg/40 rounded-2xl p-4">
             <p className="font-body text-xs text-atlas-text-muted">
               No drafts yet. Generate your first tweet above.
             </p>
@@ -108,7 +108,7 @@ export default function DraftHistorySidebar({
                   key={draft.id}
                   type="button"
                   onClick={() => onSelectDraft(draft)}
-                  className={`w-full rounded-2xl border bg-atlas-surface p-4 text-left transition-all ${
+                  className={`w-full rounded-2xl border bg-atlas-bg/40 p-4 text-left transition-all ${
                     isActive
                       ? "border-atlas-teal/50 ring-1 ring-atlas-teal/30"
                       : "border-glass-border hover:border-atlas-text-muted/30"

--- a/src/components/ui/ContentInput.tsx
+++ b/src/components/ui/ContentInput.tsx
@@ -127,13 +127,13 @@ export default function ContentInput({
       <div
         onDrop={handleDrop}
         onDragOver={(event) => event.preventDefault()}
-        className="rounded-2xl border-2 border-dashed border-atlas-text-secondary/30 bg-atlas-surface p-6 text-center transition-colors hover:border-atlas-teal/50 sm:p-8"
+        className="rounded-2xl border border-dashed border-glass-border bg-atlas-bg/30 p-6 text-center transition-colors hover:border-atlas-teal/50 sm:p-8"
       >
         <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-3 sm:gap-8">
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border bg-atlas-nav px-4 py-4 text-atlas-text-secondary transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border/50 bg-atlas-surface/50 px-4 py-4 text-atlas-text-muted transition-colors hover:border-atlas-teal hover:text-atlas-teal"
           >
             <FileText className="w-8 h-8" aria-hidden="true" />
             <span className="text-xs">Drop a report</span>
@@ -141,7 +141,7 @@ export default function ContentInput({
           <button
             type="button"
             onClick={() => textInputRef.current?.focus()}
-            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border bg-atlas-nav px-4 py-4 text-atlas-text-secondary transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border/50 bg-atlas-surface/50 px-4 py-4 text-atlas-text-muted transition-colors hover:border-atlas-teal hover:text-atlas-teal"
           >
             <MessageSquare className="w-8 h-8" aria-hidden="true" />
             <span className="text-xs">Paste a tweet idea</span>
@@ -149,7 +149,7 @@ export default function ContentInput({
           <button
             type="button"
             onClick={() => onTrendingClick?.()}
-            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border bg-atlas-nav px-4 py-4 text-atlas-text-secondary transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-glass-border/50 bg-atlas-surface/50 px-4 py-4 text-atlas-text-muted transition-colors hover:border-atlas-teal hover:text-atlas-teal"
           >
             <TrendingUp className="w-8 h-8" aria-hidden="true" />
             <span className="text-xs">Pick a trending alert</span>


### PR DESCRIPTION
Soften dashed border, darken action cards and sidebar to match dark glass theme.