### PR TITLE
fix: UAT checklist — stat destinations + trending prefill

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -95,13 +95,13 @@ export default function AnalyticsPage() {
   const usageStats = summary
     ? [
         { label: "Drafts", value: String(summary.draftsCreated), href: "/crafting" },
-        { label: "Feedback", value: String(summary.feedbackGiven), href: "/crafting" },
+        { label: "Feedback", value: String(summary.feedbackGiven), href: "/dashboard" },
         { label: "Refinements", value: String(summary.refinements ?? 0), href: "/voice-profiles" },
         { label: "Ingested", value: String(summary.reportsIngested), href: "/alerts" },
       ]
     : [
         { label: "Drafts", value: "0", href: "/crafting" },
-        { label: "Feedback", value: "0", href: "/crafting" },
+        { label: "Feedback", value: "0", href: "/dashboard" },
         { label: "Refinements", value: "0", href: "/voice-profiles" },
         { label: "Ingested", value: "0", href: "/alerts" },
       ];

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -274,7 +274,7 @@ export default function DashboardPage() {
             </div>
             <div className="mt-3 space-y-2">
               {trending.map((topic) => (
-                <Link key={topic.id} href="/crafting" className="flex items-center justify-between rounded-xl bg-atlas-bg/40 px-4 py-3 group card-interactive">
+                <Link key={topic.id} href={`/crafting?content=${encodeURIComponent(topic.headline || topic.topic)}`} className="flex items-center justify-between rounded-xl bg-atlas-bg/40 px-4 py-3 group card-interactive">
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium text-atlas-text truncate group-hover:text-atlas-teal transition-colors">{topic.headline || topic.topic}</p>
                     {topic.sentiment && (


### PR DESCRIPTION
Analytics Feedback→/dashboard (distinct from Drafts→/crafting). Trending topics prefill crafting content.