### PR TITLE
feat: Twitter OAuth login — callback + button (#309)

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { setAccessToken, api } from "@/lib/api";
+
+/**
+ * /auth/callback — handles server-side OAuth redirects.
+ * Backend redirects here with ?token=JWT&provider=twitter after successful OAuth.
+ * Stores the token, validates the session, and redirects to dashboard.
+ */
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<"processing" | "success" | "error">("processing");
+  const [message, setMessage] = useState("Signing you in...");
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    const provider = searchParams.get("provider");
+    const error = searchParams.get("error");
+
+    if (error) {
+      setStatus("error");
+      setMessage(
+        error === "access_denied"
+          ? "Authorization was denied. Please try again."
+          : error === "session_expired"
+            ? "Session expired. Please try again."
+            : `Login failed: ${error}`
+      );
+      return;
+    }
+
+    if (!token) {
+      setStatus("error");
+      setMessage("Missing authentication token. Please try again.");
+      return;
+    }
+
+    // Store the JWT
+    setAccessToken(token);
+    document.cookie = "atlas_access_token=1; path=/; max-age=86400; SameSite=Lax";
+    document.cookie = "atlas_session=1; path=/; max-age=604800; SameSite=Lax";
+
+    // Validate session by calling /me
+    api.auth.me()
+      .then((res) => {
+        setStatus("success");
+        const handle = res.user?.handle;
+        setMessage(handle ? `Welcome, @${handle}!` : "You're in!");
+        setTimeout(() => router.replace("/dashboard"), 1500);
+      })
+      .catch(() => {
+        setStatus("error");
+        setMessage("Session validation failed. Please try again.");
+        setAccessToken(null);
+        document.cookie = "atlas_session=; path=/; max-age=0";
+      });
+  }, [searchParams, router]);
+
+  return (
+    <div className="min-h-screen bg-atlas-bg flex items-center justify-center p-4 font-body">
+      <div className="bg-glass backdrop-blur-xl border border-glass-border rounded-2xl p-12 text-center max-w-md w-full">
+        {status === "processing" && (
+          <div className="animate-spin w-8 h-8 border-2 border-atlas-teal border-t-transparent rounded-full mx-auto mb-6" />
+        )}
+        {status === "success" && (
+          <div className="w-12 h-12 rounded-full bg-green-500/20 flex items-center justify-center mx-auto mb-6">
+            <span className="text-green-400 text-2xl">&#10003;</span>
+          </div>
+        )}
+        {status === "error" && (
+          <div className="w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center mx-auto mb-6">
+            <span className="text-red-400 text-2xl">&#10007;</span>
+          </div>
+        )}
+        <p className="text-atlas-text text-lg">{message}</p>
+        {status === "success" && (
+          <p className="text-atlas-text-secondary text-sm mt-2">Redirecting to dashboard...</p>
+        )}
+        {status === "error" && (
+          <button
+            onClick={() => router.push("/")}
+            className="mt-6 px-6 py-2 bg-atlas-surface border border-glass-border rounded-lg text-atlas-text hover:border-atlas-teal transition-colors"
+          >
+            Back to Login
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -189,6 +189,30 @@ export default function LoginPage() {
             : "Already have an account? Sign in \u2192"}
         </button>
 
+        <div className="h-5" />
+
+        <div className="relative flex items-center justify-center">
+          <div className="h-px flex-1 bg-glass-border" />
+          <span className="px-3 text-xs text-atlas-text-muted uppercase tracking-wider">or</span>
+          <div className="h-px flex-1 bg-glass-border" />
+        </div>
+
+        <div className="h-5" />
+
+        <button
+          type="button"
+          onClick={() => {
+            const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "https://api-production-9bef.up.railway.app";
+            window.location.href = `${apiUrl}/api/auth/twitter`;
+          }}
+          className="w-full flex items-center justify-center gap-3 px-4 py-3 bg-atlas-surface border border-glass-border rounded-lg text-atlas-text hover:border-atlas-teal hover:bg-atlas-surface/80 transition-all"
+        >
+          <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          <span className="font-medium">Continue with X</span>
+        </button>
+
         <div className="h-6" />
 
         <p className="text-atlas-text-muted text-xs tracking-wider uppercase">Powered by Delphi Digital</p>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 // Public routes that don't require authentication
-const PUBLIC_PATHS = new Set(["/", "/auth/x/callback", "/onboarding"]);
+const PUBLIC_PATHS = new Set(["/", "/auth/x/callback", "/auth/callback", "/onboarding"]);
 
 function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.has(pathname) || pathname.startsWith("/onboarding") || pathname.startsWith("/admin") || pathname.startsWith("/_next") || pathname.startsWith("/api") || pathname === "/style-tile.html";


### PR DESCRIPTION
## Summary
- Adds `/auth/callback` page that handles server-side OAuth redirects (stores JWT, validates session, redirects to dashboard)
- Adds "Continue with X" button with divider on the login page — navigates to `GET /api/auth/twitter` which triggers the full OAuth flow
- Updates middleware to allow `/auth/callback` as a public path

## Depends on
- a13xperi/atlas-backend#119 (backend Twitter OAuth endpoints)

## Test plan
- [ ] Click "Continue with X" on login page → verify redirect to X authorize
- [ ] Complete OAuth → verify landing on /auth/callback with spinner → dashboard
- [ ] Deny access on X → verify error message on callback page with "Back to Login" button
- [ ] Email/password login still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)