### PR TITLE
fix(voice-lab): inspirations-first layout + calibration gate + voice comparison preview

### DIFF
--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -1453,6 +1453,7 @@ function CraftingPage() {
                         sourceContent={draftInputText}
                         sourceType={getDraftGenerationInput(draftInputText).sourceType}
                         blendId={selectedBlendId || undefined}
+                        isCalibrationBlocked={isVoiceCalibrationBlocked}
                         onDraftsGenerated={(drafts) => {
                           drafts.forEach(draft => commitDraft(draft));
                           setShowAdvisor(false);

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -116,6 +116,14 @@ export default function VoiceProfilesPage() {
     Record<string, string>
   >({});
   const [blendPreviews, setBlendPreviews] = useState<Record<string, string>>({});
+  const [previewCompareBlendId, setPreviewCompareBlendId] = useState<string | null>(null);
+  const [previewCompareLoading, setPreviewCompareLoading] = useState(false);
+  const [previewCompareError, setPreviewCompareError] = useState<string | null>(null);
+  const [previewCompareResult, setPreviewCompareResult] = useState<{
+    label: string;
+    current: string;
+    variant: string;
+  } | null>(null);
   const [calibrateHandle, setCalibrateHandle] = useState("");
   const [blendSelectMode, setBlendSelectMode] = useState(false);
   const [blendSourceId, setBlendSourceId] = useState<string | null>(null);
@@ -302,6 +310,48 @@ export default function VoiceProfilesPage() {
       }
     },
     [previewingBlendId]
+  );
+
+  const PREVIEW_SAMPLE_CONTENT =
+    "Bitcoin just reclaimed $100k after a brutal 3-week drawdown. Open interest is climbing again, funding is neutral, and the ETF flows flipped positive yesterday. Market looks like it wants higher.";
+
+  const handlePreviewCompare = useCallback(
+    async (blendId: string | null) => {
+      if (previewCompareLoading) return;
+      const targetBlend = blendId ? blends.find((b) => b.id === blendId) : null;
+      const label = targetBlend ? targetBlend.name : "Personal Voice";
+      setPreviewCompareBlendId(blendId);
+      setPreviewCompareLoading(true);
+      setPreviewCompareError(null);
+      setPreviewCompareResult(null);
+      try {
+        const [currentResponse, variantResponse] = await Promise.all([
+          api.drafts.generate({
+            sourceContent: PREVIEW_SAMPLE_CONTENT,
+            sourceType: "MANUAL",
+          }),
+          api.drafts.generate({
+            sourceContent: PREVIEW_SAMPLE_CONTENT,
+            sourceType: "MANUAL",
+            blendId: blendId ?? undefined,
+          }),
+        ]);
+        setPreviewCompareResult({
+          label,
+          current: currentResponse.draft.content,
+          variant: variantResponse.draft.content,
+        });
+      } catch (previewError: unknown) {
+        setPreviewCompareError(
+          previewError instanceof Error
+            ? previewError.message
+            : "Couldn't generate the voice comparison."
+        );
+      } finally {
+        setPreviewCompareLoading(false);
+      }
+    },
+    [blends, previewCompareLoading]
   );
 
   const handleUseVoice = (voiceId: string) => {
@@ -676,6 +726,97 @@ export default function VoiceProfilesPage() {
           )}
         </section>
         </div>{/* end blends wrapper */}
+
+        <section className="mt-10 rounded-2xl border border-glass-border bg-atlas-surface/40 p-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-sm font-medium uppercase tracking-[0.2em] text-atlas-teal">
+                Voice Preview
+              </p>
+              <h2 className="mt-2 font-heading text-xl font-semibold text-atlas-text">
+                Preview in my voice
+              </h2>
+              <p className="mt-1 max-w-xl text-sm text-atlas-text-secondary">
+                See how Atlas writes the same sample tweet in your current voice
+                versus a saved blend. Great for checking that calibration is
+                pulling in the right direction.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:min-w-[220px]">
+              <label className="text-xs uppercase tracking-wider text-atlas-text-muted">
+                Compare against
+              </label>
+              <select
+                value={previewCompareBlendId ?? ""}
+                onChange={(e) =>
+                  setPreviewCompareBlendId(e.target.value || null)
+                }
+                className="rounded-lg border border-glass-border bg-atlas-surface px-3 py-2 text-sm text-atlas-text focus:outline-none focus:border-atlas-teal/50"
+                disabled={previewCompareLoading || blends.length === 0}
+              >
+                <option value="">
+                  {blends.length === 0
+                    ? "No blends yet"
+                    : "Pick a blend to compare"}
+                </option>
+                {blends.map((blend) => (
+                  <option key={blend.id} value={blend.id}>
+                    {blend.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() =>
+                  void handlePreviewCompare(previewCompareBlendId)
+                }
+                disabled={
+                  previewCompareLoading ||
+                  (blends.length > 0 && !previewCompareBlendId)
+                }
+                className="rounded-lg bg-gradient-to-r from-atlas-teal to-atlas-teal/60 px-4 py-2 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {previewCompareLoading
+                  ? "Generating…"
+                  : "Preview in my voice"}
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-xl border border-dashed border-glass-border bg-atlas-surface/60 px-4 py-3 text-xs text-atlas-text-muted">
+            Sample: {PREVIEW_SAMPLE_CONTENT}
+          </div>
+
+          {previewCompareError && (
+            <p
+              role="alert"
+              className="mt-4 rounded-lg border border-atlas-error/30 bg-atlas-error/10 px-3 py-2 text-xs text-atlas-error"
+            >
+              {previewCompareError}
+            </p>
+          )}
+
+          {previewCompareResult && !previewCompareLoading && (
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              <div className="rounded-xl border border-glass-border bg-atlas-surface/70 p-4">
+                <p className="text-xs font-medium uppercase tracking-wider text-atlas-text-muted">
+                  Your voice
+                </p>
+                <p className="mt-3 text-sm leading-6 text-atlas-text">
+                  {previewCompareResult.current}
+                </p>
+              </div>
+              <div className="rounded-xl border border-atlas-teal/40 bg-atlas-teal/5 p-4">
+                <p className="text-xs font-medium uppercase tracking-wider text-atlas-teal">
+                  {previewCompareResult.label}
+                </p>
+                <p className="mt-3 text-sm leading-6 text-atlas-text">
+                  {previewCompareResult.variant}
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
 
         <VoiceEditorModal
           isOpen={editorMode !== null}

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -507,8 +507,19 @@ export default function VoiceProfilesPage() {
         <p className="text-sm font-medium uppercase tracking-[0.2em] text-atlas-teal">Voice Studio</p>
         <h1 className="mt-2 font-heading text-2xl font-bold tracking-tight text-atlas-text">Your Voices</h1>
         <p className="mt-1 text-sm text-atlas-text-secondary">
-          Pick a voice and start crafting. Each voice shapes how Atlas writes for you.
+          Add inspirations, then blend them into voices you can craft with.
         </p>
+
+        {/* Inspirations — seed your voice before seeing blends */}
+        <div className="mt-8" data-tour="reference-voices">
+          <ReferenceVoicesSection
+            references={references}
+            onReferencesChange={setReferences}
+          />
+        </div>
+
+        {/* Blends — only shown after user has added at least one inspiration */}
+        <div className="mt-10 border-t border-glass-border pt-10">
 
         {blendSelectMode && (
           <div className="mb-4 flex items-center justify-between rounded-xl border border-atlas-teal/20 bg-atlas-teal/10 px-4 py-3 text-sm">
@@ -589,10 +600,10 @@ export default function VoiceProfilesPage() {
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <p className="text-sm font-medium uppercase tracking-[0.2em] text-atlas-teal">
-                Your Saved Voices
+                Your Blends
               </p>
               <h2 className="mt-2 font-heading text-2xl font-semibold text-atlas-text">
-                Individual creator voices and custom blends for crafting
+                Mix your inspirations into custom voices for crafting
               </h2>
             </div>
             <div className="rounded-full border border-glass-border bg-atlas-surface/60 px-4 py-2 text-sm text-atlas-text-secondary">
@@ -644,31 +655,27 @@ export default function VoiceProfilesPage() {
             </div>
           )}
 
-          <button
-            type="button"
-            onClick={() => setEditorMode("create")}
-            className="mt-6 flex w-full flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-glass-border bg-atlas-surface/30 px-6 py-10 text-center transition-colors hover:border-atlas-teal/40 hover:bg-atlas-surface/50"
-          >
-            <span className="flex h-12 w-12 items-center justify-center rounded-full border border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal">
-              <Plus className="h-5 w-5" aria-hidden="true" />
-            </span>
-            <div>
-              <p className="font-heading text-xl font-semibold text-atlas-text">
-                Add a Creator Voice
-              </p>
-              <p className="mt-1 text-sm text-atlas-text-secondary">
-                Pick a creator from your follows and shape their voice style.
-              </p>
-            </div>
-          </button>
+          {references.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setEditorMode("create")}
+              className="mt-6 flex w-full flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-glass-border bg-atlas-surface/30 px-6 py-10 text-center transition-colors hover:border-atlas-teal/40 hover:bg-atlas-surface/50"
+            >
+              <span className="flex h-12 w-12 items-center justify-center rounded-full border border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal">
+                <Plus className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div>
+                <p className="font-heading text-xl font-semibold text-atlas-text">
+                  Create a Blend
+                </p>
+                <p className="mt-1 text-sm text-atlas-text-secondary">
+                  Mix your inspirations into a custom voice for crafting.
+                </p>
+              </div>
+            </button>
+          )}
         </section>
-
-        <div className="mt-10 pb-24" data-tour="reference-voices">
-          <ReferenceVoicesSection
-            references={references}
-            onReferencesChange={setReferences}
-          />
-        </div>
+        </div>{/* end blends wrapper */}
 
         <VoiceEditorModal
           isOpen={editorMode !== null}

--- a/src/components/crafting/CraftingAdvisor.tsx
+++ b/src/components/crafting/CraftingAdvisor.tsx
@@ -12,6 +12,7 @@ interface CraftingAdvisorProps {
   sourceType: string;
   blendId?: string;
   pageCount?: number;
+  isCalibrationBlocked?: boolean;
   onDraftsGenerated: (drafts: TweetDraft[]) => void;
   onClose: () => void;
 }
@@ -21,6 +22,7 @@ export function CraftingAdvisor({
   sourceType,
   blendId,
   pageCount,
+  isCalibrationBlocked = false,
   onDraftsGenerated,
   onClose,
 }: CraftingAdvisorProps) {
@@ -29,7 +31,8 @@ export function CraftingAdvisor({
   const [showCustomInput, setShowCustomInput] = useState(false);
 
   const selectedCount = advisor.selectedAngleIds.size;
-  const canGenerate = selectedCount > 0 && advisor.phase === 'presenting';
+  const canGenerate =
+    selectedCount > 0 && advisor.phase === 'presenting' && !isCalibrationBlocked;
 
   // Auto-start analysis on mount
   useEffect(() => {
@@ -40,6 +43,7 @@ export function CraftingAdvisor({
   }, []);
 
   const handleGenerate = async () => {
+    if (isCalibrationBlocked) return;
     await advisor.generateSelected(sourceContent, sourceType, blendId);
     // drafts are passed up via the complete-state useEffect below
   };
@@ -189,6 +193,12 @@ export function CraftingAdvisor({
               </p>
             )}
 
+            {isCalibrationBlocked && (
+              <p className="text-xs text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2">
+                Calibrate your voice first in Voice Studio before generating drafts.
+              </p>
+            )}
+
             {/* Generate button */}
             <button
               onClick={handleGenerate}
@@ -201,7 +211,9 @@ export function CraftingAdvisor({
                 }
               `}
             >
-              {selectedCount === 0
+              {isCalibrationBlocked
+                ? 'Calibrate voice to generate'
+                : selectedCount === 0
                 ? 'Select at least one angle'
                 : `Generate ${selectedCount} draft${selectedCount !== 1 ? 's' : ''}`}
             </button>

--- a/src/components/voice-profiles/VoiceCard.tsx
+++ b/src/components/voice-profiles/VoiceCard.tsx
@@ -108,8 +108,6 @@ export default function VoiceCard({
         : "border-glass-border bg-glass/50 backdrop-blur-xl hover:border-atlas-teal/40",
   ].join(" ");
 
-  void showDetails; // reserved for future use
-
   return (
     <div className={containerClass}>
       {/* Invisible overlay button for card selection — avoids nested-interactive a11y violation */}
@@ -144,23 +142,34 @@ export default function VoiceCard({
 
       <p className="relative z-10 mt-2 truncate font-heading text-sm font-semibold text-atlas-text">{name}</p>
 
-      <div className="relative z-10 mt-3 min-h-[1.75rem]">
-        {recipePills.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5">
-            {recipePills.map((pill) => (
-              <span
-                key={pill.key}
-                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${pill.pillClass}`}
-              >
-                <span className="text-atlas-text-secondary">{pill.label}:</span>
-                <span className="ml-1">{pill.qualifier}</span>
+      <div className="relative z-10 mt-3">
+        <button
+          type="button"
+          onClick={() => setShowDetails((v) => !v)}
+          className="text-[10px] text-atlas-text-muted hover:text-atlas-text-secondary transition-colors"
+        >
+          {showDetails ? "Hide details ▴" : "Show details ▾"}
+        </button>
+        {showDetails && (
+          <div className="mt-2 min-h-[1.75rem]">
+            {recipePills.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {recipePills.map((pill) => (
+                  <span
+                    key={pill.key}
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${pill.pillClass}`}
+                  >
+                    <span className="text-atlas-text-secondary">{pill.label}:</span>
+                    <span className="ml-1">{pill.qualifier}</span>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="inline-flex rounded-full border border-dashed border-glass-border px-2 py-0.5 text-[10px] text-atlas-text-muted">
+                No profile yet
               </span>
-            ))}
+            )}
           </div>
-        ) : (
-          <span className="inline-flex rounded-full border border-dashed border-glass-border px-2 py-0.5 text-[10px] text-atlas-text-muted">
-            No profile yet
-          </span>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
Three Wednesday-demo changes bundled into one PR (same area — Voice Lab + Crafting):

**1. Voice Labs seeds model — inspirations first** (commit `fe536d7`)
- Moves ReferenceVoicesSection (Inspirations) to the **top** of `/voice-profiles` — users seed their voice before seeing blends
- Renames "Your Saved Voices" → **"Your Blends"** with updated description
- Gates "Create a Blend" CTA on having ≥1 inspiration added
- Removes duplicate ReferenceVoicesSection from the bottom
- `VoiceCard`: dimension pills now hidden behind "Show details ▾" toggle (cleaner default state)

**2. Crafting Advisor respects calibration gate** (commit `940304b`) — CRITICAL
- `CraftingAdvisor` previously rendered a Generate button that ignored `isVoiceCalibrationBlocked`, so uncalibrated users could still mint drafts from the advisor panel while the main "Generate Draft" button was correctly blocked.
- Threads the flag through as a new `isCalibrationBlocked` prop, disables `canGenerate` + `handleGenerate` when set, adds an amber calibration banner, and updates the button label to "Calibrate voice to generate".
- `crafting/page.tsx` passes `isVoiceCalibrationBlocked` at the render site.

**3. Voice comparison preview on Voice Lab** (commit `940304b`) — nice-to-have
- New "Preview in my voice" section on `/voice-profiles` generates the same hardcoded sample tweet twice via `api.drafts.generate` — once in the user's current voice, once with a selected saved blend — and displays them side-by-side.
- Reuses the `Promise.all` pattern from `handleCompareVoices` in `crafting/page.tsx`.
- Demo-scoped: one sample, inline panel, no plumbing into child components.

## Neil / Anil feedback addressed
> "It's scaring the hose with all those calibrations... it should be as simple as: who are you inspired by? Add a seed — boom that's the Hussey voice. Blends should be secondary, not front and center."

Plus the advisor-bypass gap flagged during Anil-demo QA.

## Test plan
- [ ] `npm run build` — passes with no new TS errors (verified locally — 36 static pages).
- [ ] Load `/voice-profiles` with zero inspirations — Inspirations section at top, no blends section below.
- [ ] Add one inspiration — blends section appears, "Create a Blend" CTA appears.
- [ ] VoiceCard: dimension pills hidden by default; click "Show details ▾" to reveal.
- [ ] On `/crafting` with an uncalibrated user: open "Craft with Atlas" advisor — Generate button shows "Calibrate voice to generate" and the amber banner is visible; click does nothing.
- [ ] On `/crafting` with a calibrated user: advisor still generates drafts normally.
- [ ] On `/voice-profiles` with ≥1 saved blend: pick a blend, click "Preview in my voice" — two draft generations return and render side-by-side.
- [ ] On `/voice-profiles` with no blends: preview button disabled, select shows "No blends yet".
- [ ] Regression: crafting station still works with existing blends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)