### PR TITLE
feat: per-page contextual tours (replaces linear FTUE)

### DIFF
--- a/src/components/tour/TourProvider.tsx
+++ b/src/components/tour/TourProvider.tsx
@@ -8,31 +8,62 @@ import {
   useRef,
   useState,
 } from "react";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useDemoMode } from "@/lib/demo-mode";
-import { TOUR_STEPS } from "@/lib/tour";
+import {
+  PAGE_TOURS,
+  ROUTE_TO_PAGE,
+  TOUR_PAGES,
+  isPageTourComplete,
+  markPageTourComplete,
+  resetAllPageTours,
+  type TourPage,
+  type TourStep,
+} from "@/lib/tour";
 import TourSpotlight from "./TourSpotlight";
 
 interface TourContextValue {
+  /** Whether a page tour is currently active. */
   active: boolean;
+  /** Which page tour is running, if any. */
+  activePage: TourPage | null;
+  /** Current step index within the active page tour. */
   currentStep: number;
+  /** Total steps in the active page tour. */
   totalSteps: number;
+  /** Start (or restart) the tour for a specific page. */
+  startPageTour: (page: TourPage) => void;
+  /** Start the tour for the current page. */
   startTour: () => void;
+  /** Advance to the next step. Completes tour on last step. */
   nextStep: () => void;
+  /** Go back one step. */
   prevStep: () => void;
+  /** Skip / dismiss the active tour. */
   skipTour: () => void;
+  /** Reset all page tours so they re-trigger on next visit. */
+  resetAllTours: () => void;
+  /** Number of pages whose tours are completed. */
+  completedPages: number;
+  /** Total number of tour pages. */
+  totalPages: number;
 }
 
 const TourContext = createContext<TourContextValue>({
   active: false,
+  activePage: null,
   currentStep: 0,
-  totalSteps: TOUR_STEPS.length,
+  totalSteps: 0,
+  startPageTour: () => {},
   startTour: () => {},
   nextStep: () => {},
   prevStep: () => {},
   skipTour: () => {},
+  resetAllTours: () => {},
+  completedPages: 0,
+  totalPages: TOUR_PAGES.length,
 });
 
 export function useTour() {
@@ -40,64 +71,82 @@ export function useTour() {
 }
 
 export function TourProvider({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
   const pathname = usePathname();
   const { user } = useAuth();
-  const [active, setActive] = useState(false);
-  const [currentStep, setCurrentStep] = useState(0);
-  const [hasChecked, setHasChecked] = useState(false);
-
-  // Check if user needs the tour on mount
-  useEffect(() => {
-    if (!user || hasChecked) return;
-    const u = user as unknown as { tourCompleted?: boolean; tourStep?: number };
-    if (u.tourCompleted === false && pathname === "/dashboard") {
-      // Small delay so the dashboard renders first
-      const t = setTimeout(() => setActive(true), 1500);
-      if (typeof u.tourStep === "number" && u.tourStep > 0) {
-        setCurrentStep(u.tourStep);
-      }
-      setHasChecked(true);
-      return () => clearTimeout(t);
-    }
-    setHasChecked(true);
-  }, [user, hasChecked, pathname]);
-
-  // Navigate to the correct page when step changes
-  useEffect(() => {
-    if (!active) return;
-    const step = TOUR_STEPS[currentStep];
-    if (step && pathname !== step.route) {
-      router.push(step.route);
-    }
-  }, [active, currentStep, pathname, router]);
-
-  // Persist step progress
-  useEffect(() => {
-    if (!active || !user) return;
-    api.users.updateProfile({ tourStep: currentStep }).catch(() => {});
-  }, [active, currentStep, user]);
-
   const { isDemoMode, toggleDemoMode } = useDemoMode();
-  const demoWasOff = useRef(false);
 
+  const [activePage, setActivePage] = useState<TourPage | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [completedPages, setCompletedPages] = useState(0);
+  const demoWasOff = useRef(false);
+  const autoTriggerRef = useRef<Set<string>>(new Set());
+
+  const active = activePage !== null;
+  const steps: TourStep[] = activePage ? PAGE_TOURS[activePage] : [];
+  const totalSteps = steps.length;
+
+  // Count completed page tours on mount and after changes
+  const refreshCompletedCount = useCallback(() => {
+    const count = TOUR_PAGES.filter((p) => isPageTourComplete(p)).length;
+    setCompletedPages(count);
+  }, []);
+
+  useEffect(() => {
+    refreshCompletedCount();
+  }, [refreshCompletedCount]);
+
+  // \u2500\u2500 Auto-trigger on first page visit \u2500\u2500
+  useEffect(() => {
+    if (active || !user) return;
+    const page = ROUTE_TO_PAGE[pathname];
+    if (!page) return;
+    if (isPageTourComplete(page)) return;
+    // Only auto-trigger once per page per session
+    if (autoTriggerRef.current.has(page)) return;
+    autoTriggerRef.current.add(page);
+
+    const t = setTimeout(() => {
+      // Re-check: another tour may have started in the meantime
+      if (activePage !== null) return;
+      setCurrentStep(0);
+      setActivePage(page);
+      // Enable demo mode for the tour
+      if (!isDemoMode) {
+        demoWasOff.current = true;
+        toggleDemoMode();
+      }
+    }, 1200);
+
+    return () => clearTimeout(t);
+  }, [pathname, active, user, activePage, isDemoMode, toggleDemoMode]);
+
+  // \u2500\u2500 Complete active tour \u2500\u2500
   const completeTour = useCallback(() => {
-    setActive(false);
-    // Restore demo mode if we turned it on for the tour
+    if (activePage) {
+      markPageTourComplete(activePage);
+      refreshCompletedCount();
+    }
+    setActivePage(null);
+    setCurrentStep(0);
+    // Restore demo mode
     if (demoWasOff.current) {
       toggleDemoMode();
       demoWasOff.current = false;
     }
-    api.users.updateProfile({ tourCompleted: true, tourStep: TOUR_STEPS.length }).catch(() => {});
-  }, [toggleDemoMode]);
+    // Sync overall completion to backend if all done
+    const allDone = TOUR_PAGES.every((p) => isPageTourComplete(p));
+    if (allDone) {
+      api.users.updateProfile({ tourCompleted: true }).catch(() => {});
+    }
+  }, [activePage, toggleDemoMode, refreshCompletedCount]);
 
   const nextStep = useCallback(() => {
-    if (currentStep >= TOUR_STEPS.length - 1) {
+    if (currentStep >= totalSteps - 1) {
       completeTour();
     } else {
       setCurrentStep((s) => s + 1);
     }
-  }, [currentStep, completeTour]);
+  }, [currentStep, totalSteps, completeTour]);
 
   const prevStep = useCallback(() => {
     setCurrentStep((s) => Math.max(0, s - 1));
@@ -107,34 +156,55 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     completeTour();
   }, [completeTour]);
 
+  const startPageTour = useCallback(
+    (page: TourPage) => {
+      if (!isDemoMode) {
+        demoWasOff.current = true;
+        toggleDemoMode();
+      }
+      setCurrentStep(0);
+      setActivePage(page);
+    },
+    [isDemoMode, toggleDemoMode],
+  );
+
   const startTour = useCallback(() => {
-    // Auto-enable demo mode so every page has data during the tour
-    if (!isDemoMode) {
-      demoWasOff.current = true;
-      toggleDemoMode();
+    const page = ROUTE_TO_PAGE[pathname];
+    if (!page) return;
+    // If all pages are toured, reset everything; otherwise just replay current page
+    const allDone = TOUR_PAGES.every((p) => isPageTourComplete(p));
+    if (allDone) {
+      resetAllPageTours();
+      refreshCompletedCount();
+      api.users.updateProfile({ tourCompleted: false, tourStep: 0 }).catch(() => {});
+      autoTriggerRef.current.clear();
     }
-    setCurrentStep(0);
-    setActive(true);
-  }, [isDemoMode, toggleDemoMode]);
+    startPageTour(page);
+  }, [pathname, startPageTour, refreshCompletedCount]);
 
   return (
     <TourContext.Provider
       value={{
         active,
+        activePage,
         currentStep,
-        totalSteps: TOUR_STEPS.length,
+        totalSteps,
+        startPageTour,
         startTour,
         nextStep,
         prevStep,
         skipTour,
+        resetAllTours: startTour,
+        completedPages,
+        totalPages: TOUR_PAGES.length,
       }}
     >
       {children}
-      {active ? (
+      {active && steps[currentStep] ? (
         <TourSpotlight
-          step={TOUR_STEPS[currentStep]}
+          step={steps[currentStep]}
           stepIndex={currentStep}
-          totalSteps={TOUR_STEPS.length}
+          totalSteps={totalSteps}
           onNext={nextStep}
           onPrev={currentStep > 0 ? prevStep : undefined}
           onSkip={skipTour}

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,68 +1,181 @@
-/** Tour step definitions for the FTUE guided tour. */
+/** Per-page contextual tour definitions for the FTUE. */
 
 export interface TourStep {
   id: string;
-  route: string;
   targetSelector: string;
   oracleMessage: string;
   position: "top" | "bottom" | "left" | "right";
 }
 
-export const TOUR_STEPS: TourStep[] = [
-  {
-    id: "welcome",
-    route: "/dashboard",
-    targetSelector: "[data-tour='oracle-banner']",
-    oracleMessage:
-      "Welcome to Atlas. I'm The Oracle \u2014 I'll help you find your voice. Let me show you around.",
-    position: "bottom",
-  },
-  {
-    id: "voice-sliders",
-    route: "/voice-profiles",
-    targetSelector: "[data-tour='dimension-sliders']",
-    oracleMessage:
-      "This is your voice DNA. Each slider shapes how your tweets sound. Try dragging one \u2014 see how the preview changes.",
-    position: "bottom",
-  },
-  {
-    id: "reference-voices",
-    route: "/voice-profiles",
-    targetSelector: "[data-tour='reference-voices']",
-    oracleMessage:
-      "Pick writers you admire. I'll blend their style with yours. Most analysts pick 2-3.",
-    position: "bottom",
-  },
-  {
-    id: "crafting-input",
-    route: "/crafting",
-    targetSelector: "[data-tour='content-input']",
-    oracleMessage:
-      "This is the Crafting Station. Paste any content \u2014 a report, an article, a hot take \u2014 and I'll draft a tweet in your voice.",
-    position: "bottom",
-  },
-  {
-    id: "generate-draft",
-    route: "/crafting",
-    targetSelector: "[data-tour='generate-button']",
-    oracleMessage:
-      "Hit Generate and watch. I'll use your voice profile to craft something that sounds like you, not a bot.",
-    position: "bottom",
-  },
-  {
-    id: "signals-feed",
-    route: "/alerts",
-    targetSelector: "[data-tour='signals-feed']",
-    oracleMessage:
-      "Signals watches crypto twitter for you. Trending topics, competitor posts, market moves \u2014 all in one feed.",
-    position: "bottom",
-  },
-  {
-    id: "tour-complete",
-    route: "/dashboard",
-    targetSelector: "[data-tour='oracle-widget']",
-    oracleMessage:
-      "That's the basics. I'm always here \u2014 click me anytime for help, drafting ideas, or voice tuning. Now go craft something.",
-    position: "top",
-  },
+/** Pages that have contextual tours. */
+export type TourPage =
+  | "dashboard"
+  | "voice-profiles"
+  | "crafting"
+  | "alerts"
+  | "analytics"
+  | "arena";
+
+/** Map route pathnames to TourPage identifiers. */
+export const ROUTE_TO_PAGE: Record<string, TourPage> = {
+  "/dashboard": "dashboard",
+  "/voice-profiles": "voice-profiles",
+  "/crafting": "crafting",
+  "/alerts": "alerts",
+  "/analytics": "analytics",
+  "/arena": "arena",
+};
+
+/** Per-page tour step definitions. Oracle narrates each contextually. */
+export const PAGE_TOURS: Record<TourPage, TourStep[]> = {
+  dashboard: [
+    {
+      id: "welcome",
+      targetSelector: "[data-tour='oracle-banner']",
+      oracleMessage:
+        "Welcome to Atlas. I\u2019m The Oracle \u2014 I\u2019ll help you find your voice. Explore any page and I\u2019ll show you the ropes.",
+      position: "bottom",
+    },
+    {
+      id: "oracle-always-here",
+      targetSelector: "[data-tour='oracle-widget']",
+      oracleMessage:
+        "I\u2019m always here \u2014 click me anytime for help, drafting ideas, or voice tuning.",
+      position: "top",
+    },
+  ],
+
+  "voice-profiles": [
+    {
+      id: "voice-sliders",
+      targetSelector: "[data-tour='dimension-sliders']",
+      oracleMessage:
+        "This is your voice DNA. Each slider shapes how your tweets sound. Try dragging one \u2014 see how the preview changes.",
+      position: "bottom",
+    },
+    {
+      id: "reference-voices",
+      targetSelector: "[data-tour='reference-voices']",
+      oracleMessage:
+        "Pick writers you admire. I\u2019ll blend their style with yours. Most analysts pick 2\u20133.",
+      position: "bottom",
+    },
+  ],
+
+  crafting: [
+    {
+      id: "crafting-input",
+      targetSelector: "[data-tour='content-input']",
+      oracleMessage:
+        "This is the Crafting Station. Paste any content \u2014 a report, an article, a hot take \u2014 and I\u2019ll draft a tweet in your voice.",
+      position: "bottom",
+    },
+    {
+      id: "generate-draft",
+      targetSelector: "[data-tour='generate-button']",
+      oracleMessage:
+        "Hit Generate and watch. I\u2019ll use your voice profile to craft something that sounds like you, not a bot.",
+      position: "bottom",
+    },
+  ],
+
+  alerts: [
+    {
+      id: "signals-feed",
+      targetSelector: "[data-tour='signals-feed']",
+      oracleMessage:
+        "Signals watches crypto twitter for you. Trending topics, competitor posts, market moves \u2014 all in one feed.",
+      position: "bottom",
+    },
+    {
+      id: "signals-subscribe",
+      targetSelector: "[data-tour='signals-subscribe']",
+      oracleMessage:
+        "Subscribe to topics you care about. I\u2019ll ping you when something breaks through the noise.",
+      position: "bottom",
+    },
+  ],
+
+  analytics: [
+    {
+      id: "analytics-summary",
+      targetSelector: "[data-tour='analytics-summary']",
+      oracleMessage:
+        "Track what\u2019s working. Your best posts share a pattern \u2014 I\u2019ll help you spot it.",
+      position: "bottom",
+    },
+    {
+      id: "analytics-learning",
+      targetSelector: "[data-tour='analytics-learning']",
+      oracleMessage:
+        "The learning log shows how your voice evolves over time. Every draft teaches me more about you.",
+      position: "bottom",
+    },
+  ],
+
+  arena: [
+    {
+      id: "arena-leaderboard",
+      targetSelector: "[data-tour='arena-leaderboard']",
+      oracleMessage:
+        "The Arena ranks analysts by output, engagement, and consistency. Climb the board.",
+      position: "bottom",
+    },
+    {
+      id: "arena-your-rank",
+      targetSelector: "[data-tour='arena-your-rank']",
+      oracleMessage:
+        "This is where you stand. Post more, engage more, and watch your rank rise.",
+      position: "bottom",
+    },
+  ],
+};
+
+/** All tour pages in recommended first-visit order. */
+export const TOUR_PAGES: TourPage[] = [
+  "dashboard",
+  "voice-profiles",
+  "crafting",
+  "alerts",
+  "analytics",
+  "arena",
 ];
+
+/** localStorage key for tracking whether a page tour has been completed. */
+export function pageTourKey(page: TourPage): string {
+  return `atlas_page_toured_${page}`;
+}
+
+/** Check if a page tour has been completed. */
+export function isPageTourComplete(page: TourPage): boolean {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem(pageTourKey(page)) === "true";
+}
+
+/** Mark a page tour as completed. */
+export function markPageTourComplete(page: TourPage): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(pageTourKey(page), "true");
+}
+
+/** Reset all page tour completion flags. */
+export function resetAllPageTours(): void {
+  if (typeof window === "undefined") return;
+  for (const page of TOUR_PAGES) {
+    localStorage.removeItem(pageTourKey(page));
+  }
+}
+
+// \u2500\u2500 Legacy compat: flat TOUR_STEPS array for anything still referencing it \u2500\u2500
+// Remove once all consumers are migrated.
+export interface LegacyTourStep extends TourStep {
+  route: string;
+}
+export const TOUR_STEPS: LegacyTourStep[] = Object.entries(PAGE_TOURS).flatMap(
+  ([page, steps]) => {
+    const route = Object.entries(ROUTE_TO_PAGE).find(
+      ([, p]) => p === page,
+    )?.[0];
+    return steps.map((s) => ({ ...s, route: route ?? `/${page}` }));
+  },
+);


### PR DESCRIPTION
## Summary
- Refactors the 7-step linear FTUE into per-page contextual tours (2 steps each)
- 6 pages covered: dashboard, voice-profiles, crafting, alerts, analytics, arena
- Each page tour auto-fires on first visit, stores completion in `localStorage(atlas_page_toured_{page})`
- TOUR pill replays current page or resets all if everything's done
- Backend `tourCompleted` synced when all 6 pages finished
- Existing TourSpotlight and auto-demo-mode behavior preserved

## Test plan
- [ ] Visit dashboard as new user — welcome tour auto-fires after 1.2s
- [ ] Navigate to voice-profiles — sliders + reference voices tour fires
- [ ] Navigate to crafting — input + generate tour fires
- [ ] Revisit dashboard — tour does NOT re-fire (localStorage set)
- [ ] Click TOUR pill — replays current page's tour
- [ ] Complete all 6 pages, click TOUR pill — resets all and restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)