### PR TITLE
feat(voice-library): recipe cards + blend pair-select + preview in voice

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -78,6 +78,8 @@ export default function VoiceProfilesPage() {
   const [dismissedSetupPrompt, setDismissedSetupPrompt] = useState(false);
   const [showCalibrationInput, setShowCalibrationInput] = useState(false);
   const [calibrateHandle, setCalibrateHandle] = useState("");
+  const [blendSelectMode, setBlendSelectMode] = useState(false);
+  const [blendSourceId, setBlendSourceId] = useState<string | null>(null);
   const setupPrompt = searchParams.get("prompt");
   const showSetupPrompt =
     setupPrompt === "complete-voice-setup" && !dismissedSetupPrompt;
@@ -216,6 +218,50 @@ export default function VoiceProfilesPage() {
       window.localStorage.setItem("atlas_active_blend", voiceId);
     }
     router.push("/crafting");
+  };
+
+  const handleCreatePairedBlend = async (targetId: string) => {
+    const sourceName =
+      blendSourceId === PERSONAL_VOICE_ID
+        ? "Personal"
+        : blends.find((b) => b.id === blendSourceId)?.name ?? "Voice A";
+    const targetName =
+      targetId === PERSONAL_VOICE_ID
+        ? "Personal"
+        : blends.find((b) => b.id === targetId)?.name ?? "Voice B";
+    const blendName = `${sourceName} × ${targetName}`;
+
+    const sourceVoice: BlendVoiceInput =
+      blendSourceId === PERSONAL_VOICE_ID
+        ? { label: "My voice", percentage: 50 }
+        : { label: sourceName, percentage: 50, referenceVoiceId: blendSourceId ?? undefined };
+    const targetVoice: BlendVoiceInput =
+      targetId === PERSONAL_VOICE_ID
+        ? { label: "My voice", percentage: 50 }
+        : { label: targetName, percentage: 50, referenceVoiceId: targetId };
+
+    try {
+      await api.voice.createBlend(blendName, [sourceVoice, targetVoice]);
+      const response = await api.voice.getBlends();
+      setBlends(response.blends);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create blend");
+    } finally {
+      setBlendSelectMode(false);
+      setBlendSourceId(null);
+    }
+  };
+
+  const handleBlendSelect = (voiceId: string) => {
+    if (!blendSelectMode) {
+      setBlendSelectMode(true);
+      setBlendSourceId(voiceId);
+    } else if (voiceId === blendSourceId) {
+      setBlendSelectMode(false);
+      setBlendSourceId(null);
+    } else {
+      void handleCreatePairedBlend(voiceId);
+    }
   };
 
   const buildBlendVoicesFromReferences = (): BlendVoiceInput[] => {
@@ -370,6 +416,30 @@ export default function VoiceProfilesPage() {
           Pick a voice and start crafting. Each voice shapes how Atlas writes for you.
         </p>
 
+        {blendSelectMode && (
+          <div className="mb-4 flex items-center justify-between rounded-xl border border-atlas-teal/20 bg-atlas-teal/10 px-4 py-3 text-sm">
+            <span className="font-semibold text-atlas-teal">
+              Select a second voice to blend with{" "}
+              <span className="text-atlas-text">
+                {blendSourceId === PERSONAL_VOICE_ID
+                  ? "Personal Voice"
+                  : blends.find((b) => b.id === blendSourceId)?.name}
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                setBlendSelectMode(false);
+                setBlendSourceId(null);
+              }}
+              aria-label="Cancel blend selection"
+              className="text-atlas-text-muted hover:text-atlas-text"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
         {/* Voice Library Grid */}
         <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           <VoiceCard
@@ -377,20 +447,26 @@ export default function VoiceProfilesPage() {
             isActive={activeVoiceId === PERSONAL_VOICE_ID}
             isPersonal
             isSelected={selectedVoiceId === PERSONAL_VOICE_ID}
-            dimensions={personalDimensions}
+            notableDimensions={personalStandouts}
+            userHandle={user?.handle}
             onSelect={() => setSelectedVoiceId(PERSONAL_VOICE_ID)}
             onUse={() => handleUseVoice(PERSONAL_VOICE_ID)}
+            onBlend={() => handleBlendSelect(PERSONAL_VOICE_ID)}
+            blendTargetMode={blendSelectMode && blendSourceId !== PERSONAL_VOICE_ID}
           />
-          {blends.map((blend) => (
+          {recipeCards.map(({ blend, notableDimensions }) => (
             <VoiceCard
               key={blend.id}
               name={blend.name}
               isActive={activeVoiceId === blend.id}
               isPersonal={false}
               isSelected={selectedVoiceId === blend.id}
-              dimensions={personalDimensions}
+              notableDimensions={notableDimensions}
+              userHandle={user?.handle}
               onSelect={() => setSelectedVoiceId(blend.id)}
               onUse={() => handleUseVoice(blend.id)}
+              onBlend={() => handleBlendSelect(blend.id)}
+              blendTargetMode={blendSelectMode && blendSourceId !== blend.id}
             />
           ))}
           {blends.length === 0 && (

--- a/src/components/voice-profiles/VoiceCard.tsx
+++ b/src/components/voice-profiles/VoiceCard.tsx
@@ -1,24 +1,56 @@
 "use client";
 
+import { useCallback, useMemo, useState } from "react";
+import { GitMerge, Loader2, Sparkles } from "lucide-react";
+import { api } from "@/lib/api";
+import {
+  getNotableVoiceDimensions,
+  type VoiceDimensionSnapshot,
+} from "@/lib/voice-recipes";
+import type { VoiceDimensions } from "@/lib/voice-profile-dimensions";
+
 interface VoiceCardProps {
   name: string;
   isActive: boolean;
   isPersonal: boolean;
   isSelected: boolean;
-  dimensions?: { humor?: number; formality?: number; brevity?: number; contrarianTone?: number };
+  notableDimensions?: VoiceDimensionSnapshot[];
+  /** @deprecated Prefer notableDimensions. Kept for backwards compat. */
+  dimensions?: VoiceDimensions;
+  userHandle?: string;
   onSelect: () => void;
   onUse: () => void;
+  onBlend?: () => void;
+  blendTargetMode?: boolean;
 }
 
-function MiniBar({ value }: { value: number }) {
-  return (
-    <div className="h-1 w-full rounded-full bg-atlas-bg/60">
-      <div
-        className="h-1 rounded-full bg-atlas-teal/60"
-        style={{ width: `${value}%` }}
-      />
-    </div>
-  );
+type Qualifier = "High" | "Med" | "Low";
+
+interface RecipePill {
+  key: string;
+  label: string;
+  qualifier: Qualifier;
+  pillClass: string;
+}
+
+function qualifierFor(value: number): Qualifier {
+  if (value >= 65) return "High";
+  if (value <= 35) return "Low";
+  return "Med";
+}
+
+function pillClassFor(qualifier: Qualifier): string {
+  if (qualifier === "High") return "border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal";
+  if (qualifier === "Low") return "border-glass-border bg-glass/60 text-atlas-text-muted";
+  return "border-glass-border bg-glass/60 text-atlas-text-secondary";
+}
+
+function toRecipePills(snapshots: VoiceDimensionSnapshot[] | undefined): RecipePill[] {
+  if (!snapshots || snapshots.length === 0) return [];
+  return snapshots.slice(0, 3).map((s) => {
+    const qualifier = qualifierFor(s.value);
+    return { key: s.field, label: s.label, qualifier, pillClass: pillClassFor(qualifier) };
+  });
 }
 
 export default function VoiceCard({
@@ -26,12 +58,60 @@ export default function VoiceCard({
   isActive,
   isPersonal,
   isSelected,
+  notableDimensions,
   dimensions,
+  userHandle: _userHandle,
   onSelect,
   onUse,
+  onBlend,
+  blendTargetMode = false,
 }: VoiceCardProps) {
+  const [previewText, setPreviewText] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const recipePills = useMemo<RecipePill[]>(() => {
+    if (notableDimensions && notableDimensions.length > 0) return toRecipePills(notableDimensions);
+    if (dimensions) return toRecipePills(getNotableVoiceDimensions(dimensions, 3));
+    return [];
+  }, [notableDimensions, dimensions]);
+
+  const loadPreview = useCallback(async () => {
+    if (previewLoading) return;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    try {
+      const res = await api.oracle.chat({
+        page: "voice-preview",
+        messages: [
+          {
+            role: "user",
+            content: `Write a 2-sentence sample tweet in this voice style: ${name}. Be concise and demonstrate the voice clearly.`,
+          },
+        ],
+      });
+      setPreviewText(res.text?.trim() ?? "");
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : "Preview failed. Try again.");
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [name, previewLoading]);
+
+  const containerClass = [
+    "relative flex flex-col rounded-2xl border p-5 text-left transition-all cursor-pointer",
+    blendTargetMode
+      ? "border-atlas-teal/50 bg-atlas-surface ring-2 ring-atlas-teal/40 ring-offset-1 ring-offset-atlas-bg"
+      : isSelected
+        ? "border-atlas-teal ring-1 ring-atlas-teal bg-atlas-surface"
+        : "border-glass-border bg-glass/50 backdrop-blur-xl hover:border-atlas-teal/40",
+  ].join(" ");
+
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
       onClick={onSelect}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -39,54 +119,111 @@ export default function VoiceCard({
           onSelect();
         }
       }}
-      className={`relative rounded-2xl border p-5 text-left transition-all cursor-pointer ${
-        isSelected
-          ? "border-atlas-teal ring-1 ring-atlas-teal bg-atlas-surface"
-          : "border-glass-border bg-glass/50 backdrop-blur-xl hover:border-atlas-teal/40"
-      }`}
+      className={containerClass}
     >
-      {/* Badge */}
-      <span
-        className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-          isPersonal
-            ? "bg-atlas-teal/15 text-atlas-teal"
-            : "bg-glass text-atlas-text-muted"
-        }`}
-      >
-        {isPersonal ? "Personal" : "Voice"}
-      </span>
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+            isPersonal ? "bg-atlas-teal/15 text-atlas-teal" : "bg-glass text-atlas-text-muted"
+          }`}
+        >
+          {isPersonal ? "Personal" : "Voice"}
+        </span>
 
-      {/* Name */}
-      <p className="mt-2 font-heading text-sm font-semibold text-atlas-text truncate">
-        {name}
-      </p>
+        {onBlend && !blendTargetMode && (
+          <button
+            type="button"
+            aria-label={`Blend with ${name}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onBlend();
+            }}
+            className="rounded-lg border border-glass-border p-1.5 text-atlas-text-muted transition-colors hover:border-atlas-teal/40 hover:text-atlas-teal"
+          >
+            <GitMerge className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
 
-      {/* Mini dimension preview */}
-      {dimensions && (
-        <div className="mt-3 space-y-1.5">
-          <MiniBar value={dimensions.humor ?? 50} />
-          <MiniBar value={dimensions.formality ?? 50} />
-          <MiniBar value={dimensions.brevity ?? 50} />
-          <MiniBar value={dimensions.contrarianTone ?? 50} />
-        </div>
-      )}
+      <p className="mt-2 truncate font-heading text-sm font-semibold text-atlas-text">{name}</p>
 
-      {/* Use / Active button */}
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onUse();
-        }}
-        disabled={isActive}
-        className={`mt-4 w-full rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-          isActive
-            ? "bg-atlas-teal/15 text-atlas-teal border border-atlas-teal/30 cursor-default"
-            : "border border-glass-border text-atlas-text-secondary hover:border-atlas-teal hover:text-atlas-teal"
-        }`}
-      >
-        {isActive ? "Active" : "Craft with this voice"}
-      </button>
+      <div className="mt-3 min-h-[1.75rem]">
+        {recipePills.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {recipePills.map((pill) => (
+              <span
+                key={pill.key}
+                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${pill.pillClass}`}
+              >
+                <span className="text-atlas-text-secondary">{pill.label}:</span>
+                <span className="ml-1">{pill.qualifier}</span>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="inline-flex rounded-full border border-dashed border-glass-border px-2 py-0.5 text-[10px] text-atlas-text-muted">
+            No profile yet
+          </span>
+        )}
+      </div>
+
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void loadPreview();
+          }}
+          disabled={previewLoading}
+          className="inline-flex items-center gap-1 rounded-lg border border-glass-border px-2 py-1 text-[11px] font-medium text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-teal disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {previewLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+          <span>{previewLoading ? "Previewing…" : "Preview"}</span>
+        </button>
+
+        {previewError && (
+          <p className="mt-2 rounded-lg border border-atlas-error/30 bg-atlas-error/10 px-2 py-1.5 text-[11px] text-atlas-error">
+            {previewError}
+          </p>
+        )}
+
+        {previewText && !previewError && (
+          <p className="mt-2 rounded-lg border border-glass-border bg-atlas-bg/40 px-2 py-1.5 text-[11px] italic text-atlas-text-secondary">
+            {previewText}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-auto pt-4">
+        {blendTargetMode ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUse();
+            }}
+            className="w-full rounded-lg bg-gradient-to-r from-atlas-teal to-atlas-teal/60 px-3 py-2 text-xs font-semibold text-atlas-bg transition-opacity hover:opacity-90"
+          >
+            Mix with this
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUse();
+            }}
+            disabled={isActive}
+            className={`w-full rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+              isActive
+                ? "cursor-default border border-atlas-teal/30 bg-atlas-teal/15 text-atlas-teal"
+                : "border border-glass-border text-atlas-text-secondary hover:border-atlas-teal hover:text-atlas-teal"
+            }`}
+          >
+            {isActive ? "Active" : "Craft with this voice"}
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **VoiceCard redesign**: labeled recipe pills (Humor: High, Formality: Low) replace anonymous dimension bars — immediately readable at a glance
- **Preview in your voice**: Sparkles button per card calls oracle API inline, shows 2-sentence sample tweet in that voice style
- **Blend pair-select UX**: GitMerge icon on any card enters blend mode; selecting a second card auto-creates a 50/50 blend (e.g. "Personal × Trader") via banner flow
- **Bug fix**: blend VoiceCards now receive their own computed dimensions (not always personalDimensions)
- Backwards compat: deprecated `dimensions` prop still accepted

## Test plan
- [ ] Voice Library grid shows recipe pills with labels + qualifiers (High/Med/Low)
- [ ] Preview button generates sample tweet inline, shows loading state
- [ ] Blend mode: click GitMerge on card A → teal banner appears → click second card → blend created
- [ ] Cancelling blend via ✕ exits mode cleanly
- [ ] Personal Voice card shows its own standout dimensions, not generic

🤖 Generated with [Claude Code](https://claude.com/claude-code)