### PR TITLE
fix: demo mode toggle reloads page

### DIFF
--- a/src/lib/demo-mode.tsx
+++ b/src/lib/demo-mode.tsx
@@ -45,6 +45,8 @@ export function DemoModeProvider({ children }: { children: React.ReactNode }) {
       const next = !prev;
       sessionStorage.setItem(STORAGE_KEY, String(next));
       setApiDemoMode(next);
+      // Reload so all pages refetch with new mode
+      window.location.reload();
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary
- Demo toggle was setting the flag but pages kept showing stale data
- Now reloads the page after toggle so all data refetches with new mode

## Test plan
- [x] Click DEMO pill → page reloads with demo data
- [x] Click LIVE pill → page reloads with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)