### PR TITLE
feat(voice-profiles): Anil feedback improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-')
           echo "PLAYWRIGHT_BASE_URL=https://delphi-atlas-git-${SLUG}-alex-peris-projects.vercel.app" >> $GITHUB_ENV
-      - run: npx playwright test --config=playwright-e2e.config.ts --shard=${{ matrix.shard }}/4 --reporter=blob
+      - run: npx playwright test --config=playwright-e2e.config.ts --project=a11y --project=errors --project=performance --shard=${{ matrix.shard }}/4 --reporter=blob
         env:
           VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
       - uses: actions/upload-artifact@v4

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -65,6 +65,7 @@ const TWEET_TEMPLATES = [
 
 const NEWS_SOURCE_PREFIX = "source:";
 const VOICE_COMPARISON_DELTA = { humor: 20 } as const;
+const MIN_TWEETS_FOR_CRAFTING = 3;
 
 type CraftingMode = (typeof CRAFTING_MODES)[number]["id"];
 type DraftSourceType = "REPORT" | "ARTICLE" | "MANUAL";
@@ -235,7 +236,6 @@ function buildVoiceVariationInstruction(
 function CraftingPage() {
   useTour("crafting");
 
-
   const searchParams = useSearchParams();
   const voiceModeLabelId = useId();
   const savedBlendLabelId = useId();
@@ -327,6 +327,14 @@ function CraftingPage() {
     currentFormality,
     currentBrevity,
     currentContrarianTone
+  );
+  const voiceTweetsAnalyzed = user?.voiceProfile?.tweetsAnalyzed ?? 0;
+  const isVoiceCalibrationBlocked =
+    user?.voiceProfile?.maturity === "BEGINNER" &&
+    voiceTweetsAnalyzed < MIN_TWEETS_FOR_CRAFTING;
+  const calibrationTweetsRemaining = Math.max(
+    MIN_TWEETS_FOR_CRAFTING - voiceTweetsAnalyzed,
+    0
   );
 
   const loadDrafts = useCallback(async () => {
@@ -634,7 +642,7 @@ function CraftingPage() {
     hasSource: boolean,
     angle?: string | null
   ) => {
-    if (!user) return false;
+    if (!user || isVoiceCalibrationBlocked) return false;
 
     setError(null);
     const { isValid, trimmedContent } = validateDraftSubmission(content, hasSource);
@@ -664,7 +672,13 @@ function CraftingPage() {
     } finally {
       setCreating(false);
     }
-  }, [commitDraft, selectedBlendId, user, validateDraftSubmission]);
+  }, [
+    commitDraft,
+    isVoiceCalibrationBlocked,
+    selectedBlendId,
+    user,
+    validateDraftSubmission,
+  ]);
 
   const handleTextFileInput = useCallback(async (file: File) => {
     if (!isTextFile(file)) {
@@ -787,7 +801,7 @@ function CraftingPage() {
   }, []);
 
   const handleGenerateNews = async (articleUrl: string, fallbackText = "") => {
-    if (!user) {
+    if (!user || isVoiceCalibrationBlocked) {
       return {};
     }
 
@@ -1039,7 +1053,7 @@ function CraftingPage() {
   const activeTabPanelId = `${activeMode}-panel`;
 
   const handleCompareVoices = async (text = draftInputValueRef.current) => {
-    if (!user) {
+    if (!user || isVoiceCalibrationBlocked) {
       return false;
     }
 
@@ -1208,6 +1222,29 @@ function CraftingPage() {
         </Link>
       </div>
 
+      {isVoiceCalibrationBlocked ? (
+        <div
+          role="alert"
+          className="mt-6 rounded-2xl border border-atlas-warning/30 bg-atlas-warning/10 px-4 py-4 text-sm text-atlas-warning"
+        >
+          <p className="font-semibold text-atlas-text">
+            Voice calibration is not ready for drafting yet.
+          </p>
+          <p className="mt-1 text-atlas-text-secondary">
+            Atlas needs at least {MIN_TWEETS_FOR_CRAFTING} analyzed tweets before
+            it unlocks generation here. You have {voiceTweetsAnalyzed}, so add{" "}
+            {calibrationTweetsRemaining} more in{" "}
+            <Link
+              href="/voice-profiles"
+              className="font-semibold text-atlas-teal hover:underline"
+            >
+              Voice Lab
+            </Link>
+            .
+          </p>
+        </div>
+      ) : null}
+
       <div className="mt-6 flex flex-col gap-6 lg:flex-row">
         <DraftHistorySidebar
           drafts={draftHistoryItems}
@@ -1226,6 +1263,7 @@ function CraftingPage() {
                   <button
                     key={topic.id}
                     type="button"
+                    disabled={creating || isVoiceCalibrationBlocked}
                     onClick={() =>
                       void createDraftFromSource(
                         `${topic.headline}. ${topic.context || ""}`,
@@ -1233,7 +1271,7 @@ function CraftingPage() {
                         true
                       )
                     }
-                    className="rounded-full border border-glass-border bg-atlas-surface px-3 py-1.5 text-xs text-atlas-text transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+                    className="rounded-full border border-glass-border bg-atlas-surface px-3 py-1.5 text-xs text-atlas-text transition-colors hover:border-atlas-teal hover:text-atlas-teal disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {topic.headline.length > 50
                       ? `${topic.headline.slice(0, 50)}…`
@@ -1284,6 +1322,7 @@ function CraftingPage() {
               >
                 <NewsMode
                   creating={creating}
+                  disabled={isVoiceCalibrationBlocked}
                   error={error}
                   onDismissError={() => setError(null)}
                   onGenerateNews={handleGenerateNews}
@@ -1412,7 +1451,7 @@ function CraftingPage() {
                   <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]" data-tour="generate-button">
                     <GradientButton
                       fullWidth
-                      disabled={creating}
+                      disabled={creating || isVoiceCalibrationBlocked}
                       onClick={() => void handleCreateDraft()}
                     >
                       {creating && !comparingVoices ? (
@@ -1429,7 +1468,7 @@ function CraftingPage() {
                     <button
                       type="button"
                       onClick={() => void handleCompareVoices()}
-                      disabled={creating}
+                      disabled={creating || isVoiceCalibrationBlocked}
                       className="inline-flex items-center justify-center gap-2 rounded-2xl border border-glass-border bg-glass px-4 py-3 text-sm font-medium text-atlas-text transition-colors hover:border-atlas-teal/50 hover:text-atlas-teal disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {comparingVoices ? (
@@ -1449,7 +1488,7 @@ function CraftingPage() {
                     <button
                       type="button"
                       onClick={() => setShowAdvisor(true)}
-                      disabled={creating}
+                      disabled={creating || isVoiceCalibrationBlocked}
                       className="mt-2 w-full inline-flex items-center justify-center gap-2 rounded-xl border border-delphi-teal/20 bg-delphi-teal/5 px-4 py-2.5 text-sm font-medium text-delphi-teal transition-colors hover:bg-delphi-teal/10 hover:border-delphi-teal/40 disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       <Sparkles className="h-4 w-4" />

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Sparkles, Wand2 } from "lucide-react";
+import { Plus, Sparkles } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
 import ReferenceVoicesSection from "@/components/voice-profiles/ReferenceVoicesSection";
 import RecipeCard from "@/components/voice-profiles/RecipeCard";
@@ -23,14 +23,10 @@ import {
   pickVoiceDimensions,
   type VoiceDimensions,
 } from "@/lib/voice-profile-dimensions";
-import {
-  buildReferenceBlendVoices,
-  REFERENCE_ACCOUNT_FALLBACK,
-} from "@/lib/reference-accounts";
+import { REFERENCE_ACCOUNT_FALLBACK } from "@/lib/reference-accounts";
 import {
   buildBlendFingerprint,
   getNotableVoiceDimensions,
-  normalizeReferenceSelectionKey,
 } from "@/lib/voice-recipes";
 
 const PERSONAL_VOICE_ID = "__personal__";
@@ -58,6 +54,44 @@ function getActiveRecipeLabel(
   return blends.find((blend) => blend.id === activeVoiceId)?.name ?? "Personal Voice";
 }
 
+const BLEND_PREVIEW_DIMENSIONS: Array<[keyof VoiceDimensions, string]> = [
+  ["humor", "Humor"],
+  ["formality", "Formality"],
+  ["brevity", "Brevity"],
+  ["contrarianTone", "Contrarian tone"],
+  ["directness", "Directness"],
+  ["warmth", "Warmth"],
+  ["technicalDepth", "Technical depth"],
+  ["confidence", "Confidence"],
+  ["evidenceOrientation", "Evidence orientation"],
+  ["solutionOrientation", "Solution orientation"],
+  ["socialPosture", "Social posture"],
+  ["selfPromotionalIntensity", "Self-promotion"],
+];
+
+function buildBlendPreviewPrompt(blend: SavedBlend, dimensions: VoiceDimensions) {
+  const composition = blend.voices
+    .map((voice) => `${voice.percentage}% ${voice.label}`)
+    .join(", ");
+  const dimensionSummary = BLEND_PREVIEW_DIMENSIONS.map(
+    ([field, label]) => `${label}: ${formatVoiceDimensionValue(dimensions[field])}`
+  ).join(", ");
+
+  return [
+    "Write one original sample tweet for a crypto analyst.",
+    `Match this saved Atlas voice recipe: ${blend.name}.`,
+    `Blend composition: ${composition}.`,
+    `Voice fingerprint: ${dimensionSummary}.`,
+    "Keep it under 260 characters.",
+    "No hashtags, no thread marker, and no surrounding quotation marks.",
+    "Make it feel publishable right now, with a specific point of view.",
+  ].join(" ");
+}
+
+function sanitizeBlendPreview(text: string) {
+  return text.trim().replace(/^"+|"+$/g, "");
+}
+
 export default function VoiceProfilesPage() {
   const router = useRouter();
   const { user } = useAuth();
@@ -75,6 +109,11 @@ export default function VoiceProfilesPage() {
   const [error, setError] = useState<string | null>(null);
   const [calibrateHandle, setCalibrateHandle] = useState("");
   const [showCalibrationInput, setShowCalibrationInput] = useState(false);
+  const [previewingBlendId, setPreviewingBlendId] = useState<string | null>(null);
+  const [blendPreviewErrors, setBlendPreviewErrors] = useState<
+    Record<string, string>
+  >({});
+  const [blendPreviews, setBlendPreviews] = useState<Record<string, string>>({});
 
   useEffect(() => {
     const savedBlendId = window.localStorage.getItem("atlas_active_blend");
@@ -195,6 +234,61 @@ export default function VoiceProfilesPage() {
   const activeRecipeLabel = useMemo(
     () => getActiveRecipeLabel(activeVoiceId, blends),
     [activeVoiceId, blends]
+  );
+
+  const handlePreviewBlend = useCallback(
+    async (blend: SavedBlend, dimensions: VoiceDimensions) => {
+      if (previewingBlendId) {
+        return;
+      }
+
+      setPreviewingBlendId(blend.id);
+      setBlendPreviewErrors((current) => {
+        const nextErrors = { ...current };
+        delete nextErrors[blend.id];
+        return nextErrors;
+      });
+
+      try {
+        const response = await api.oracle.chat({
+          page: "voice-profiles",
+          messages: [
+            {
+              role: "user",
+              content: buildBlendPreviewPrompt(blend, dimensions),
+            },
+          ],
+        });
+        const previewText = sanitizeBlendPreview(response.text);
+
+        if (!previewText) {
+          throw new Error("Atlas returned an empty sample tweet.");
+        }
+
+        setBlendPreviews((current) => ({
+          ...current,
+          [blend.id]: previewText,
+        }));
+        setBlendPreviewErrors((current) => {
+          const nextErrors = { ...current };
+          delete nextErrors[blend.id];
+          return nextErrors;
+        });
+      } catch (previewError: unknown) {
+        setBlendPreviewErrors((current) => ({
+          ...current,
+          [blend.id]:
+            previewError instanceof Error
+              ? previewError.message
+              : "Couldn't generate a sample tweet for this voice.",
+        }));
+      } finally {
+        setPreviewingBlendId((current) =>
+          current === blend.id ? null : current
+        );
+      }
+    },
+    [previewingBlendId]
   );
 
   const handleUseVoice = (voiceId: string) => {
@@ -425,6 +519,12 @@ export default function VoiceProfilesPage() {
                   isActive={activeVoiceId === blend.id}
                   userHandle={user?.handle}
                   onUse={() => handleUseVoice(blend.id)}
+                  onPreviewSample={() =>
+                    void handlePreviewBlend(blend, dimensions)
+                  }
+                  previewError={blendPreviewErrors[blend.id]}
+                  previewLoading={previewingBlendId === blend.id}
+                  previewText={blendPreviews[blend.id]}
                   onEdit={() => {
                     setEditorBlendId(blend.id);
                     setEditorMode("edit-blend");

--- a/src/components/crafting/NewsMode.tsx
+++ b/src/components/crafting/NewsMode.tsx
@@ -6,6 +6,7 @@ import GradientButton from "@/components/ui/GradientButton";
 
 export interface NewsModeProps {
   creating?: boolean;
+  disabled?: boolean;
   error?: string | null;
   onDismissError?: () => void;
   onArticleUrlChange?: (value: string) => void;
@@ -18,6 +19,7 @@ export interface NewsModeProps {
 
 export default function NewsMode({
   creating = false,
+  disabled = false,
   error,
   onDismissError,
   onArticleUrlChange,
@@ -108,7 +110,7 @@ export default function NewsMode({
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
-        <GradientButton disabled={creating} type="submit">
+        <GradientButton disabled={creating || disabled} type="submit">
           {creating ? (
             <span className="flex items-center justify-center gap-2">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -122,7 +124,8 @@ export default function NewsMode({
           <button
             type="button"
             onClick={() => setShowFallback(true)}
-            className="text-sm text-atlas-text-secondary transition-colors hover:text-atlas-teal"
+            disabled={disabled}
+            className="text-sm text-atlas-text-secondary transition-colors hover:text-atlas-teal disabled:cursor-not-allowed disabled:opacity-50"
           >
             Paste text instead
           </button>

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { AnimatePresence, motion, useCycle } from "framer-motion";
-import { ChevronDown, ChevronUp, PencilLine, Sparkles } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  PencilLine,
+  Sparkles,
+} from "lucide-react";
 import DimensionBar from "@/components/ui/DimensionBar";
 import type { BlendVoice, SavedBlend } from "@/lib/api";
 import type { VoiceDimensionSnapshot } from "@/lib/voice-recipes";
@@ -18,7 +24,11 @@ interface RecipeCardProps {
   notableDimensions: VoiceDimensionSnapshot[];
   isActive: boolean;
   onEdit: () => void;
+  onPreviewSample: () => void;
   onUse: () => void;
+  previewError?: string | null;
+  previewLoading?: boolean;
+  previewText?: string;
   userHandle?: string;
 }
 
@@ -115,7 +125,11 @@ export default function RecipeCard({
   notableDimensions,
   isActive,
   onEdit,
+  onPreviewSample,
   onUse,
+  previewError,
+  previewLoading = false,
+  previewText,
   userHandle,
 }: RecipeCardProps) {
   const [isExpanded, toggleExpanded] = useCycle(false, true);
@@ -270,7 +284,25 @@ export default function RecipeCard({
           ) : (
             <ChevronDown className="h-4 w-4" />
           )}
-          {isExpanded ? "Hide Preview" : "Preview"}
+          {isExpanded ? "Hide fingerprint" : "Show fingerprint"}
+        </button>
+        <button
+          type="button"
+          onClick={onPreviewSample}
+          disabled={previewLoading}
+          className="inline-flex items-center gap-2 rounded-xl border border-atlas-teal/30 bg-atlas-teal/10 px-4 py-2 text-sm font-semibold text-atlas-teal transition-colors hover:border-atlas-teal hover:bg-atlas-teal/15 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {previewLoading ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Generating sample...
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-4 w-4" />
+              {previewText ? "Regenerate sample" : "Preview in this voice"}
+            </>
+          )}
         </button>
         <button
           type="button"
@@ -294,6 +326,26 @@ export default function RecipeCard({
           Edit
         </button>
       </div>
+
+      {previewText || previewError ? (
+        <div className="mt-4 rounded-2xl border border-glass-border bg-atlas-surface/40 p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-atlas-text-muted">
+            Sample tweet
+          </p>
+          {previewError ? (
+            <p role="alert" className="mt-2 text-sm text-atlas-error">
+              {previewError}
+            </p>
+          ) : (
+            <p
+              aria-live="polite"
+              className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-atlas-text"
+            >
+              {previewText}
+            </p>
+          )}
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/src/components/voice-profiles/ReferenceVoicesSection.tsx
+++ b/src/components/voice-profiles/ReferenceVoicesSection.tsx
@@ -25,6 +25,21 @@ interface ReferenceVoicesSectionProps {
   references: ReferenceVoice[];
 }
 
+function normalizeTwitterHandle(handle?: string | null) {
+  const trimmedHandle = handle?.trim();
+
+  if (!trimmedHandle) {
+    return "";
+  }
+
+  const urlMatch = trimmedHandle.match(
+    /(?:twitter\.com|x\.com)\/([A-Za-z0-9_]+)/i
+  );
+  const extractedHandle = urlMatch?.[1] ?? trimmedHandle;
+
+  return extractedHandle.replace(/^@+/, "");
+}
+
 export default function ReferenceVoicesSection({
   onReferencesChange,
   references,
@@ -128,7 +143,9 @@ export default function ReferenceVoicesSection({
       name: matchingReference?.name ?? id,
       profileImageUrl: matchingReference?.avatarUrl
         ?? (matchingReference?.handle
-          ? `https://unavatar.io/twitter/${matchingReference.handle.replace("@", "")}`
+          ? `https://unavatar.io/twitter/${normalizeTwitterHandle(
+              matchingReference.handle
+            )}`
           : null),
     });
   });
@@ -251,57 +268,61 @@ export default function ReferenceVoicesSection({
           </div>
         ) : (
           <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {selectedAccounts.map((account) => (
-              <div
-                key={account.id}
-                className="flex items-center gap-3 rounded-2xl border border-glass-border bg-atlas-surface/70 p-4"
-              >
-                {account.profileImageUrl && !avatarErrors[account.id] ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    alt={`${account.displayName || account.name || account.handle} avatar`}
-                    className="h-12 w-12 rounded-full border border-glass-border object-cover"
-                    onError={() =>
-                      setAvatarErrors((current) => ({
-                        ...current,
-                        [account.id]: true,
-                      }))
-                    }
-                    src={account.profileImageUrl}
-                  />
-                ) : (
-                  <div
-                    aria-hidden="true"
-                    className="flex h-12 w-12 items-center justify-center rounded-full border border-atlas-teal/30 text-sm font-semibold uppercase"
-                    style={{
-                      backgroundColor: `${colors.atlasTeal}1A`,
-                      color: colors.atlasTeal,
-                    }}
-                  >
-                    {(account.handle || account.id).charAt(0)}
-                  </div>
-                )}
+            {selectedAccounts.map((account) => {
+              const normalizedHandle = normalizeTwitterHandle(account.handle);
 
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-semibold text-atlas-text">
-                    {account.displayName || account.name || account.handle || account.id}
-                  </p>
-                  {account.handle ? (
-                    <a
-                      href={`https://twitter.com/${account.handle}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-0.5 text-xs text-atlas-text-secondary hover:text-atlas-teal hover:underline"
-                    >
-                      @{account.handle}
-                      <ExternalLink className="h-2.5 w-2.5" />
-                    </a>
+              return (
+                <div
+                  key={account.id}
+                  className="flex items-center gap-3 rounded-2xl border border-glass-border bg-atlas-surface/70 p-4"
+                >
+                  {account.profileImageUrl && !avatarErrors[account.id] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      alt={`${account.displayName || account.name || account.handle} avatar`}
+                      className="h-12 w-12 rounded-full border border-glass-border object-cover"
+                      onError={() =>
+                        setAvatarErrors((current) => ({
+                          ...current,
+                          [account.id]: true,
+                        }))
+                      }
+                      src={account.profileImageUrl}
+                    />
                   ) : (
-                    <p className="truncate text-xs text-atlas-text-secondary">@{account.id}</p>
+                    <div
+                      aria-hidden="true"
+                      className="flex h-12 w-12 items-center justify-center rounded-full border border-atlas-teal/30 text-sm font-semibold uppercase"
+                      style={{
+                        backgroundColor: `${colors.atlasTeal}1A`,
+                        color: colors.atlasTeal,
+                      }}
+                    >
+                      {(normalizedHandle || account.id).charAt(0)}
+                    </div>
                   )}
+
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold text-atlas-text">
+                      {account.displayName || account.name || account.handle || account.id}
+                    </p>
+                    {normalizedHandle ? (
+                      <a
+                        href={`https://twitter.com/${normalizedHandle}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-0.5 text-xs text-atlas-text-secondary hover:text-atlas-teal hover:underline"
+                      >
+                        @{normalizedHandle}
+                        <ExternalLink className="h-2.5 w-2.5" />
+                      </a>
+                    ) : (
+                      <p className="truncate text-xs text-atlas-text-secondary">@{account.id}</p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- fix reference voice handle links so cards always display `@handle` while linking to a clean Twitter URL
- block crafting generation until early-stage voice profiles have enough analyzed tweets, with an in-product calibration banner
- add saved-blend sample tweet previews in Voice Lab using Oracle-backed blend context

## Verification
- `npx tsc --noEmit`
