### PR TITLE
feat(admin/qa): severity tracking for test results

### DIFF
--- a/src/app/admin/qa/page.tsx
+++ b/src/app/admin/qa/page.tsx
@@ -187,6 +187,31 @@ function QaContent() {
             note,
             tester: existing?.tester ?? testerInitials,
             timestamp: new Date().toISOString(),
+            severity: existing?.severity,
+            userFeedback: existing?.userFeedback,
+          },
+        };
+        scheduleSave(next);
+        return next;
+      });
+    },
+    [canEdit, testerInitials, scheduleSave],
+  );
+
+  const setSeverity = useCallback(
+    (testId: string, severity: Severity | "") => {
+      if (!canEdit) return;
+      setResults((prev) => {
+        const existing = prev[testId];
+        const next: ResultsMap = {
+          ...prev,
+          [testId]: {
+            status: existing?.status ?? "fail",
+            note: existing?.note ?? "",
+            tester: existing?.tester ?? testerInitials,
+            timestamp: new Date().toISOString(),
+            severity: severity === "" ? undefined : severity,
+            userFeedback: existing?.userFeedback,
           },
         };
         scheduleSave(next);


### PR DESCRIPTION
## Summary
- Add setSeverity callback to QA test result tracking
- Preserve severity and userFeedback fields on result map updates
- Admin-only QA panel improvement

## Test plan
- [ ] Set severity on a QA test result — verify it persists on save
- [ ] Update test note — verify severity is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)