### PR TITLE
fix(onboarding): remove tweet ratings + topics steps, fix calibration error, fix voice lab scroll

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -289,7 +289,7 @@ export default function VoiceProfilesPage() {
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 xl:px-8">
+      <div>
         {error && (
           <div
             role="alert"
@@ -483,7 +483,7 @@ export default function VoiceProfilesPage() {
           </button>
         </section>
 
-        <div className="mt-10" data-tour="reference-voices">
+        <div className="mt-10 pb-24" data-tour="reference-voices">
           <ReferenceVoicesSection
             references={references}
             onReferencesChange={setReferences}

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -363,8 +363,21 @@ export default function OracleChat() {
         }).catch(() => { /* LLM is optional */ });
       } catch (err) {
         console.error("Calibration failed:", err);
-        // Still advance so user isn't stuck
-        dispatch({ type: "ADVANCE", payload: "Calibration unavailable" });
+        // Surface a friendly Oracle message, then silently advance so the
+        // user isn't stuck and doesn't see a raw error echoed as their reply.
+        dispatch({
+          type: "ENQUEUE_MESSAGES",
+          messages: [
+            {
+              id: `calibration-skip-${Date.now()}`,
+              role: "oracle" as const,
+              content:
+                "I couldn't scan your tweets right now — no worries, we can calibrate later. Let's keep going.",
+              timestamp: Date.now(),
+            },
+          ],
+        });
+        dispatch({ type: "ADVANCE", payload: undefined });
       } finally {
         calibratingRef.current = false;
       }
@@ -650,12 +663,10 @@ export default function OracleChat() {
     // Steps that need a Continue button
     const continueSteps = [
       "TRACK_A_RESULT",
-      "TRACK_A_RATE",
       "TRACK_B_STYLE",
       "TRACK_B_DIMENSIONS",
       "REFERENCES",
       "BLEND",
-      "TOPICS",
     ];
 
     if (continueSteps.includes(step)) {
@@ -692,7 +703,7 @@ export default function OracleChat() {
       </div>
 
       {/* Message list */}
-      <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 space-y-4">
         {state.messages.map((msg, i) => (
           <OracleMessage
             key={msg.id}

--- a/src/lib/oracle.ts
+++ b/src/lib/oracle.ts
@@ -7,14 +7,14 @@ const NEXT_STEP: Record<OracleStep, OracleStep | null> = {
   WELCOME: null, // determined by track selection
   CONNECT_X: "TRACK_A_SCANNING",
   TRACK_A_SCANNING: "TRACK_A_RESULT",
-  TRACK_A_RESULT: "TRACK_A_RATE",
-  TRACK_A_RATE: "REFERENCES",
+  TRACK_A_RESULT: "REFERENCES",
+  TRACK_A_RATE: "REFERENCES", // legacy fallback, step skipped in flow
   TRACK_B_STYLE: "TRACK_B_CONTENT",
   TRACK_B_CONTENT: "TRACK_B_DIMENSIONS",
   TRACK_B_DIMENSIONS: "REFERENCES",
   REFERENCES: "BLEND",
-  BLEND: "TOPICS",
-  TOPICS: "HANDOFF",
+  BLEND: "HANDOFF",
+  TOPICS: "HANDOFF", // legacy fallback, step skipped in flow
   HANDOFF: null, // terminal
 };
 
@@ -42,7 +42,7 @@ export function canAdvance(state: OracleState): boolean {
     case "BLEND":
       return true;
     case "TOPICS":
-      return state.selectedTopics.length >= 1;
+      return true; // step skipped in flow, kept for type exhaustiveness
     case "HANDOFF":
       return false; // terminal
   }


### PR DESCRIPTION
## Summary
Addresses Anil's onboarding feedback:

- **Calibration error** — Replaced "Calibration unavailable" echoed as a user reply with a friendly Oracle message ("I couldn't scan your tweets right now — no worries, we can calibrate later") and a silent ADVANCE (no user echo).
- **Removed TRACK_A_RATE** — After calibration, flow now goes TRACK_A_RESULT -> REFERENCES directly. The hardcoded stale crypto tweet thumbs up/down step is skipped. Anil: "I don't think it should do this part of the flow, honestly."
- **Removed TOPICS** — After BLEND, flow now goes BLEND -> HANDOFF directly. Content signals / arena alerts step is skipped. Anil: "I don't think it should do this yet either. Like, there should just be a crafting station right now."
- **Voice Lab scroll fix** — Removed redundant `mx-auto max-w-7xl px-4 py-8 sm:px-6 xl:px-8` wrapper on voice-profiles page (AppShell already provides centering and max-width). Added `pb-24` to the ReferenceVoicesSection wrapper so the fixed FloatingOracle doesn't overlap bottom content. Added `pb-8` to the OracleChat message scroll area so bottom content isn't clipped.

The TRACK_A_RATE and TOPICS cases are left in `NEXT_STEP` / `canAdvance` / `OracleStep` union as legacy fallbacks for type exhaustiveness — they're just unreachable in the flow now.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally, exit 0)
- [ ] Onboarding Track A: calibration error path shows friendly Oracle message, does not echo "Calibration unavailable" as user reply
- [ ] Onboarding Track A: after calibration result, Continue goes straight to References (no thumbs up/down step)
- [ ] Onboarding Track B: after BLEND, Continue goes straight to Handoff (no topics step)
- [ ] Voice Lab page: ReferenceVoicesSection is fully scrollable, not clipped by FloatingOracle
- [ ] Onboarding chat bottom messages are not clipped by ActionZone

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>