### PR TITLE
Voice Lab: seeds model, onboarding simplification, draft quality improvements (Neil feedback)

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -110,6 +110,7 @@ export default function VoiceProfilesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dismissedSetupPrompt, setDismissedSetupPrompt] = useState(false);
+  const [dismissedRecalibrateNudge, setDismissedRecalibrateNudge] = useState(false);
   const [showCalibrationInput, setShowCalibrationInput] = useState(false);
   const [previewingBlendId, setPreviewingBlendId] = useState<string | null>(null);
   const [blendPreviewErrors, setBlendPreviewErrors] = useState<
@@ -551,6 +552,38 @@ export default function VoiceProfilesPage() {
             >
               ✕
             </button>
+          </div>
+        )}
+
+        {profile && !profile.analysis && !dismissedRecalibrateNudge && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-6 flex items-start justify-between rounded-xl border border-atlas-teal/20 bg-atlas-teal/10 px-4 py-3 text-sm"
+          >
+            <div>
+              <p className="font-semibold text-atlas-teal">Improve your voice quality</p>
+              <p className="mt-1 text-atlas-text-secondary">
+                Re-calibrate your voice to unlock better draft quality — takes about 30 seconds.
+              </p>
+            </div>
+            <div className="ml-3 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setShowCalibrationInput(true)}
+                className="rounded-lg border border-atlas-teal/30 bg-atlas-teal/15 px-3 py-1.5 text-xs font-semibold text-atlas-teal transition-colors hover:bg-atlas-teal/25"
+              >
+                Re-calibrate
+              </button>
+              <button
+                type="button"
+                onClick={() => setDismissedRecalibrateNudge(true)}
+                aria-label="Dismiss calibration nudge"
+                className="text-atlas-text-secondary hover:text-atlas-text"
+              >
+                ✕
+              </button>
+            </div>
           </div>
         )}
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -783,6 +783,7 @@ export interface VoiceProfile {
   selfPromotionalIntensity?: number;
   maturity: "BEGINNER" | "INTERMEDIATE" | "ADVANCED";
   tweetsAnalyzed: number;
+  analysis?: string | null;
 }
 
 export interface CalibrationResult {


### PR DESCRIPTION
## Summary

Full implementation of Neil's feedback from testing session:

**Voice Lab → Seeds Model**
- Inspirations section moved to top of page (before blends)
- Heading: "Reference voices" → "Inspirations"
- "Create a Blend" gated on having ≥1 inspiration
- VoiceCard dimension pills hidden behind "Show details" toggle (not default view)
- Re-calibrate nudge shown to existing users missing `analysis` field

**Onboarding Simplification**
- BLEND step removed from Oracle onboarding flow
- Minimum reference picks reduced from 2 → 1
- Oracle messages updated to "Add inspiration" language

**Draft Quality**
- Calibration analysis text now injected into generation prompts (voice summary layer)
- Extended dimension scale normalization in `fetchBlend` (0-10 stored → 0-100 normalized)
- Blend-not-found warning surfaced in Crafting Station UI with dismissible banner
- `blendWarning` returned from `/generate`, `/regenerate`, `/refine` endpoints

**Nav**
- "Voices" → "Voice Lab" in nav + command palette

## Test plan
- [ ] New user: onboarding completes without BLEND step, one reference pick accepted
- [ ] Voice Lab: page loads with Inspirations at top, Blends section below
- [ ] Existing user with `analysis: null` sees re-calibrate nudge; dismisses cleanly
- [ ] VoiceCard shows name by default; "Show details" expands dimension pills
- [ ] Crafting Station: select a blend → generate → no errors
- [ ] If blend not found, warning banner appears; dismiss removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)