### PR TITLE
feat: Voice Lab + Tweet Tinder + DM-322 through DM-325 batch

### DIFF
--- a/src/__tests__/app/VoiceProfilesPage.test.tsx
+++ b/src/__tests__/app/VoiceProfilesPage.test.tsx
@@ -73,6 +73,11 @@ jest.mock("@/components/layout/AppShell", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
+jest.mock("@/app/voice-profiles/tweet-tinder-section", () => ({
+  __esModule: true,
+  default: () => <div>Tweet Tinder Section</div>,
+}));
+
 jest.mock("@/components/voice-profiles/ReferenceVoicesSection", () => ({
   __esModule: true,
   default: ({

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Sparkles, Wand2 } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
+import TweetTinderSection from "./tweet-tinder-section";
 import ReferenceVoicesSection from "@/components/voice-profiles/ReferenceVoicesSection";
 import RecipeCard from "@/components/voice-profiles/RecipeCard";
 import VoiceCard from "@/components/voice-profiles/VoiceCard";
@@ -481,6 +482,11 @@ export default function VoiceProfilesPage() {
             setEditorBlendId(null);
           }}
         />
+
+        {/* Tweet Tinder — voice calibration via liked tweets */}
+        <div className="mt-8">
+          <TweetTinderSection />
+        </div>
       </div>
     </AppShell>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -659,6 +659,7 @@ export const api = {
   },
 
 
+
   campaigns: {
     list: () =>
       request<{ campaigns: Campaign[] }>("/api/campaigns"),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -153,6 +153,7 @@ export interface FeatureFlagRecord {
 
 export type OnboardingTrack = "TRACK_A" | "TRACK_B";
 
+
 export class ApiError extends Error {
   statusCode: number;
   constructor(message: string, statusCode: number) {
@@ -753,10 +754,64 @@ export interface BlendVoice {
   referenceVoice?: ReferenceVoice | null;
 }
 
+
 export interface SavedBlend {
   id: string;
   name: string;
   voices: BlendVoice[];
+}
+
+export interface BlendedVoiceDimensions {
+  humor: number;
+  formality: number;
+  brevity: number;
+  contrarianTone: number;
+  directness: number;
+  warmth: number;
+  technicalDepth: number;
+  confidence: number;
+  evidenceOrientation: number;
+  solutionOrientation: number;
+  socialPosture: number;
+  selfPromotionalIntensity: number;
+}
+
+export interface BlendedVoiceProfile {
+  id: string;
+  primaryTwitterId: string;
+  primaryHandle: string | null;
+  additionalTwitterIds: string[];
+  additionalHandles: string[];
+  weights: Record<string, number>;
+  dimensions: BlendedVoiceDimensions;
+  styleSignals?: Record<string, unknown> | null;
+  tweetsAnalyzed: number;
+  blendSummary?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BlendedVoiceInspiration {
+  twitterId: string;
+  handle: string;
+  name: string;
+  tweetCount: number;
+  weight: number;
+}
+
+export interface VoiceBlendResponse {
+  blendedProfile: {
+    id: string;
+    primaryTwitterId: string;
+    additionalTwitterIds: string[];
+    weights: Record<string, number>;
+    tweetsAnalyzed: number;
+    blendSummary?: string | null;
+  };
+  inspirations: BlendedVoiceInspiration[];
+  dimensions: BlendedVoiceDimensions;
+  styleSignals?: Record<string, unknown> | null;
+  summary: string;
 }
 
 export interface BlendedVoiceDimensions {


### PR DESCRIPTION
## Summary
- **DM-322**: Atlas UI simplification + Voice Lab cleanup
- **DM-323**: Twitter follow inspiration picker + Tweet Tinder swipe UX
- **DM-324**: Auto-populate profile from Twitter
- **DM-325**: Inline per-tweet refinement chips
- Discovery hitboxes, design token migration, E2E fixes

## Test plan
- [ ] Voice Lab: Twitter follow picker renders
- [ ] Tweet Tinder: swipe UX on calibration
- [ ] Profile: auto-populates from X after OAuth
- [ ] Crafting: refinement chips appear inline
- [ ] No regression on crafting/dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)