### PR TITLE
feat(oracle): add Open Oracle command to command palette

### DIFF
--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -124,6 +124,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     { id: "arena", label: "Arena", description: "Competitive scoreboard", icon: Trophy, action: () => navigate("/arena"), keywords: "arena leaderboard score compete ranking" },
     { id: "campaigns", label: "Campaigns", description: "Posting queue & threads", icon: CalendarClock, action: () => navigate("/campaigns"), keywords: "campaign queue schedule thread post" },
     { id: "onboarding", label: "Oracle Onboarding", description: "Re-run onboarding flow", icon: Sparkles, action: () => navigate("/onboarding"), keywords: "oracle onboarding setup voice wizard" },
+    { id: "oracle-open", label: "Open Oracle", description: "Chat with your AI copilot", icon: Sparkles, action: () => { window.dispatchEvent(new CustomEvent("oracle:open")); closePalette(); }, keywords: "oracle ai copilot chat assistant" },
   ];
 
   const toggleFavorite = useCallback((id: string, e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- Adds `Open Oracle` entry to the Cmd+K command palette — dispatches `oracle:open` custom event and closes palette
- Wires up the FloatingOracle's `oracle:open` event listener so keyboard-first users can open Oracle without clicking the FAB

## Test plan
- [ ] Cmd+K → type "oracle" → "Open Oracle" appears → click it → Oracle chat opens
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)