### PR TITLE
[codex] Fix onboardingTrack enum, preview bypass, and engagement response shape

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ E2E_USER_PASSWORD=
 # Vercel Deployment Protection Bypass
 # Token that allows Playwright to access PR preview deployments behind Vercel SSO.
 # Set in GitHub Actions secrets. Get from Vercel project settings > Deployment Protection.
+VERCEL_AUTOMATION_BYPASS_SECRET=
 VERCEL_PROTECTION_BYPASS=

--- a/e2e/demo-mode.spec.ts
+++ b/e2e/demo-mode.spec.ts
@@ -66,8 +66,11 @@ const test = fixtureTest.extend<{ authedPage: Page }>({
 
     // Set session cookie so middleware allows /dashboard
     const hostname = new URL(baseURL ?? "http://localhost:3000").hostname;
-    const bypassCookies = process.env.VERCEL_PROTECTION_BYPASS
-      ? [{ name: "_vercel_password", value: process.env.VERCEL_PROTECTION_BYPASS, domain: hostname, path: "/" }]
+    const vercelBypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    const bypassCookies = vercelBypass
+      ? [{ name: "_vercel_password", value: vercelBypass, domain: hostname, path: "/" }]
       : [];
     await context.addCookies([
       { name: "atlas_session", value: "1", domain: hostname, path: "/" },

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -199,7 +199,9 @@ async function stubDataEndpoints(page: Page) {
 export function vercelBypassCookies(
   domain: string,
 ): Array<{ name: string; value: string; domain: string; path: string }> {
-  const token = process.env.VERCEL_PROTECTION_BYPASS;
+  const token =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+    process.env.VERCEL_PROTECTION_BYPASS;
   if (!token) return [];
   return [{ name: "_vercel_password", value: token, domain, path: "/" }];
 }
@@ -214,10 +216,13 @@ export const test = base.extend<{ authedPage: Page }>({
       { name: "atlas_session", value: "1", domain: url.hostname, path: "/" },
     ];
     // Bypass Vercel deployment protection on preview URLs
-    if (process.env.VERCEL_PROTECTION_BYPASS) {
+    const vercelBypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    if (vercelBypass) {
       cookies.push({
         name: "_vercel_password",
-        value: process.env.VERCEL_PROTECTION_BYPASS,
+        value: vercelBypass,
         domain: url.hostname,
         path: "/",
       });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -450,10 +450,13 @@ test.describe("Route smoke tests", () => {
         { name: "atlas_access_token", value: "1", domain: url.hostname, path: "/" },
       ];
       // Bypass Vercel deployment protection on preview URLs
-      if (process.env.VERCEL_PROTECTION_BYPASS) {
+      const vercelBypass =
+        process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+        process.env.VERCEL_PROTECTION_BYPASS;
+      if (vercelBypass) {
         cookies.push({
           name: "_vercel_password",
-          value: process.env.VERCEL_PROTECTION_BYPASS,
+          value: vercelBypass,
           domain: url.hostname,
           path: "/",
         });

--- a/playwright-e2e.config.ts
+++ b/playwright-e2e.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "https://delphi-atlas.vercel.app";
+const vercelBypass =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+  process.env.VERCEL_PROTECTION_BYPASS;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -13,8 +16,11 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   use: {
     baseURL,
-    extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS
-      ? { "x-vercel-protection-bypass": process.env.VERCEL_PROTECTION_BYPASS }
+    extraHTTPHeaders: vercelBypass
+      ? {
+          "x-vercel-protection-bypass": vercelBypass,
+          "x-vercel-set-bypass-cookie": "true",
+        }
       : {},
     trace: "on-first-retry",
     screenshot: "only-on-failure",

--- a/playwright-qa.config.ts
+++ b/playwright-qa.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const vercelBypass =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+  process.env.VERCEL_PROTECTION_BYPASS;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -7,8 +11,11 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://delphi-atlas.vercel.app",
-    extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS
-      ? { "x-vercel-protection-bypass": process.env.VERCEL_PROTECTION_BYPASS }
+    extraHTTPHeaders: vercelBypass
+      ? {
+          "x-vercel-protection-bypass": vercelBypass,
+          "x-vercel-set-bypass-cookie": "true",
+        }
       : {},
     trace: "on-first-retry",
     screenshot: "only-on-failure",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ const apiURL =
   process.env.NEXT_PUBLIC_API_URL ??
   "https://api-production-9bef.up.railway.app";
 
-const vercelBypass = process.env.VERCEL_PROTECTION_BYPASS;
+const vercelBypass =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+  process.env.VERCEL_PROTECTION_BYPASS;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -23,7 +25,10 @@ export default defineConfig({
   use: {
     baseURL,
     extraHTTPHeaders: vercelBypass
-      ? { "x-vercel-protection-bypass": vercelBypass }
+      ? {
+          "x-vercel-protection-bypass": vercelBypass,
+          "x-vercel-set-bypass-cookie": "true",
+        }
       : {},
     trace: "on-first-retry",
     screenshot: "only-on-failure",

--- a/playwright.demo.config.ts
+++ b/playwright.demo.config.ts
@@ -1,8 +1,22 @@
 import { defineConfig, devices } from "@playwright/test";
+
+const vercelBypass =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+  process.env.VERCEL_PROTECTION_BYPASS;
+
 export default defineConfig({
   testDir: "./e2e", testMatch: ["demo-mode.spec.ts"], fullyParallel: true, retries: 0, reporter: "list",
   timeout: 45_000, expect: { timeout: 10_000 },
-  use: { baseURL: "http://localhost:3000", screenshot: "only-on-failure" },
+  use: {
+    baseURL: "http://localhost:3000",
+    extraHTTPHeaders: vercelBypass
+      ? {
+          "x-vercel-protection-bypass": vercelBypass,
+          "x-vercel-set-bypass-cookie": "true",
+        }
+      : {},
+    screenshot: "only-on-failure",
+  },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: { command: "npm run dev", url: "http://localhost:3000", reuseExistingServer: true, timeout: 120_000,
     env: { ...process.env, NEXT_PUBLIC_API_URL: "https://api-production-9bef.up.railway.app" } },

--- a/src/__tests__/lib/api.test.ts
+++ b/src/__tests__/lib/api.test.ts
@@ -59,12 +59,12 @@ describe("api.auth.register", () => {
     const data = { user: { id: "2", handle: "bob", role: "ANALYST" }, token: "tok_456", refresh_token: "rt_456" };
     mockFetch(data);
 
-    await api.auth.register("bob", "bob@example.com", "pass123", "crypto");
+    await api.auth.register("bob", "bob@example.com", "pass123", "TRACK_A");
 
     expect(fetch).toHaveBeenCalledWith(
       `${API_URL}/api/auth/register`,
       expect.objectContaining({
-        body: JSON.stringify({ handle: "bob", email: "bob@example.com", password: "pass123", onboardingTrack: "crypto" }),
+        body: JSON.stringify({ handle: "bob", email: "bob@example.com", password: "pass123", onboardingTrack: "TRACK_A" }),
         credentials: "include",
       })
     );

--- a/src/__tests__/lib/api.test.ts
+++ b/src/__tests__/lib/api.test.ts
@@ -157,6 +157,24 @@ describe("api.drafts.list", () => {
   });
 });
 
+describe("api.analytics.engagementDaily", () => {
+  it("wraps legacy array responses in a days object", async () => {
+    const data = [{ date: "2026-04-09", dayLabel: "Wed", predicted: 12, actual: 9 }];
+    mockFetch(data);
+
+    const result = await api.analytics.engagementDaily();
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_URL}/api/analytics/engagement-daily`,
+      expect.objectContaining({
+        method: "GET",
+        credentials: "include",
+      })
+    );
+    expect(result).toEqual({ days: data });
+  });
+});
+
 describe("api.drafts.generate", () => {
   it("sends the selected reply angle metadata in the request body", async () => {
     mockFetch({ draft: { id: "draft_1" } });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -106,6 +106,8 @@ export interface FeatureFlagRecord {
   updatedAt: string;
 }
 
+export type OnboardingTrack = "TRACK_A" | "TRACK_B";
+
 export class ApiError extends Error {
   statusCode: number;
   constructor(message: string, statusCode: number) {
@@ -224,7 +226,7 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
 // Auth — all requests use HttpOnly cookies (credentials: 'include')
 export const api = {
   auth: {
-    register: (handle: string, email: string, password: string, onboardingTrack?: string) =>
+    register: (handle: string, email: string, password: string, onboardingTrack?: OnboardingTrack) =>
       request<{ user: User; token: string; refresh_token: string }>("/api/auth/register", {
         method: "POST",
         body: { handle, email, password, onboardingTrack },
@@ -616,6 +618,7 @@ export interface User {
   id: string;
   handle: string;
   role: "ANALYST" | "MANAGER" | "ADMIN";
+  onboardingTrack?: OnboardingTrack | null;
   displayName?: string;
   email?: string;
   bio?: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -206,6 +206,10 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
         if (json && typeof json === "object" && "ok" in json && "data" in json) {
           return json.data as T;
         }
+        // The analytics backend still returns a raw array for this legacy endpoint.
+        if (path === "/api/analytics/engagement-daily" && Array.isArray(json)) {
+          return { days: json } as T;
+        }
         return json as T;
       }
     } catch (e) {

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
-import { api, User, VoiceProfile, setAccessToken } from "./api";
+import { api, OnboardingTrack, User, VoiceProfile, setAccessToken } from "./api";
 
 // Session flag cookie — tells the middleware the user has logged in.
 // The real auth token is cross-origin (HttpOnly on the backend domain),
@@ -19,7 +19,7 @@ interface AuthState {
   user: (User & { voiceProfile?: VoiceProfile }) | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
-  register: (handle: string, email: string, password: string, onboardingTrack?: string) => Promise<void>;
+  register: (handle: string, email: string, password: string, onboardingTrack?: OnboardingTrack) => Promise<void>;
   logout: () => void;
 }
 
@@ -71,7 +71,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionCookie(true);
   }, []);
 
-  const register = useCallback(async (handle: string, email: string, password: string, onboardingTrack?: string) => {
+  const register = useCallback(async (handle: string, email: string, password: string, onboardingTrack?: OnboardingTrack) => {
     const res = await api.auth.register(handle, email, password, onboardingTrack);
     if (res.token) {
       setAccessToken(res.token);


### PR DESCRIPTION
## Summary
- align the frontend `onboardingTrack` contract with the backend enum by typing it as `TRACK_A | TRACK_B` and updating the stale register test payload
- restore the Playwright Vercel preview bypass setup, preferring `VERCEL_AUTOMATION_BYPASS_SECRET` with `VERCEL_PROTECTION_BYPASS` as a fallback, and set the bypass cookie header in the configs
- normalize legacy raw-array responses from `/api/analytics/engagement-daily` so the frontend consistently receives `{ days: [...] }`

## Root causes
- the frontend auth layer accepted arbitrary strings for `onboardingTrack`, and the only coverage still asserted the old `"crypto"` value
- the Playwright preview bypass wiring depended on an older env name and was brittle across configs/spec helpers
- the analytics client expected an object envelope while the backend endpoint can still return a bare array

## Validation
- `git diff --check`
- attempted `npm test -- --runTestsByPath src/__tests__/lib/api.test.ts`, but the clean worktree initially had no local `jest` binary available
