### PR TITLE
Sprint merge: Brief polish + linter config + telegram timeout (#103 #125 #106)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {},
+  "eslint.autoFixOnSave": false,
+  "typescript.format.enable": false
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -226,6 +226,7 @@ type SmokeRoute = {
   path: string;
   finalUrl?: RegExp;
   ready: (page: Page) => Locator;
+  readyTimeout?: number;
 };
 
 const smokeRoutes: SmokeRoute[] = [
@@ -282,6 +283,7 @@ const smokeRoutes: SmokeRoute[] = [
     path: "/telegram",
     ready: (page) =>
       page.getByRole("heading", { name: /telegram/i }).first(),
+    readyTimeout: 15_000,
   },
   {
     name: "campaigns",
@@ -423,7 +425,7 @@ async function expectHealthyPage(
     await page.waitForURL(smokeRoute.finalUrl);
   }
 
-  await expect(smokeRoute.ready(page)).toBeVisible();
+  await expect(smokeRoute.ready(page)).toBeVisible({ timeout: smokeRoute.readyTimeout });
   await expect(page.getByText("Something went wrong", { exact: true })).toHaveCount(0);
   await expect(page.getByText("Page not found", { exact: true })).toHaveCount(0);
 

--- a/src/app/briefing/page.tsx
+++ b/src/app/briefing/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2, Settings, RefreshCw, Clock, ChevronDown, ChevronUp, PenTool } from "lucide-react";
+import { Loader2, Settings, RefreshCw, Clock, ChevronDown, ChevronUp, PenTool, Sparkles } from "lucide-react";
 import GlassCard from "@/components/ui/GlassCard";
 import GradientButton from "@/components/ui/GradientButton";
 import AppShell from "@/components/layout/AppShell";
@@ -189,8 +189,13 @@ export default function BriefingPage() {
     return (
       <AppShell>
         <div className="mx-auto max-w-3xl py-8 space-y-6">
-          <header className="space-y-3">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">Morning Briefing</p>
+          <header className="space-y-3" data-tour="briefing-header">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">Morning Briefing</p>
+              <span className="inline-flex items-center gap-1 rounded-full bg-atlas-teal/10 px-2.5 py-0.5 text-[10px] font-semibold text-atlas-teal ring-1 ring-atlas-teal/20">
+                <Sparkles className="h-3 w-3" /> AI-powered
+              </span>
+            </div>
             <h1 className="font-heading font-extrabold tracking-tight text-3xl text-atlas-text sm:text-4xl">
               Your Daily Briefing
             </h1>
@@ -216,9 +221,14 @@ export default function BriefingPage() {
   return (
     <AppShell>
       <div className="mx-auto max-w-3xl py-8 space-y-6">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between" data-tour="briefing-header">
           <div className="space-y-2">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">Morning Briefing</p>
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">Morning Briefing</p>
+              <span className="inline-flex items-center gap-1 rounded-full bg-atlas-teal/10 px-2.5 py-0.5 text-[10px] font-semibold text-atlas-teal ring-1 ring-atlas-teal/20">
+                <Sparkles className="h-3 w-3" /> AI-powered
+              </span>
+            </div>
             <h1 className="font-heading font-extrabold tracking-tight text-3xl text-atlas-text sm:text-4xl">
               Your Briefings
             </h1>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import StatusPill from "@/components/ui/StatusPill";
 import GradientButton from "@/components/ui/GradientButton";
 import { useAuth } from "@/lib/auth";
 import { api, TweetDraft, QueuedDraft, TrendingTopic } from "@/lib/api";
-import { PenTool, Bell, BarChart3, Mic2, BookOpen, Send, Users, TrendingUp, X, Clock, Zap, Calendar } from "lucide-react";
+import { PenTool, Bell, BarChart3, Mic2, BookOpen, Send, Users, TrendingUp, X, Clock, Zap, Calendar, Sparkles, ArrowRight } from "lucide-react";
 import DashboardSkeleton from "@/components/skeletons/DashboardSkeleton";
 import OracleWidget from "@/components/oracle/OracleWidget";
 
@@ -289,6 +289,24 @@ export default function DashboardPage() {
           </div>
         ) : null}
       </div>
+
+      <Link
+        href="/briefing"
+        className="mt-8 flex items-center justify-between rounded-2xl border border-atlas-teal/20 bg-gradient-to-r from-atlas-teal/5 to-transparent p-5 ring-1 ring-atlas-teal/10 transition-all hover:ring-atlas-teal/30 hover:shadow-lg hover:shadow-atlas-teal/5"
+      >
+        <div className="flex items-center gap-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-atlas-teal/10">
+            <Sparkles className="h-5 w-5 text-atlas-teal" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-atlas-text">Brief: AI-powered tweet ideas</p>
+            <p className="text-xs text-atlas-text-secondary">Pick sources, get tweet angles instantly. Zero thinking required.</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 text-xs font-medium text-atlas-teal">
+          Try Brief <ArrowRight className="h-3.5 w-3.5" />
+        </div>
+      </Link>
 
       <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {navCards.map((card) => (

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -143,6 +143,9 @@ export default function NavBar({ variant }: NavBarProps) {
                   }`}
                 >
                   {link.label}
+                  {link.label === "Briefing" && (
+                    <span className="ml-1 rounded-full bg-atlas-teal/15 px-1.5 py-0.5 text-[9px] font-bold text-atlas-teal">NEW</span>
+                  )}
                 </Link>
               ))}
             </div>
@@ -272,6 +275,9 @@ export default function NavBar({ variant }: NavBarProps) {
                     >
                       <Icon className="h-4 w-4" aria-hidden="true" />
                       {link.label}
+                      {link.label === "Briefing" && (
+                        <span className="ml-auto rounded-full bg-atlas-teal/15 px-1.5 py-0.5 text-[9px] font-bold text-atlas-teal">NEW</span>
+                      )}
                     </Link>
                   );
                 })}

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -12,6 +12,7 @@ export type TourPage =
   | "dashboard"
   | "voice-profiles"
   | "crafting"
+  | "briefing"
   | "alerts"
   | "analytics"
   | "arena";
@@ -21,6 +22,7 @@ export const ROUTE_TO_PAGE: Record<string, TourPage> = {
   "/dashboard": "dashboard",
   "/voice-profiles": "voice-profiles",
   "/crafting": "crafting",
+  "/briefing": "briefing",
   "/alerts": "alerts",
   "/analytics": "analytics",
   "/arena": "arena",
@@ -75,6 +77,16 @@ export const PAGE_TOURS: Record<TourPage, TourStep[]> = {
       targetSelector: "[data-tour='generate-button']",
       oracleMessage:
         "Hit Generate and watch. I\u2019ll use your voice profile to craft something that sounds like you, not a bot.",
+      position: "bottom",
+    },
+  ],
+
+  briefing: [
+    {
+      id: "briefing-intro",
+      targetSelector: "[data-tour='briefing-header']",
+      oracleMessage:
+        "This is Brief \u2014 pick your sources and it generates tweet angles automatically. Zero thinking required. Anil called it gigabrain.",
       position: "bottom",
     },
   ],
@@ -136,6 +148,7 @@ export const TOUR_PAGES: TourPage[] = [
   "dashboard",
   "voice-profiles",
   "crafting",
+  "briefing",
   "alerts",
   "analytics",
   "arena",


### PR DESCRIPTION
## Summary
- **#103** Brief highlighted as hero feature: AI badge, guided tour step, nav indicator, dashboard promo card
- **#125** IDE linter config (.vscode/settings.json) to prevent aggressive auto-rewrites
- **#106** Telegram smoke test timeout increased to prevent CI flakiness

## Test plan
- [x] `next build` passes locally
- [ ] CI check passes
- [ ] Verify Brief page shows AI badge and tour step
- [ ] Verify dashboard promo card links to /briefing

🤖 Generated with [Claude Code](https://claude.com/claude-code)