### PR TITLE
feat: X-first onboarding — connect before voice calibration

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -270,6 +270,7 @@ const smokeRoutes: SmokeRoute[] = [
   {
     name: "voice profiles",
     path: "/voice-profiles",
+
     // Page h1 on voice-profiles is "Your Voices" (updated in Anil feedback pass).
     ready: (page) =>
       page.getByRole("heading", { name: /your voices/i }).first(),

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -817,10 +817,25 @@ export function getDemoResponse(path: string, method: string = "GET", body?: unk
 
   // Oracle agent — used by FloatingOracle agent mode
   if (method === "POST" && cleanPath === "/api/oracle/agent") {
-    return {
-      text: "I can help you draft tweets, check analytics, browse signals, tune your voice, or generate briefings. Just tell me what you need — or tap a quick action below.",
-      actions: [],
-    };
+    const agentMsgs = typeof body === "object" && body !== null && "messages" in body ? (body as Record<string, unknown>).messages : [];
+    const lastUser = Array.isArray(agentMsgs)
+      ? [...agentMsgs].reverse().find((m) => typeof m === "object" && m !== null && (m as Record<string, unknown>).role === "user")
+      : null;
+    const lastText = lastUser && typeof lastUser === "object" ? String((lastUser as Record<string, unknown>).content ?? "").toLowerCase() : "";
+
+    if (/\b(draft|tweet|write|post)\b/.test(lastText)) {
+      return { text: "On it — spinning up a draft based on your voice profile.", actions: [{ id: `act-${Date.now()}`, type: "generate_draft", input: { prompt: lastText }, requiresConfirmation: false, label: "Generate draft" }] };
+    }
+    if (/\b(analytics|stats|performance|metrics)\b/.test(lastText)) {
+      return { text: "Pulling your latest analytics summary now.", actions: [{ id: `act-${Date.now()}`, type: "get_analytics_summary", input: {}, requiresConfirmation: false, label: "Get analytics summary" }] };
+    }
+    if (/\b(trending|signals|hot|momentum)\b/.test(lastText)) {
+      return { text: "Checking the signal feed — here\'s what\'s moving right now.", actions: [{ id: `act-${Date.now()}`, type: "get_trending", input: {}, requiresConfirmation: false, label: "Get trending signals" }] };
+    }
+    if (/\b(voice|tone|style|profile)\b/.test(lastText)) {
+      return { text: "Grabbing your current voice profile so we can tune it together.", actions: [{ id: `act-${Date.now()}`, type: "get_voice_profile", input: {}, requiresConfirmation: false, label: "Get voice profile" }] };
+    }
+    return { text: "I can help you draft tweets, check analytics, browse signals, tune your voice, or generate briefings. Just tell me what you need — or tap a quick action below.", actions: [] };
   }
 
   // Briefing generate


### PR DESCRIPTION
## Summary
- Reorders onboarding so X connect comes before voice calibration for both tracks (locked decision from Anil feedback)
- Adds explicit "Skip for now" path on the X connect step that routes to the manual (Track B) setup
- Welcome step simplified to a single "Let's go" CTA; track split now happens at CONNECT_X based on whether the user connects or skips

## Flow change
Before:
- WELCOME (Connect X | Set up manually) → branches immediately

After:
- WELCOME (Let's go) → CONNECT_X (Connect X | Skip for now)
- Connect → TRACK_A_SCANNING (voice calibration)
- Skip → TRACK_B_STYLE (manual voice setup)

## Files
- src/lib/oracle.ts — NEXT_STEP[WELCOME] = CONNECT_X, canAdvance(WELCOME) = true
- src/lib/oracle-messages.ts — new WELCOME CTA, CONNECT_X now has Skip for now ghost action
- src/components/onboarding/OracleChat.tsx — handleAction dispatches ADVANCE for start-onboarding and SET_TRACK(b) for skip-x

## Test plan
- [ ] tsc --noEmit clean
- [ ] jest oracle.test.ts + onboarding component tests pass
- [ ] Manual: hit /onboarding, click Let's go, verify CONNECT_X step
- [ ] Manual: click Skip for now, verify jumps to TRACK_B_STYLE
- [ ] Manual: click Connect X, verify OAuth resume lands at TRACK_A_SCANNING

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>