### PR TITLE
feat(queue): add Queue API types and client methods

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,39 @@ interface BriefingPreferenceInput {
   channel: string;
 }
 
+export type QueuePlatform = "twitter";
+export type QueueStatus = "queued" | "scheduled" | "published" | "failed";
+
+export interface QueueItem {
+  id: string;
+  content: string;
+  platform: QueuePlatform;
+  status: QueueStatus;
+  scheduledAt: string | null;
+  publishedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  failureReason?: string | null;
+}
+
+export interface QueueListResponse {
+  items: QueueItem[];
+  total: number;
+}
+
+export interface QueueCreateInput {
+  content: string;
+  platform?: QueuePlatform;
+  scheduledAt?: string | null;
+}
+
+export interface QueueUpdateInput {
+  content?: string;
+  scheduledAt?: string | null;
+  status?: QueueStatus;
+  failureReason?: string | null;
+}
+
 export interface QaTestRun {
   id: string;
   project: string;
@@ -279,6 +312,31 @@ export const api = {
       request<{ reordered: number }>("/api/drafts/queue/reorder", { method: "PATCH", body: { orderedIds } }),
     resetQueueOrder: () =>
       request<{ reset: boolean }>("/api/drafts/queue/reset-order", { method: "POST" }),
+  },
+
+  queue: {
+    list: (status?: QueueStatus) =>
+      request<QueueListResponse | QueueItem[]>(
+        `/api/queue${status ? `?status=${status}` : ""}`
+      ),
+    create: (data: QueueCreateInput) =>
+      request<{ item: QueueItem } | QueueItem>("/api/queue", {
+        method: "POST",
+        body: data,
+      }),
+    update: (id: string, data: QueueUpdateInput) =>
+      request<{ item: QueueItem } | QueueItem>(`/api/queue/${id}`, {
+        method: "PATCH",
+        body: data,
+      }),
+    remove: (id: string) =>
+      request<{ success: boolean }>(`/api/queue/${id}`, {
+        method: "DELETE",
+      }),
+    publish: (id: string) =>
+      request<{ item: QueueItem } | QueueItem>(`/api/queue/${id}/publish`, {
+        method: "POST",
+      }),
   },
 
   analytics: {


### PR DESCRIPTION
## Summary
- Adds standalone `api.queue` namespace and TypeScript types for the Draft Queue v1.1 flagship feature
- New contract at `/api/queue` (separate from the existing `api.drafts.queue` that operates on `TweetDraft` objects)
- Methods: `list(status?)`, `create`, `update`, `remove`, `publish`

## What's new in `src/lib/api.ts`
- Types: `QueueItem`, `QueueListResponse`, `QueueCreateInput`, `QueueUpdateInput`
- Enums: `QueuePlatform` (`"twitter"`), `QueueStatus` (`queued` | `scheduled` | `published` | `failed`)
- Namespace: `api.queue` with 5 methods calling `/api/queue[/:id[/publish]]`

## Context
Rescued from a WIP auto-preserve commit on `feat/draft-queue-frontend`. The queue page (`src/app/queue/page.tsx`) already ships on main — this PR adds the first-class client contract that the v1.1 Draft Queue UI can consume.

## Test plan
- [ ] Verify types compile against consumer pages (queue page, dashboard widgets)
- [ ] Confirm backend `/api/queue` endpoints match this contract before wiring UI
- [ ] No conflict with existing `api.drafts.queue` (drafts-scoped) — confirmed different namespace

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>