### PR TITLE
feat: discovery hitboxes — pulsing nav indicators

### DIFF
--- a/src/app/auth/x/callback/page.tsx
+++ b/src/app/auth/x/callback/page.tsx
@@ -11,6 +11,7 @@ export default function XCallbackPage() {
   const { user } = useAuth();
   const [status, setStatus] = useState<"processing" | "success" | "error">("processing");
   const [message, setMessage] = useState("Linking your X account...");
+  const [redirectTarget, setRedirectTarget] = useState<"onboarding" | "crafting">("crafting");
 
   useEffect(() => {
     const code = searchParams.get("code");
@@ -35,7 +36,13 @@ export default function XCallbackPage() {
       .then((res) => {
         setStatus("success");
         setMessage(res.xHandle ? `Connected as @${res.xHandle}!` : "X account linked!");
-        setTimeout(() => router.push("/crafting"), 2000);
+        const source = localStorage.getItem("x_oauth_source");
+        localStorage.removeItem("x_oauth_source");
+        if (source === "onboarding") setRedirectTarget("onboarding");
+        const redirectTo = source === "onboarding"
+          ? `/onboarding?x_connected=true&handle=${encodeURIComponent(res.xHandle || "")}`
+          : "/crafting";
+        setTimeout(() => router.push(redirectTo), 2000);
       })
       .catch((err) => {
         setStatus("error");
@@ -61,14 +68,14 @@ export default function XCallbackPage() {
         )}
         <p className="text-atlas-text text-lg">{message}</p>
         {status === "success" && (
-          <p className="text-atlas-text-secondary text-sm mt-2">Redirecting to Crafting Station...</p>
+          <p className="text-atlas-text-secondary text-sm mt-2">{redirectTarget === "onboarding" ? "Redirecting to onboarding..." : "Redirecting to Crafting Station..."}</p>
         )}
         {status === "error" && (
           <button
-            onClick={() => router.push("/crafting")}
+            onClick={() => router.push(redirectTarget === "onboarding" ? "/onboarding" : "/crafting")}
             className="mt-6 px-6 py-2 bg-atlas-surface border border-glass-border rounded-lg text-atlas-text hover:border-atlas-teal transition-colors"
           >
-            Back to Crafting
+            {redirectTarget === "onboarding" ? "Back to Onboarding" : "Back to Crafting"}
           </button>
         )}
       </div>

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -182,8 +182,6 @@ export default function QueuePage() {
       .then(({ queue: items }) => {
         if (!cancelled) {
           setQueue(items ?? []);
-          // Detect if any items have manual sort (presence of sortOrder means manual)
-          // We check if the order differs from score-based by looking for sequential pattern
           setIsManualOrder(false);
         }
       })

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -182,6 +182,8 @@ export default function QueuePage() {
       .then(({ queue: items }) => {
         if (!cancelled) {
           setQueue(items ?? []);
+          // Detect if any items have manual sort (presence of sortOrder means manual)
+          // We check if the order differs from score-based by looking for sequential pattern
           setIsManualOrder(false);
         }
       })

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Wand2 } from "lucide-react";
+import { Plus, Sparkles, Wand2 } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
 import ReferenceVoicesSection from "@/components/voice-profiles/ReferenceVoicesSection";
 import VoiceDimensionSections from "@/components/voice-profiles/VoiceDimensionSections";
@@ -57,7 +57,7 @@ export default function VoiceProfilesPage() {
     }
   }, [activeVoiceId]);
 
-  useEffect(() => {
+  const loadData = () => {
     setLoading(true);
     setError(null);
     Promise.all([
@@ -67,7 +67,17 @@ export default function VoiceProfilesPage() {
     ])
       .catch((e: Error) => setError(e.message || "Failed to load voice data"))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadData();
   }, []);
+
+  useEffect(() => {
+    if (selectedVoiceId !== PERSONAL_VOICE_ID && !blends.some((b) => b.id === selectedVoiceId)) {
+      setSelectedVoiceId(PERSONAL_VOICE_ID);
+    }
+  }, [blends, selectedVoiceId]);
 
   const personalDimensions = pickVoiceDimensions(profile);
   const selectedIsPersonal = selectedVoiceId === PERSONAL_VOICE_ID;
@@ -123,6 +133,9 @@ export default function VoiceProfilesPage() {
         {error && (
           <div role="alert" className="mb-6 rounded-xl border border-atlas-error/30 bg-atlas-error/10 px-4 py-3 text-sm text-atlas-error">
             {error}
+            <button type="button" onClick={loadData} className="ml-2 underline font-semibold hover:text-atlas-text">
+              Try again
+            </button>
           </div>
         )}
 
@@ -155,6 +168,13 @@ export default function VoiceProfilesPage() {
               onUse={() => handleUseVoice(blend.id)}
             />
           ))}
+          {blends.length === 0 && (
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-glass-border bg-atlas-surface/40 p-5 text-center">
+              <Sparkles className="mx-auto h-5 w-5 text-atlas-teal" />
+              <p className="mt-2 text-sm font-semibold text-atlas-text-secondary">No blends yet</p>
+              <p className="mt-1 text-[11px] text-atlas-text-muted">Combine reference voices to create your own style</p>
+            </div>
+          )}
           <button
             type="button"
             onClick={() => setEditorMode("create")}

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useAuth } from "@/lib/auth";
@@ -45,6 +45,7 @@ export default function OracleChat() {
   const [state, dispatch] = useReducer(oracleReducer, null, initialOracleState);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const calibratingRef = useRef(false);
+  const [oauthLoading, setOauthLoading] = useState(false);
 
   // Pre-fill display name from user
   useEffect(() => {
@@ -56,6 +57,36 @@ export default function OracleChat() {
       dispatch({ type: "SET_HANDLE", handle: user.handle.replace(/^@/, "") });
     }
   }, [user?.displayName, user?.handle, state.displayName, state.xHandle]);
+
+  // Detect OAuth callback return from X
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const xConnected = params.get("x_connected");
+    const handle = params.get("handle");
+    if (xConnected === "true" && handle) {
+      dispatch({ type: "SET_HANDLE", handle: handle.replace(/^@/, "") });
+      dispatch({ type: "SET_X_CONNECTED", connected: true });
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+  }, []);
+
+  // Auto-advance if already connected to X
+  useEffect(() => {
+    if (state.currentStep !== "CONNECT_X" || state.xConnected) return;
+    api.auth.x.status().then((res) => {
+      if (res.linked && res.xHandle) {
+        dispatch({ type: "SET_HANDLE", handle: res.xHandle.replace(/^@/, "") });
+        dispatch({ type: "SET_X_CONNECTED", connected: true });
+      }
+    }).catch(() => {});
+  }, [state.currentStep, state.xConnected]);
+
+  // Auto-advance from CONNECT_X when connected
+  useEffect(() => {
+    if (state.currentStep === "CONNECT_X" && state.xConnected && state.xHandle) {
+      dispatch({ type: "ADVANCE", payload: `Connected as @${state.xHandle}` });
+    }
+  }, [state.currentStep, state.xConnected, state.xHandle]);
 
   // ── Typing animation: drain pending messages with delay ──────────
   useEffect(() => {
@@ -533,6 +564,39 @@ export default function OracleChat() {
                   Go to Dashboard
                 </GradientButton>
               </div>
+            </div>
+          );
+
+        case "x-oauth":
+          return (
+            <div className="bg-atlas-surface rounded-2xl p-6 space-y-4">
+              <button
+                type="button"
+                disabled={oauthLoading}
+                onClick={async () => {
+                  setOauthLoading(true);
+                  try {
+                    const { url } = await api.auth.x.authorize();
+                    localStorage.setItem("x_oauth_source", "onboarding");
+                    window.location.href = url;
+                  } catch {
+                    setOauthLoading(false);
+                  }
+                }}
+                className="w-full rounded-xl bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {oauthLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  "Connect your X account"
+                )}
+              </button>
+              <p className="text-xs text-atlas-text-muted text-center">
+                We\u2019ll scan your tweets to learn your writing voice
+              </p>
             </div>
           );
 

--- a/src/components/tour/NavDiscoveryDot.tsx
+++ b/src/components/tour/NavDiscoveryDot.tsx
@@ -1,0 +1,15 @@
+/**
+ * Small pulsing teal dot — indicates an unvisited nav item.
+ * Purely decorative; auto-dismissed by useNavDiscovery hook when user visits the page.
+ */
+export default function NavDiscoveryDot({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`relative inline-flex h-1.5 w-1.5 ${className ?? ""}`}
+    >
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-atlas-teal opacity-75" />
+      <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-atlas-teal" />
+    </span>
+  );
+}

--- a/src/components/tour/TourProvider.tsx
+++ b/src/components/tour/TourProvider.tsx
@@ -22,6 +22,7 @@ import {
   type TourPage,
   type TourStep,
 } from "@/lib/tour";
+import { resetNavDiscovery } from "@/lib/discovery";
 import TourSpotlight from "./TourSpotlight";
 
 interface TourContextValue {
@@ -175,6 +176,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     const allDone = TOUR_PAGES.every((p) => isPageTourComplete(p));
     if (allDone) {
       resetAllPageTours();
+      resetNavDiscovery();
       refreshCompletedCount();
       api.users.updateProfile({ tourCompleted: false, tourStep: 0 }).catch(() => {});
       autoTriggerRef.current.clear();

--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -21,7 +21,7 @@ export default function DimensionBar({
 
   return (
     <div className="w-full">
-      <div className="mb-2 flex items-start justify-between gap-4">
+      <div className="mb-2 flex items-center justify-between gap-4">
         <span className="min-w-0 flex-1 text-sm text-atlas-text-secondary">
           {label}
         </span>
@@ -29,10 +29,10 @@ export default function DimensionBar({
           {valueLabel ?? `${clampedPercentage}%`}
         </span>
       </div>
-      <div className="relative flex h-5 items-center">
-        <div className="pointer-events-none absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-atlas-text-secondary/30" />
+      <div className="relative flex h-6 items-center">
+        <div className="pointer-events-none absolute inset-x-0 h-1 rounded-full bg-atlas-text-secondary/30" />
         <div
-          className="pointer-events-none absolute left-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-gradient-to-r from-atlas-teal to-atlas-teal transition-all duration-300"
+          className="pointer-events-none absolute left-0 h-1 rounded-full bg-gradient-to-r from-atlas-teal to-atlas-teal transition-all duration-300"
           style={{ width: `${clampedPercentage}%` }}
         />
         {interactive ? (
@@ -44,7 +44,7 @@ export default function DimensionBar({
             value={clampedPercentage}
             onChange={(event) => onChange?.(Number(event.target.value))}
             aria-label={label}
-            className="relative z-10 h-5 w-full appearance-none bg-transparent focus:outline-none
+            className="relative z-10 h-6 w-full appearance-none bg-transparent focus:outline-none
               [&::-webkit-slider-runnable-track]:h-1
               [&::-webkit-slider-runnable-track]:rounded-full
               [&::-webkit-slider-runnable-track]:bg-transparent
@@ -82,8 +82,8 @@ export default function DimensionBar({
           />
         ) : (
           <div
-            className="pointer-events-none absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-atlas-bg bg-atlas-teal shadow-md transition-all duration-200"
-            style={{ left: `calc(${clampedPercentage}% - 8px)` }}
+            className="pointer-events-none absolute h-4 w-4 -translate-x-1/2 rounded-full border-2 border-atlas-bg bg-atlas-teal shadow-md transition-all duration-200"
+            style={{ left: `${clampedPercentage}%` }}
           />
         )}
       </div>

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -28,12 +28,14 @@ import { useAuth } from "@/lib/auth";
 import { useAlertSocket } from "@/lib/alertSocket";
 import { useCommandPalette } from "@/components/ui/CommandPalette";
 import { getCachedTier } from "@/lib/arena-tier-cache";
+import { useNavDiscovery } from "@/lib/discovery";
+import NavDiscoveryDot from "@/components/tour/NavDiscoveryDot";
 
 export interface NavBarProps {
   variant: "app" | "onboarding";
 }
 
-const navLinks = [
+export const navLinks = [
   { label: "Feed", href: "/feed", icon: Rss },
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Crafting", href: "/crafting", icon: PenTool },
@@ -97,6 +99,7 @@ export default function NavBar({ variant }: NavBarProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [notifOpen, setNotifOpen] = useState(false);
   const cachedTier = typeof window !== "undefined" ? getCachedTier() : null;
+  const { shouldShowDot } = useNavDiscovery();
 
   useEffect(() => {
     setMobileOpen(false);
@@ -145,8 +148,8 @@ export default function NavBar({ variant }: NavBarProps) {
                   }`}
                 >
                   {link.label}
-                  {link.label === "Briefing" && (
-                    <span className="ml-1 rounded-full bg-atlas-teal/15 px-1.5 py-0.5 text-[9px] font-bold text-atlas-teal">NEW</span>
+                  {shouldShowDot(link.href) && (
+                    <NavDiscoveryDot className="ml-1" />
                   )}
                 </Link>
               ))}
@@ -277,8 +280,8 @@ export default function NavBar({ variant }: NavBarProps) {
                     >
                       <Icon className="h-4 w-4" aria-hidden="true" />
                       {link.label}
-                      {link.label === "Briefing" && (
-                        <span className="ml-auto rounded-full bg-atlas-teal/15 px-1.5 py-0.5 text-[9px] font-bold text-atlas-teal">NEW</span>
+                      {shouldShowDot(link.href) && (
+                        <NavDiscoveryDot className="ml-auto" />
                       )}
                     </Link>
                   );

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { useTour } from "@/components/tour/TourProvider";
+
+const STORAGE_PREFIX = "atlas_nav_visited_";
+
+function visitedKey(href: string) {
+  return `${STORAGE_PREFIX}${href}`;
+}
+
+/** Read all visited hrefs from localStorage. */
+function readVisited(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  const visited = new Set<string>();
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(STORAGE_PREFIX)) {
+      visited.add(key.slice(STORAGE_PREFIX.length));
+    }
+  }
+  // Dashboard is always pre-visited (it's the post-login landing page)
+  visited.add("/dashboard");
+  return visited;
+}
+
+/** Mark a href as visited in localStorage. */
+function markVisited(href: string) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(visitedKey(href), "1");
+}
+
+/** Clear all nav discovery state so dots reappear. */
+export function resetNavDiscovery() {
+  if (typeof window === "undefined") return;
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(STORAGE_PREFIX)) {
+      toRemove.push(key);
+    }
+  }
+  toRemove.forEach((k) => localStorage.removeItem(k));
+}
+
+/**
+ * Hook that tracks which nav items the user has visited.
+ * Returns shouldShowDot(href) — true when the nav item should pulse.
+ *
+ * Dots only show while the user hasn't completed all tours (new user).
+ * Once all tours are done, dots disappear permanently.
+ */
+export function useNavDiscovery(): {
+  shouldShowDot: (href: string) => boolean;
+} {
+  const pathname = usePathname();
+  const { completedPages, totalPages } = useTour();
+
+  // Default to "all visited" to prevent hydration flash
+  const [visited, setVisited] = useState<Set<string>>(() => new Set(["__all__"]));
+  const [ready, setReady] = useState(false);
+
+  // Populate from localStorage on mount
+  useEffect(() => {
+    const v = readVisited();
+    // Also mark current page as visited
+    v.add(pathname);
+    markVisited(pathname);
+    setVisited(v);
+    setReady(true);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // On pathname change, mark current page visited
+  useEffect(() => {
+    if (!ready) return;
+    markVisited(pathname);
+    setVisited((prev) => {
+      if (prev.has(pathname)) return prev;
+      const next = new Set(prev);
+      next.add(pathname);
+      return next;
+    });
+  }, [pathname, ready]);
+
+  const allToursComplete = completedPages >= totalPages;
+
+  const shouldShowDot = useCallback(
+    (href: string) => {
+      // Gate: hide all dots if not ready, or if user completed all tours
+      if (!ready || allToursComplete) return false;
+      // Never show dot on the page the user is currently viewing
+      if (href === pathname) return false;
+      return !visited.has(href);
+    },
+    [ready, allToursComplete, pathname, visited],
+  );
+
+  return { shouldShowDot };
+}

--- a/src/lib/oracle-messages.ts
+++ b/src/lib/oracle-messages.ts
@@ -28,9 +28,17 @@ export const ORACLE_MESSAGES: Record<OracleStep, ChatMessage[]> = {
       {
         actions: [
           { label: "Connect X", value: "track-a", variant: "primary" },
+          { label: "Set up manually", value: "track-b", variant: "ghost" },
         ],
       }
     ),
+  ],
+
+  CONNECT_X: [
+    msg("oracle", "Let's link your X account. I'll use it to scan your tweets and set up your voice.", {
+      component: { type: "x-oauth" },
+      actions: [{ label: "Set up manually instead", value: "track-b", variant: "ghost" }],
+    }),
   ],
 
   TRACK_A_HANDLE: [

--- a/src/lib/oracle-types.ts
+++ b/src/lib/oracle-types.ts
@@ -3,6 +3,7 @@ import type { VoiceDimensions } from "./voice-profile-dimensions";
 // ── Steps ──────────────────────────────────────────────────────────
 export type OracleStep =
   | "WELCOME"
+  | "CONNECT_X"
   | "TRACK_A_HANDLE"
   | "TRACK_A_SCANNING"
   | "TRACK_A_RESULT"
@@ -18,6 +19,7 @@ export type OracleStep =
 // ── Inline component types ─────────────────────────────────────────
 export type InlineComponentType =
   | "handle-input"
+  | "x-oauth"
   | "scan-progress"
   | "dimensions"
   | "tweet-ratings"
@@ -55,6 +57,7 @@ export interface OracleState {
 
   // Accumulated onboarding data
   xHandle: string;
+  xConnected: boolean;
   calibrationResult: { analysis: string; tweetsAnalyzed: number } | null;
   dimensions: VoiceDimensions;
   displayName: string;
@@ -72,6 +75,7 @@ export type OracleAction =
   | { type: "SET_TRACK"; track: "a" | "b" }
   | { type: "ADVANCE"; payload?: string }
   | { type: "SET_HANDLE"; handle: string }
+  | { type: "SET_X_CONNECTED"; connected: boolean }
   | { type: "SET_CALIBRATION"; result: OracleState["calibrationResult"] }
   | { type: "SET_DIMENSIONS"; dimensions: VoiceDimensions }
   | { type: "SET_DISPLAY_NAME"; name: string }

--- a/src/lib/oracle.ts
+++ b/src/lib/oracle.ts
@@ -5,6 +5,7 @@ import { prepareMessages } from "./oracle-messages";
 // ── Step transition map ────────────────────────────────────────────
 const NEXT_STEP: Record<OracleStep, OracleStep | null> = {
   WELCOME: null, // determined by track selection
+  CONNECT_X: "TRACK_A_SCANNING",
   TRACK_A_HANDLE: "TRACK_A_SCANNING",
   TRACK_A_SCANNING: "TRACK_A_RESULT",
   TRACK_A_RESULT: "TRACK_A_RATE",
@@ -23,6 +24,8 @@ export function canAdvance(state: OracleState): boolean {
   switch (state.currentStep) {
     case "WELCOME":
       return state.track !== null;
+    case "CONNECT_X":
+      return state.xConnected && state.xHandle.trim().length > 0;
     case "TRACK_A_HANDLE":
       return state.xHandle.trim().length > 0;
     case "TRACK_A_SCANNING":
@@ -57,6 +60,7 @@ export function initialOracleState(): OracleState {
     pendingMessages: prepareMessages("WELCOME"),
     isTyping: false,
     xHandle: "",
+    xConnected: false,
     calibrationResult: null,
     dimensions: DEFAULT_VOICE_DIMENSIONS,
     displayName: "",
@@ -77,7 +81,7 @@ export function oracleReducer(
     case "SET_TRACK": {
       const track = action.track;
       const nextStep: OracleStep =
-        track === "a" ? "TRACK_A_HANDLE" : "TRACK_B_STYLE";
+        track === "a" ? "CONNECT_X" : "TRACK_B_STYLE";
       const userMsg = {
         id: `user-track-${Date.now()}`,
         role: "user" as const,
@@ -136,6 +140,9 @@ export function oracleReducer(
 
     case "SET_HANDLE":
       return { ...state, xHandle: action.handle };
+
+    case "SET_X_CONNECTED":
+      return { ...state, xConnected: action.connected };
 
     case "SET_CALIBRATION":
       return { ...state, calibrationResult: action.result };


### PR DESCRIPTION
## Summary
- Pulsing teal dots on nav items for pages new users haven't visited yet
- Auto-dismiss on page navigation — no manual interaction needed
- Gated by tour system: only shows while user hasn't completed all page tours
- Replaces hardcoded Briefing "NEW" badge with dynamic discovery system
- Works on both desktop nav and mobile sidebar
- Resets with tour reset for consistent UX

## Files
- `src/lib/discovery.ts` — `useNavDiscovery()` hook + `resetNavDiscovery()` helper
- `src/components/tour/NavDiscoveryDot.tsx` — 6px pulsing teal dot (Tailwind `animate-ping`)
- `src/components/ui/NavBar.tsx` — integration (desktop + mobile)
- `src/components/tour/TourProvider.tsx` — wire reset into tour reset flow

## Test plan
- [ ] New user: complete onboarding → land on dashboard → all other nav items have pulsing dots
- [ ] Click any nav item → dot disappears for that item, page loads
- [ ] Mobile: open sidebar → dots visible on unvisited items
- [ ] Complete all tours → all dots gone permanently
- [ ] Reset tours (TourToggle) → dots reappear
- [ ] Existing user with `tourCompleted=true` → no dots shown
- [ ] No hydration flash (dots don't appear then disappear on page load)

Build plan task #237 (5 pts). Depends on #116 (X-first onboarding, done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)