### PR TITLE
feat(arena): wire leaderboard to real /api/arena/* endpoints

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -268,6 +268,15 @@ export const test = base.extend<{ authedPage: Page }>({
 
     await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
     await page.waitForURL("**/dashboard");
+
+    // Seed feature flags so off-by-default features (campaigns, telegram_bot) are enabled in tests
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "atlas-feature-flags",
+        JSON.stringify({ campaigns: true, telegram_bot: true }),
+      );
+    });
+
     await use(page);
   },
 });

--- a/src/app/arena/page.tsx
+++ b/src/app/arena/page.tsx
@@ -251,8 +251,7 @@ function ArenaPage() {
           },
           rank: e.rank,
         }));
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        saveSnapshot(shim as any);
+        saveSnapshot(shim as unknown as Parameters<typeof saveSnapshot>[0]);
       }, 3000);
       return () => clearTimeout(timer);
     }

--- a/src/app/arena/page.tsx
+++ b/src/app/arena/page.tsx
@@ -6,30 +6,40 @@ import FeatureGate from "@/components/ui/FeatureGate";
 import GlassCard from "@/components/ui/GlassCard";
 import GradientButton from "@/components/ui/GradientButton";
 import { useAuth } from "@/lib/auth";
-import { api, TeamAnalyst } from "@/lib/api";
-import { rankTeam, RankedAnalyst, TIERS } from "@/lib/atlas-score";
-import { Trophy, TrendingUp, Flame, Minus, Zap, BarChart3, Loader2, AlertTriangle, Send, Volume2, ChevronUp, ChevronDown } from "lucide-react";
-import { getSuperlatives } from "@/lib/arena-superlatives";
-import { saveSnapshot, getPositionChange, isSnapshotStale } from "@/lib/arena-history";
+import {
+  api,
+  ArenaLeaderboardEntry,
+  ArenaMeEntry,
+  ArenaPeriod,
+} from "@/lib/api";
+import {
+  Trophy,
+  TrendingUp,
+  Flame,
+  Minus,
+  Zap,
+  Loader2,
+  AlertTriangle,
+  Send,
+  Volume2,
+  ChevronUp,
+  ChevronDown,
+  Award,
+} from "lucide-react";
+import {
+  saveSnapshot,
+  getPositionChange,
+  isSnapshotStale,
+} from "@/lib/arena-history";
 import { cacheMyTier } from "@/lib/arena-tier-cache";
 
-const SCORE_LABELS: Record<string, string> = {
-  output: "Output",
-  postRate: "Post Rate",
-  engagement: "Engagement",
-  maturity: "Voice",
-  feedback: "Feedback",
-  streak: "Streak",
-};
+type PeriodOption = { value: ArenaPeriod; label: string };
 
-const SCORE_MAX: Record<string, number> = {
-  output: 250,
-  postRate: 200,
-  engagement: 200,
-  maturity: 150,
-  feedback: 100,
-  streak: 100,
-};
+const PERIOD_OPTIONS: PeriodOption[] = [
+  { value: "last_7_days", label: "7d" },
+  { value: "last_30_days", label: "30d" },
+  { value: "all_time", label: "All time" },
+];
 
 function PositionBadge({ rank }: { rank: number }) {
   if (rank === 1)
@@ -57,28 +67,51 @@ function PositionBadge({ rank }: { rank: number }) {
   );
 }
 
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
 function ArenaPage() {
   const { user } = useAuth();
-  const [analysts, setAnalysts] = useState<TeamAnalyst[]>([]);
+  const [period, setPeriod] = useState<ArenaPeriod>("last_30_days");
+  const [entries, setEntries] = useState<ArenaLeaderboardEntry[]>([]);
+  const [me, setMe] = useState<ArenaMeEntry | null>(null);
   const [loading, setLoading] = useState(true);
-  const [selectedAnalyst, setSelectedAnalyst] = useState<RankedAnalyst | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
-  const [actionFeedback, setActionFeedback] = useState<{ message: string; type: "success" | "error" } | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
 
   const isManager = user?.role === "MANAGER" || user?.role === "ADMIN";
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     try {
-      const { analysts: data } = await api.analytics.team();
-      setAnalysts(data);
+      const [leaderboard, meData] = await Promise.all([
+        api.arena.leaderboard(period),
+        api.arena.me(period).catch(() => null),
+      ]);
+      setEntries(leaderboard.entries ?? []);
+      setMe(meData);
     } catch (e) {
-      console.error("Failed to load team:", e);
+      console.error("Failed to load arena:", e);
+      setError(e instanceof Error ? e.message : "Failed to load arena");
+      setEntries([]);
+      setMe(null);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [period]);
 
-  useEffect(() => { loadData(); }, [loadData]);
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   useEffect(() => {
     if (!actionFeedback) return;
@@ -86,22 +119,31 @@ function ArenaPage() {
     return () => clearTimeout(timer);
   }, [actionFeedback]);
 
-  const handleManagerAction = async (action: "pushTopProfiles" | "sendNudge" | "pushStyle") => {
+  const handleManagerAction = async (
+    action: "pushTopProfiles" | "sendNudge" | "pushStyle"
+  ) => {
     if (!user || actionLoading) return;
     const confirmMsg =
-      action === "sendNudge" ? "Send a nudge to all inactive analysts?" :
-      action === "pushStyle" ? "Push this voice style to all analysts?" :
-      "Push top-performing voice profiles to the team?";
+      action === "sendNudge"
+        ? "Send a nudge to all inactive analysts?"
+        : action === "pushStyle"
+          ? "Push this voice style to all analysts?"
+          : "Push top-performing voice profiles to the team?";
     if (!confirm(confirmMsg)) return;
 
     setActionLoading(action);
     setActionFeedback(null);
     try {
       const res =
-        action === "pushTopProfiles" ? await api.users.pushTopProfiles() :
-        action === "sendNudge" ? await api.users.sendNudge() :
-        await api.users.pushStyle();
-      setActionFeedback({ message: res.message || `Done (${res.affected} affected)`, type: "success" });
+        action === "pushTopProfiles"
+          ? await api.users.pushTopProfiles()
+          : action === "sendNudge"
+            ? await api.users.sendNudge()
+            : await api.users.pushStyle();
+      setActionFeedback({
+        message: res.message || `Done (${res.affected} affected)`,
+        type: "success",
+      });
       loadData();
     } catch (e: unknown) {
       setActionFeedback({
@@ -113,28 +155,108 @@ function ArenaPage() {
     }
   };
 
-  const ranked = rankTeam(analysts);
-  const myEntry = ranked.find((r) => r.analyst.id === user?.id);
-  const viewEntry = selectedAnalyst || myEntry;
-  const inactiveAnalysts = ranked.filter(
-    (r) => r.analyst._count.sessions === 0 && r.analyst._count.tweetDrafts === 0
+  // Merge `me` into the displayed list if the backend didn't include it
+  // (e.g. analyst is ranked below the visible top N).
+  const displayEntries: ArenaLeaderboardEntry[] = (() => {
+    if (!me) return entries;
+    const alreadyPresent = entries.some((e) => e.userId === me.userId);
+    if (alreadyPresent) return entries;
+    const meAsEntry: ArenaLeaderboardEntry = {
+      rank: me.rank,
+      userId: me.userId,
+      displayName: me.displayName,
+      avatarUrl: me.avatarUrl ?? null,
+      tweetsPublished: me.tweetsPublished,
+      totalEngagement: me.totalEngagement,
+      consistencyStreak: me.consistencyStreak,
+      badge: me.badge,
+    };
+    return [...entries, meAsEntry].sort((a, b) => a.rank - b.rank);
+  })();
+
+  const myEntry: ArenaLeaderboardEntry | undefined =
+    displayEntries.find((e) => e.userId === user?.id) ??
+    (me
+      ? {
+          rank: me.rank,
+          userId: me.userId,
+          displayName: me.displayName,
+          avatarUrl: me.avatarUrl ?? null,
+          tweetsPublished: me.tweetsPublished,
+          totalEngagement: me.totalEngagement,
+          consistencyStreak: me.consistencyStreak,
+          badge: me.badge,
+        }
+      : undefined);
+
+  const viewEntry: ArenaLeaderboardEntry | undefined = selectedUserId
+    ? displayEntries.find((e) => e.userId === selectedUserId)
+    : myEntry;
+
+  const inactiveEntries = displayEntries.filter(
+    (e) => e.tweetsPublished === 0 && e.totalEngagement === 0
   );
 
-  // Cache user's tier for NavBar badge
+  const totalTweets = displayEntries.reduce(
+    (s, e) => s + e.tweetsPublished,
+    0
+  );
+  const totalEngagement = displayEntries.reduce(
+    (s, e) => s + e.totalEngagement,
+    0
+  );
+  const avgEngagement =
+    displayEntries.length > 0
+      ? Math.round(totalEngagement / displayEntries.length)
+      : 0;
+
+  // Cache user's rank for NavBar badge (reuses the existing tier cache surface).
   useEffect(() => {
     if (myEntry) {
-      cacheMyTier(myEntry.tier.name, myEntry.score.total, myEntry.rank);
+      const label = myEntry.badge ?? `Rank #${myEntry.rank}`;
+      cacheMyTier(label, myEntry.totalEngagement, myEntry.rank);
     }
   }, [myEntry]);
 
-  // Save snapshot for position tracking (refresh every 6 hours)
+  // Save snapshot for position tracking (refresh every 6 hours).
+  // arena-history stores by analyst.id; we pass a shim shape with userId→id.
   useEffect(() => {
-    if (ranked.length > 0 && isSnapshotStale()) {
-      // Delay save so we can show changes from previous snapshot first
-      const timer = setTimeout(() => saveSnapshot(ranked), 3000);
+    if (displayEntries.length > 0 && isSnapshotStale()) {
+      const timer = setTimeout(() => {
+        const shim = displayEntries.map((e) => ({
+          analyst: {
+            id: e.userId,
+            handle: e.displayName,
+            _count: {
+              tweetDrafts: e.tweetsPublished,
+              analyticsEvents: e.totalEngagement,
+              sessions: e.consistencyStreak,
+            },
+          },
+          score: {
+            output: 0,
+            postRate: 0,
+            engagement: e.totalEngagement,
+            maturity: 0,
+            feedback: 0,
+            streak: e.consistencyStreak,
+            total: e.totalEngagement,
+          },
+          tier: {
+            name: "Analyst" as const,
+            min: 0,
+            color: "",
+            bgColor: "",
+            borderColor: "",
+          },
+          rank: e.rank,
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        saveSnapshot(shim as any);
+      }, 3000);
       return () => clearTimeout(timer);
     }
-  }, [ranked]);
+  }, [displayEntries]);
 
   return (
     <AppShell>
@@ -146,18 +268,50 @@ function ArenaPage() {
             <h1 className="font-heading font-extrabold tracking-tight text-2xl text-atlas-text">
               Atlas Arena
             </h1>
-          <p className="mt-2 text-atlas-text-secondary max-w-2xl">See how your content stacks up. The leaderboard ranks analysts by engagement, consistency, and voice maturity — friendly competition to sharpen everyone&#39;s edge.</p>
+            <p className="mt-2 text-atlas-text-secondary max-w-2xl">
+              See how your content stacks up. The leaderboard ranks analysts by
+              tweets published, engagement, and consistency — friendly
+              competition to sharpen everyone&#39;s edge.
+            </p>
           </div>
           {myEntry && (
             <div className="flex items-center gap-2">
-              <span className={`text-sm font-semibold ${myEntry.tier.color}`}>
-                {myEntry.tier.name}
-              </span>
+              {myEntry.badge && (
+                <span className="text-sm font-semibold text-yellow-400">
+                  {myEntry.badge}
+                </span>
+              )}
               <span className="text-2xl font-bold text-atlas-text">
-                {myEntry.score.total}
+                #{myEntry.rank}
               </span>
             </div>
           )}
+        </div>
+
+        {/* Period Toggle */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-atlas-text-muted uppercase tracking-wide">
+            Period
+          </span>
+          <div className="inline-flex rounded-lg border border-glass-border bg-atlas-surface/40 p-1">
+            {PERIOD_OPTIONS.map((opt) => {
+              const active = period === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setPeriod(opt.value)}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
+                    active
+                      ? "bg-atlas-teal/20 text-atlas-teal"
+                      : "text-atlas-text-secondary hover:text-atlas-text"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         {/* Hero KPI Cards */}
@@ -165,12 +319,12 @@ function ArenaPage() {
           <div className="grid grid-cols-3 gap-4">
             <GlassCard className="text-center">
               <p className="text-xs text-atlas-text-secondary uppercase tracking-wide">
-                Output
+                Tweets Published
               </p>
               <p className="text-3xl font-bold text-atlas-text mt-1">
-                {myEntry.analyst._count.tweetDrafts}
+                {myEntry.tweetsPublished}
               </p>
-              <p className="text-xs text-atlas-text-muted">drafts</p>
+              <p className="text-xs text-atlas-text-muted">this period</p>
             </GlassCard>
             <GlassCard className="text-center">
               <TrendingUp className="h-4 w-4 text-atlas-teal mx-auto mb-1" />
@@ -178,9 +332,9 @@ function ArenaPage() {
                 Engagement
               </p>
               <p className="text-3xl font-bold text-atlas-teal mt-1">
-                {myEntry.score.engagement}
+                {formatNumber(myEntry.totalEngagement)}
               </p>
-              <p className="text-xs text-atlas-text-muted">/ 200</p>
+              <p className="text-xs text-atlas-text-muted">total</p>
             </GlassCard>
             <GlassCard className="text-center">
               <Flame className="h-4 w-4 text-orange-400 mx-auto mb-1" />
@@ -188,47 +342,19 @@ function ArenaPage() {
                 Streak
               </p>
               <p className="text-3xl font-bold text-orange-400 mt-1">
-                {Math.round(myEntry.score.streak / 5)}d
+                {myEntry.consistencyStreak}d
               </p>
               <p className="text-xs text-atlas-text-muted">active</p>
             </GlassCard>
           </div>
         )}
 
-        {/* Superlatives */}
-        {ranked.length > 0 && (() => {
-          const superlatives = getSuperlatives(ranked);
-          const ICONS = {
-            climb: TrendingUp,
-            streak: Flame,
-            engage: BarChart3,
-            output: Zap,
-          };
-          return superlatives.length > 0 ? (
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-              {superlatives.map((s) => {
-                const Icon = ICONS[s.icon];
-                return (
-                  <div
-                    key={s.label}
-                    className="flex items-center gap-3 rounded-2xl border border-glass-border bg-glass px-4 py-3"
-                  >
-                    <Icon className="h-4 w-4 text-atlas-teal shrink-0" />
-                    <div className="min-w-0">
-                      <p className="text-xs text-atlas-text-muted">{s.label}</p>
-                      <p className="text-sm text-atlas-text font-medium truncate">
-                        @{s.handle}{" "}
-                        <span className="text-atlas-text-secondary font-normal">
-                          — {s.value}
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : null;
-        })()}
+        {/* Error banner */}
+        {error && !loading && (
+          <div className="rounded-xl border border-atlas-error/30 bg-atlas-error/10 px-4 py-3 text-sm text-atlas-error">
+            {error}
+          </div>
+        )}
 
         <div className="grid gap-6 lg:grid-cols-[1fr_340px]">
           {/* Leaderboard */}
@@ -246,16 +372,29 @@ function ArenaPage() {
                   />
                 ))}
               </div>
+            ) : displayEntries.length === 0 ? (
+              <div className="rounded-xl border border-glass-border bg-atlas-surface/40 px-4 py-8 text-center text-sm text-atlas-text-secondary">
+                No arena data yet for this period.
+              </div>
             ) : (
               <div className="space-y-2">
-                {ranked.map((entry) => {
-                  const isMe = entry.analyst.id === user?.id;
-                  const isSelected = viewEntry?.analyst.id === entry.analyst.id;
+                {displayEntries.map((entry) => {
+                  const isMe = entry.userId === user?.id;
+                  const isSelected = viewEntry?.userId === entry.userId;
+                  // Normalized engagement bar: relative to top entry.
+                  const topEngagement = Math.max(
+                    ...displayEntries.map((e) => e.totalEngagement),
+                    1
+                  );
+                  const pct =
+                    topEngagement > 0
+                      ? (entry.totalEngagement / topEngagement) * 100
+                      : 0;
                   return (
                     <button
-                      key={entry.analyst.id}
+                      key={entry.userId}
                       type="button"
-                      onClick={() => setSelectedAnalyst(entry)}
+                      onClick={() => setSelectedUserId(entry.userId)}
                       className={`w-full flex items-center gap-3 rounded-xl px-4 py-3 text-left transition-all ${
                         isMe
                           ? "bg-atlas-teal/5 border border-atlas-teal/20"
@@ -267,45 +406,61 @@ function ArenaPage() {
                       <PositionBadge rank={entry.rank} />
 
                       <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-wrap">
                           <span
-                            className={`text-sm font-medium ${isMe ? "text-atlas-teal" : "text-atlas-text"}`}
+                            className={`text-sm font-medium ${
+                              isMe ? "text-atlas-teal" : "text-atlas-text"
+                            }`}
                           >
-                            @{entry.analyst.handle}
+                            {entry.displayName}
                             {isMe && (
                               <span className="text-xs text-atlas-text-muted ml-1">
                                 (you)
                               </span>
                             )}
                           </span>
-                          <span
-                            className={`text-xs px-2 py-0.5 rounded-full ${entry.tier.bgColor} ${entry.tier.color}`}
-                          >
-                            {entry.tier.name}
+                          {entry.badge && (
+                            <span className="text-[10px] px-2 py-0.5 rounded-full bg-yellow-400/10 text-yellow-400 font-medium">
+                              {entry.badge}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3 mt-0.5 text-xs text-atlas-text-muted">
+                          <span>{entry.tweetsPublished} tweets</span>
+                          <span>·</span>
+                          <span>
+                            {formatNumber(entry.totalEngagement)} engagement
                           </span>
+                          {entry.consistencyStreak > 0 && (
+                            <>
+                              <span>·</span>
+                              <span>{entry.consistencyStreak}d streak</span>
+                            </>
+                          )}
                         </div>
                       </div>
 
-                      {/* Score bar */}
+                      {/* Engagement bar */}
                       <div className="w-24 hidden sm:block">
                         <div className="h-1.5 rounded-full bg-atlas-surface overflow-hidden">
                           <div
                             className="h-full rounded-full bg-gradient-to-r from-atlas-teal to-atlas-teal/40 transition-all"
-                            style={{
-                              width: `${(entry.score.total / 1000) * 100}%`,
-                            }}
+                            style={{ width: `${pct}%` }}
                           />
                         </div>
                       </div>
 
-                      <span className="text-sm font-bold text-atlas-text w-12 text-right">
-                        {entry.score.total}
+                      <span className="text-sm font-bold text-atlas-text w-14 text-right">
+                        {formatNumber(entry.totalEngagement)}
                       </span>
 
                       {/* Position change from last snapshot */}
                       <span className="w-6 text-center">
                         {(() => {
-                          const change = getPositionChange(entry.analyst.id, entry.rank);
+                          const change = getPositionChange(
+                            entry.userId,
+                            entry.rank
+                          );
                           if (change > 0)
                             return (
                               <span className="flex items-center justify-center text-atlas-success text-xs font-medium">
@@ -320,7 +475,9 @@ function ArenaPage() {
                                 {Math.abs(change)}
                               </span>
                             );
-                          return <Minus className="h-3 w-3 text-atlas-text-muted mx-auto" />;
+                          return (
+                            <Minus className="h-3 w-3 text-atlas-text-muted mx-auto" />
+                          );
                         })()}
                       </span>
                     </button>
@@ -330,53 +487,71 @@ function ArenaPage() {
             )}
           </GlassCard>
 
-          {/* Sidebar: Score Breakdown + Team Stats */}
+          {/* Sidebar: Selected Entry Breakdown + Team Stats */}
           <div className="space-y-6">
-            {/* Score Breakdown */}
+            {/* Entry Breakdown */}
             {viewEntry && (
               <GlassCard maxWidth="full" data-tour="arena-your-rank">
                 <h3 className="font-heading font-bold text-sm text-atlas-text mb-1">
-                  {viewEntry.analyst.id === user?.id
-                    ? "Your Breakdown"
-                    : `@${viewEntry.analyst.handle}`}
+                  {viewEntry.userId === user?.id
+                    ? "Your Stats"
+                    : viewEntry.displayName}
                 </h3>
                 <p className="text-xs text-atlas-text-muted mb-4">
-                  Score:{" "}
+                  Rank{" "}
                   <span className="text-atlas-text font-bold">
-                    {viewEntry.score.total}
-                  </span>{" "}
-                  / 1000
+                    #{viewEntry.rank}
+                  </span>
+                  {viewEntry.badge && (
+                    <>
+                      {" "}
+                      ·{" "}
+                      <span className="text-yellow-400 font-medium">
+                        {viewEntry.badge}
+                      </span>
+                    </>
+                  )}
                 </p>
 
                 <div className="space-y-3">
-                  {(
-                    Object.keys(SCORE_LABELS) as Array<
-                      keyof typeof SCORE_LABELS
-                    >
-                  ).map((key) => {
-                    const value =
-                      viewEntry.score[key as keyof typeof viewEntry.score];
-                    const max = SCORE_MAX[key];
-                    const pct = typeof value === "number" ? (value / max) * 100 : 0;
-                    return (
-                      <div key={key}>
-                        <div className="flex items-center justify-between text-xs mb-1">
-                          <span className="text-atlas-text-secondary">
-                            {SCORE_LABELS[key]}
-                          </span>
-                          <span className="text-atlas-text">
-                            {typeof value === "number" ? value : 0} / {max}
-                          </span>
-                        </div>
-                        <div className="h-1.5 rounded-full bg-atlas-surface overflow-hidden">
-                          <div
-                            className="h-full rounded-full bg-atlas-teal transition-all"
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 text-atlas-text-secondary">
+                      <Zap className="h-3 w-3" />
+                      Tweets published
+                    </span>
+                    <span className="text-atlas-text font-medium">
+                      {viewEntry.tweetsPublished}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 text-atlas-text-secondary">
+                      <TrendingUp className="h-3 w-3" />
+                      Total engagement
+                    </span>
+                    <span className="text-atlas-text font-medium">
+                      {formatNumber(viewEntry.totalEngagement)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 text-atlas-text-secondary">
+                      <Flame className="h-3 w-3" />
+                      Consistency streak
+                    </span>
+                    <span className="text-atlas-text font-medium">
+                      {viewEntry.consistencyStreak}d
+                    </span>
+                  </div>
+                  {viewEntry.badge && (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center gap-2 text-atlas-text-secondary">
+                        <Award className="h-3 w-3" />
+                        Badge
+                      </span>
+                      <span className="text-yellow-400 font-medium">
+                        {viewEntry.badge}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </GlassCard>
             )}
@@ -392,62 +567,36 @@ function ArenaPage() {
                     Total analysts
                   </span>
                   <span className="text-atlas-text font-medium">
-                    {ranked.length}
+                    {displayEntries.length}
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-atlas-text-secondary">
-                    Active (with drafts)
+                    Active (with tweets)
                   </span>
                   <span className="text-atlas-text font-medium">
-                    {ranked.filter((r) => r.analyst._count.tweetDrafts > 0).length}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-atlas-text-secondary">Avg score</span>
-                  <span className="text-atlas-text font-medium">
-                    {ranked.length > 0
-                      ? Math.round(
-                          ranked.reduce((s, r) => s + r.score.total, 0) /
-                            ranked.length
-                        )
-                      : 0}
+                    {
+                      displayEntries.filter((e) => e.tweetsPublished > 0)
+                        .length
+                    }
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-atlas-text-secondary">
-                    Total drafts
+                    Avg engagement
                   </span>
                   <span className="text-atlas-text font-medium">
-                    {ranked.reduce(
-                      (s, r) => s + r.analyst._count.tweetDrafts,
-                      0
-                    )}
+                    {formatNumber(avgEngagement)}
                   </span>
                 </div>
-              </div>
-
-              {/* Tier Distribution */}
-              <div className="mt-4 pt-4 border-t border-glass-border">
-                <p className="text-xs text-atlas-text-muted uppercase tracking-wide mb-2">
-                  Tier distribution
-                </p>
-                {TIERS.map((tier) => {
-                  const count = ranked.filter(
-                    (r) => r.tier.name === tier.name
-                  ).length;
-                  return (
-                    <div
-                      key={tier.name}
-                      className="flex items-center justify-between text-xs py-1"
-                    >
-                      <span className={tier.color}>{tier.name}</span>
-                      <span className="text-atlas-text-secondary">
-                        {count}
-                      </span>
-                    </div>
-                  );
-                })}
+                <div className="flex justify-between">
+                  <span className="text-atlas-text-secondary">
+                    Total tweets
+                  </span>
+                  <span className="text-atlas-text font-medium">
+                    {totalTweets}
+                  </span>
+                </div>
               </div>
             </GlassCard>
 
@@ -527,25 +676,25 @@ function ArenaPage() {
                 </div>
 
                 {/* Inactive Analysts */}
-                {inactiveAnalysts.length > 0 && (
+                {inactiveEntries.length > 0 && (
                   <div className="mt-4 pt-4 border-t border-glass-border">
                     <div className="flex items-center gap-1.5 mb-2">
                       <AlertTriangle className="h-3 w-3 text-atlas-warning" />
                       <p className="text-xs text-atlas-warning font-medium">
-                        Inactive ({inactiveAnalysts.length})
+                        Inactive ({inactiveEntries.length})
                       </p>
                     </div>
                     <div className="space-y-1.5">
-                      {inactiveAnalysts.slice(0, 5).map((entry) => (
+                      {inactiveEntries.slice(0, 5).map((entry) => (
                         <div
-                          key={entry.analyst.id}
+                          key={entry.userId}
                           className="flex items-center justify-between text-xs"
                         >
                           <span className="text-atlas-text-secondary truncate">
-                            @{entry.analyst.handle}
+                            {entry.displayName}
                           </span>
                           <span className="text-atlas-text-muted shrink-0">
-                            {entry.tier.name}
+                            #{entry.rank}
                           </span>
                         </div>
                       ))}

--- a/src/components/onboarding/BlendRatioSlider.tsx
+++ b/src/components/onboarding/BlendRatioSlider.tsx
@@ -1,26 +1,77 @@
 "use client";
 
+import { useState } from "react";
 import DimensionBar from "@/components/ui/DimensionBar";
+
+export interface BlendReference {
+  name: string;
+  handle?: string;
+}
 
 export interface BlendRatioSliderProps {
   selfPercentage: number;
   onChange: (self: number) => void;
-  referenceNames: string[];
+  /**
+   * Preferred: reference voices with optional X handles for avatar rendering.
+   */
+  references?: BlendReference[];
+  /**
+   * Back-compat: plain name list. Used when `references` is not supplied.
+   */
+  referenceNames?: string[];
+  /**
+   * Optional callback invoked when individual reference weights change.
+   * Weights are normalized so they sum to 100 (share of the reference portion).
+   */
+  onReferenceWeightsChange?: (weights: number[]) => void;
 }
 
 export default function BlendRatioSlider({
   selfPercentage,
   onChange,
+  references,
   referenceNames,
+  onReferenceWeightsChange,
 }: BlendRatioSliderProps) {
+  const refs: BlendReference[] =
+    references && references.length > 0
+      ? references
+      : (referenceNames ?? []).map((name) => ({ name }));
+
   const refPercentage = 100 - selfPercentage;
-  const perRefPercentage =
-    referenceNames.length > 0
-      ? Math.round(refPercentage / referenceNames.length)
-      : 0;
+
+  // Local weights (share of the reference portion). Default: equal split.
+  const [weights, setWeights] = useState<number[]>(() =>
+    refs.length > 0 ? refs.map(() => 100 / refs.length) : []
+  );
+
+  // Re-sync if the reference list changes length (selection edited upstream).
+  if (weights.length !== refs.length) {
+    const next =
+      refs.length > 0 ? refs.map(() => 100 / refs.length) : [];
+    // Defer to effect-like semantics without useEffect; safe because we
+    // only mutate when lengths diverge.
+    queueMicrotask(() => setWeights(next));
+  }
+
+  const handleWeightChange = (index: number, value: number) => {
+    if (refs.length <= 1) return;
+    const clamped = Math.min(100, Math.max(0, value));
+    const others = weights
+      .map((w, i) => (i === index ? 0 : w))
+      .reduce((a, b) => a + b, 0);
+    const remaining = 100 - clamped;
+    const next = weights.map((w, i) => {
+      if (i === index) return clamped;
+      if (others === 0) return remaining / (refs.length - 1);
+      return (w / others) * remaining;
+    });
+    setWeights(next);
+    onReferenceWeightsChange?.(next);
+  };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="text-center space-y-2">
         <h2 className="font-heading font-bold text-xl text-atlas-text">
           Set your blend ratio
@@ -32,47 +83,133 @@ export default function BlendRatioSlider({
       </div>
 
       <div className="bg-atlas-surface rounded-2xl p-6 space-y-4">
-        {/* Main slider */}
+        {/* Master slider: my voice vs. references */}
         <DimensionBar
-          label="My voice"
+          label="My voice vs. References"
           percentage={selfPercentage}
           interactive
           onChange={(v) => onChange(Math.round(v))}
           step={5}
-          valueLabel={`${selfPercentage}%`}
+          valueLabel={`${selfPercentage}% me`}
         />
-
-        {/* Visual split indicator */}
-        <div className="flex items-center justify-between text-xs text-atlas-text-muted pt-2">
+        <div className="flex items-center justify-between text-xs text-atlas-text-muted">
           <span>More me</span>
           <span>More references</span>
         </div>
       </div>
 
       {/* Breakdown */}
-      {referenceNames.length > 0 && (
-        <div className="bg-atlas-surface/50 rounded-2xl p-4 space-y-2">
-          <p className="text-xs text-atlas-text-muted uppercase tracking-wide mb-3">
-            Blend breakdown
-          </p>
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-atlas-text">My voice</span>
-            <span className="text-atlas-teal font-semibold">
-              {selfPercentage}%
-            </span>
+      {refs.length > 0 && (
+        <div className="bg-atlas-surface/50 rounded-2xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-atlas-text-muted uppercase tracking-wide">
+              Blend breakdown
+            </p>
+            <p className="text-xs text-atlas-text-muted">
+              References share {refPercentage}%
+            </p>
           </div>
-          {referenceNames.map((name) => (
-            <div key={name} className="flex items-center justify-between text-sm">
-              <span className="text-atlas-text-secondary truncate mr-2">
-                {name}
-              </span>
-              <span className="text-atlas-text-secondary shrink-0">
-                {perRefPercentage}%
+
+          {/* My voice row */}
+          <div className="flex items-center gap-3">
+            <div className="h-8 w-8 shrink-0 rounded-full bg-atlas-teal/20 border border-atlas-teal/40 flex items-center justify-center">
+              <span className="text-[10px] font-semibold text-atlas-teal">
+                ME
               </span>
             </div>
-          ))}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between text-sm mb-1">
+                <span className="text-atlas-text truncate">My voice</span>
+                <span className="text-atlas-teal font-semibold shrink-0 ml-2">
+                  {selfPercentage}%
+                </span>
+              </div>
+              <div className="h-1.5 w-full rounded-full bg-atlas-text-secondary/20 overflow-hidden">
+                <div
+                  className="h-full bg-atlas-teal transition-all duration-300"
+                  style={{ width: `${selfPercentage}%` }}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Reference voice rows */}
+          {refs.map((ref, i) => {
+            const share = weights[i] ?? 0;
+            // Effective portion of total voice
+            const effective = Math.round((share / 100) * refPercentage);
+            const interactive = refs.length > 1;
+            return (
+              <div key={`${ref.name}-${i}`} className="flex items-center gap-3">
+                <RefAvatar handle={ref.handle} name={ref.name} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between text-sm mb-1">
+                    <span className="text-atlas-text-secondary truncate">
+                      {ref.name}
+                    </span>
+                    <span className="text-atlas-text-secondary shrink-0 ml-2 tabular-nums">
+                      {effective}%
+                    </span>
+                  </div>
+                  {interactive ? (
+                    <div className="relative h-1.5 w-full rounded-full bg-atlas-text-secondary/20 overflow-hidden">
+                      <div
+                        className="pointer-events-none absolute inset-y-0 left-0 bg-atlas-teal/70 transition-all duration-200"
+                        style={{ width: `${Math.round(share)}%` }}
+                      />
+                      <input
+                        type="range"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={Math.round(share)}
+                        onChange={(e) =>
+                          handleWeightChange(i, Number(e.target.value))
+                        }
+                        aria-label={`${ref.name} share`}
+                        className="absolute inset-0 w-full h-full cursor-pointer opacity-0"
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-1.5 w-full rounded-full bg-atlas-text-secondary/20 overflow-hidden">
+                      <div
+                        className="h-full bg-atlas-teal/70 transition-all duration-300"
+                        style={{ width: `${Math.round(share)}%` }}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
+  );
+}
+
+function RefAvatar({ handle, name }: { handle?: string; name: string }) {
+  const [errored, setErrored] = useState(false);
+  const initial = (name || "?").trim().charAt(0).toUpperCase();
+
+  if (!handle || errored) {
+    return (
+      <div className="h-8 w-8 shrink-0 rounded-full bg-atlas-surface border border-atlas-text-secondary/20 flex items-center justify-center">
+        <span className="text-[10px] font-semibold text-atlas-text-secondary">
+          {initial}
+        </span>
+      </div>
+    );
+  }
+
+  const cleanHandle = handle.replace(/^@/, "");
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`https://unavatar.io/twitter/${cleanHandle}`}
+      alt={name}
+      onError={() => setErrored(true)}
+      className="h-8 w-8 shrink-0 rounded-full object-cover border border-atlas-text-secondary/20 bg-atlas-surface"
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Replaces local atlas-score computation with live `/api/arena/leaderboard` + `/api/arena/me` backend calls
- Adds period selector (last 7 days / 30 days / all time)
- Adds Arena types to `api.ts`: `ArenaPeriod`, `ArenaLeaderboardEntry`, `ArenaMeEntry`, `ArenaLeaderboardData`
- Improves `BlendRatioSlider`: `BlendReference` interface + per-reference weight callbacks (back-compat)

## Test plan
- [ ] Arena page loads leaderboard from `/api/arena/leaderboard?period=last_30_days`
- [ ] Period toggle updates data
- [ ] "Your rank" card calls `/api/arena/me`
- [ ] 401 → redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)