### PR TITLE
fix(ci): slugify branch name in Vercel preview URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,13 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install chromium --with-deps
+      - name: Set Vercel preview URL (slugify branch name)
+        run: |
+          SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-')
+          echo "PLAYWRIGHT_BASE_URL=https://delphi-atlas-git-${SLUG}-alex-peris-projects.vercel.app" >> $GITHUB_ENV
       - run: npx playwright test --config=playwright-e2e.config.ts --project=${{ matrix.project }}
         env:
           VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
-          PLAYWRIGHT_BASE_URL: https://delphi-atlas-git-${{ github.head_ref }}-alex-peris-projects.vercel.app
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
## Summary
- Branches with `/` in their name (feat/*, fix/*, chore/*) produce a malformed Vercel preview URL in CI
- `github.head_ref` = `fix/something` → URL becomes `https://delphi-atlas-git-fix/something-...` (broken)
- Fix: add a step to replace `/` with `-` via `tr '/' '-'` and write to `GITHUB_ENV`

## Test plan
- [ ] e2e-extended jobs no longer fail with `ERR_NAME_NOT_RESOLVED`
- [ ] Vercel preview URL resolves correctly for branches with `/` in the name

🤖 Generated with [Claude Code](https://claude.com/claude-code)