### PR TITLE
fix(nav): rename Voices → Voice Lab in nav + command palette

### DIFF
--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -115,7 +115,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     { id: "crafting", label: "Crafting Station", description: "Draft & generate tweets", icon: PenTool, action: () => navigate("/crafting"), keywords: "tweet draft write" },
     { id: "alerts", label: "Alerts + Momentum", description: "Live alerts feed", icon: Bell, action: () => navigate("/alerts"), keywords: "notifications feed trending" },
     { id: "analytics", label: "Analytics", description: "Performance metrics", icon: BarChart3, action: () => navigate("/analytics"), keywords: "stats data chart" },
-    { id: "voice-profiles", label: "Voice Profiles", description: "Manage your tone", icon: Mic2, action: () => navigate("/voice-profiles"), keywords: "voice tone blend" },
+    { id: "voice-profiles", label: "Voice Lab", description: "Your voice dimensions, blends & inspiration", icon: Mic2, action: () => navigate("/voice-profiles"), keywords: "voice tone blend lab calibration" },
     { id: "team-library", label: "Team Library", description: "Approved style cards", icon: BookOpen, action: () => navigate("/team-library"), keywords: "library styles" },
     { id: "management", label: "Team Management", description: "Manage analysts", icon: Users, action: () => navigate("/management"), keywords: "team kpi leaderboard" },
     { id: "telegram", label: "Telegram Setup", description: "Bot configuration guide", icon: Send, action: () => navigate("/telegram"), keywords: "bot notifications" },

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -40,7 +40,7 @@ export const navLinks = [
   { label: "Feed", href: "/feed", icon: Rss },
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Crafting", href: "/crafting", icon: PenTool },
-  { label: "Voices", href: "/voice-profiles", icon: Mic2 },
+  { label: "Voice Lab", href: "/voice-profiles", icon: Mic2 },
   { label: "Analytics", href: "/analytics", icon: BarChart3 },
   { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Signals", href: "/alerts", icon: Zap },


### PR DESCRIPTION
Renames the nav tab and command palette entry from "Voices" / "Voice Profiles" to "Voice Lab" to match DM-323 decision.

**Changes:**
- `NavBar.tsx` line 43: `"Voices"` → `"Voice Lab"`
- `CommandPalette.tsx` line 118: `"Voice Profiles"` → `"Voice Lab"`, updated description + keywords

**Why:** Anil's decision matrix DM-323 calls it "Voice Lab". The nav was still showing the old label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)