### PR TITLE
fix(campaigns): demo data + crafting→campaign shortcut

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -4,7 +4,7 @@ test.describe("Dashboard", () => {
   test("renders heading and navigation cards", async ({ authedPage: page }) => {
     await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
     await expect(page.getByText("Crafting Station")).toBeVisible();
-    await expect(page.getByText("Voice Lab")).toBeVisible();
+    await expect(page.locator("#main-content").getByRole("link", { name: "Voice Lab" }).first()).toBeVisible();
   });
 
   test("renders stat cards", async ({ authedPage: page }) => {

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Calendar,
   ListOrdered,
@@ -16,7 +17,7 @@ import FeatureGate from "@/components/ui/FeatureGate";
 import GlassCard from "@/components/ui/GlassCard";
 import GradientButton from "@/components/ui/GradientButton";
 import { useAuth } from "@/lib/auth";
-import { api, Campaign } from "@/lib/api";
+import { api, Campaign, TweetDraft } from "@/lib/api";
 
 const STATUS_BADGES: Record<Campaign["status"], { label: string; cls: string }> = {
   DRAFT: { label: "Planning", cls: "bg-atlas-text-muted/20 text-atlas-text-muted" },
@@ -56,6 +57,8 @@ export default function CampaignsPage() {
 }
 
 function CampaignsTab() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { user } = useAuth();
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [loading, setLoading] = useState(true);
@@ -63,6 +66,13 @@ function CampaignsTab() {
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
   const [newThesis, setNewThesis] = useState("");
+  const [prefillDraft, setPrefillDraft] = useState<TweetDraft | null>(null);
+  const [prefillError, setPrefillError] = useState<string | null>(null);
+
+  const seededDraftId = useMemo(
+    () => (searchParams.get("newCampaign") === "true" ? searchParams.get("draftId") : null),
+    [searchParams],
+  );
 
   const load = useCallback(async () => {
     if (!user) return;
@@ -74,11 +84,45 @@ function CampaignsTab() {
 
   useEffect(() => { load(); }, [load]);
 
+  // Handle deep link from Crafting: /campaigns?newCampaign=true&draftId={id}
+  // Opens the create form pre-populated with a suggested name from the draft.
+  useEffect(() => {
+    if (!user || !seededDraftId) return;
+    let cancelled = false;
+    setShowCreate(true);
+    (async () => {
+      try {
+        const { draft } = await api.drafts.get(seededDraftId);
+        if (cancelled) return;
+        setPrefillDraft(draft);
+        // Seed the campaign name from the first line / first 48 chars of the draft
+        const firstLine = (draft.content || "").split("\n")[0]?.trim() ?? "";
+        const suggested = firstLine.length > 48
+          ? `${firstLine.slice(0, 48)}…`
+          : firstLine || "New Campaign";
+        setNewName((prev) => prev || suggested);
+      } catch {
+        if (!cancelled) {
+          setPrefillError("Couldn't load that draft, but you can still create the campaign.");
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [seededDraftId, user]);
+
   const handleCreate = async () => {
     if (!newName.trim()) return;
     setCreating(true);
     try {
       const { campaign } = await api.campaigns.create(newName.trim(), newThesis.trim() || undefined);
+      // If this create came from the crafting deep-link, attach the draft.
+      if (seededDraftId) {
+        try {
+          await api.campaigns.addDraft(campaign.id, seededDraftId, 1);
+        } catch { /* non-fatal — campaign still exists */ }
+        router.push(`/campaigns/${campaign.id}`);
+        return;
+      }
       setCampaigns((prev) => [campaign, ...prev]);
       setNewName("");
       setNewThesis("");
@@ -114,7 +158,25 @@ function CampaignsTab() {
 
       {showCreate && (
         <GlassCard className="mb-6 p-5">
-          <h3 className="mb-3 text-sm font-semibold text-atlas-text">Define your campaign</h3>
+          <h3 className="mb-3 text-sm font-semibold text-atlas-text">
+            {seededDraftId ? "New campaign from this draft" : "Define your campaign"}
+          </h3>
+          {seededDraftId && (
+            <div className="mb-3 rounded-lg border border-atlas-teal/30 bg-atlas-teal/5 p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-atlas-teal">
+                Linked draft
+              </p>
+              {prefillDraft ? (
+                <p className="mt-1 line-clamp-3 text-xs text-atlas-text-secondary">
+                  {prefillDraft.content}
+                </p>
+              ) : prefillError ? (
+                <p className="mt-1 text-xs text-atlas-warning">{prefillError}</p>
+              ) : (
+                <p className="mt-1 text-xs text-atlas-text-muted">Loading draft…</p>
+              )}
+            </div>
+          )}
           <input
             type="text"
             value={newName}
@@ -130,7 +192,11 @@ function CampaignsTab() {
             className="mb-3 w-full rounded-lg border border-glass-border bg-atlas-surface px-3 py-2 text-sm text-atlas-text placeholder:text-atlas-text-muted focus:border-atlas-teal focus:outline-none"
           />
           <GradientButton onClick={handleCreate} disabled={!newName.trim() || creating} fullWidth>
-            {creating ? "Creating…" : "Create Campaign"}
+            {creating
+              ? "Creating…"
+              : seededDraftId
+                ? "Create Campaign & Attach Draft"
+                : "Create Campaign"}
           </GradientButton>
         </GlassCard>
       )}

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -17,6 +17,7 @@ import {
   Clipboard,
   Link2,
   Loader2,
+  Megaphone,
   Mic,
   RefreshCw,
   Sparkles,
@@ -24,7 +25,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/layout/AppShell";
 import { useTour } from "@/components/tour/TourProvider";
 import FeatureGate from "@/components/ui/FeatureGate";
@@ -237,6 +238,7 @@ function buildVoiceVariationInstruction(
 function CraftingPage() {
   useTour("crafting");
 
+  const router = useRouter();
   const searchParams = useSearchParams();
   const voiceModeLabelId = useId();
   const savedBlendLabelId = useId();
@@ -1960,6 +1962,19 @@ function CraftingPage() {
                         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                       </svg>
                       Post to X
+                    </button>
+                  ) : null}
+                  {activeDraft.status === "APPROVED" || activeDraft.status === "DRAFT" ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        router.push(`/campaigns?newCampaign=true&draftId=${activeDraft.id}`)
+                      }
+                      title="Add this draft to a new campaign"
+                      className="flex items-center gap-1.5 rounded-lg border border-glass-border bg-atlas-surface px-3 py-1.5 text-xs font-medium text-atlas-text transition-colors hover:border-atlas-teal/50 hover:text-atlas-teal"
+                    >
+                      <Megaphone className="h-3.5 w-3.5" aria-hidden="true" />
+                      Add to Campaign
                     </button>
                   ) : null}
                   <button

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -99,6 +99,192 @@ const drafts: { drafts: TweetDraft[] } = {
   ],
 };
 
+// ── Campaigns ────────────────────────────────────────────────────────────────
+
+type DemoCampaign = {
+  id: string;
+  name: string;
+  description: string;
+  status: "DRAFT" | "ACTIVE" | "PAUSED" | "COMPLETED";
+  draftCount: number;
+  createdAt: string;
+  drafts: TweetDraft[];
+};
+
+const demoCampaigns: DemoCampaign[] = [
+  {
+    id: "camp-1",
+    name: "Modular Rollups Report",
+    description:
+      "Report-sourced campaign from Delphi's modular rollups quarterly note — drives the shared sequencer narrative with supporting trending commentary.",
+    status: "ACTIVE",
+    draftCount: 4,
+    createdAt: daysAgo(7),
+    drafts: [
+      {
+        id: "camp-1-draft-1",
+        content:
+          "Blob fees just cratered 40% and CT is calling it bearish. It's the opposite — L2 calldata compression is the modular thesis playing out in real-time. Cheaper infra is the adoption signal nobody's pricing in.",
+        version: 1,
+        status: "POSTED",
+        confidence: 0.91,
+        predictedEngagement: 4200,
+        actualEngagement: 5380,
+        sourceType: "REPORT",
+        createdAt: daysAgo(6),
+      },
+      {
+        id: "camp-1-draft-2",
+        content:
+          "Shared sequencers aren't a scaling upgrade. They're an alignment mechanism. When rollups share ordering, they stop competing for MEV and start compounding liquidity. That's the real unlock.",
+        version: 2,
+        status: "APPROVED",
+        confidence: 0.87,
+        predictedEngagement: 3600,
+        sourceType: "REPORT",
+        createdAt: daysAgo(5),
+      },
+      {
+        id: "camp-1-draft-3",
+        content:
+          "Hot take: EigenDA + Celestia + Avail aren't competing for the same market. They're each optimizing for a different failure mode. The winning rollup stack will run all three in parallel.",
+        version: 1,
+        status: "APPROVED",
+        confidence: 0.82,
+        predictedEngagement: 2900,
+        sourceType: "REPORT",
+        createdAt: daysAgo(4),
+      },
+      {
+        id: "camp-1-draft-4",
+        content:
+          "Three metrics that actually matter for modular L2s: blob fee efficiency, sequencer uptime, and cross-rollup message latency. Everyone's watching TPS. The data is in the footnotes.",
+        version: 1,
+        status: "DRAFT",
+        confidence: 0.78,
+        predictedEngagement: 2400,
+        sourceType: "REPORT",
+        createdAt: daysAgo(2),
+      },
+    ],
+  },
+  {
+    id: "camp-2",
+    name: "DeFi Market Update",
+    description:
+      "Working campaign for the upcoming DeFi update — stablecoin payments angle plus the restaking thread idea, both still in DRAFT status.",
+    status: "DRAFT",
+    draftCount: 3,
+    createdAt: daysAgo(3),
+    drafts: [
+      {
+        id: "camp-2-draft-1",
+        content:
+          "The carry trade is back — and this time it's denominated in stablecoins. $180B in circulating USDC/USDT is quietly earning 5%+ on T-bills. Banks aren't ready for what happens when that yield flows on-chain.",
+        version: 1,
+        status: "DRAFT",
+        confidence: 0.84,
+        predictedEngagement: 3100,
+        sourceType: "MANUAL",
+        createdAt: daysAgo(3),
+      },
+      {
+        id: "camp-2-draft-2",
+        content:
+          "Restaking is overleveraged. When the same ETH secures 15 AVSs, you're not distributing risk — you're concentrating it with extra steps. The first correlated slashing event will reprice the entire sector.",
+        version: 2,
+        status: "DRAFT",
+        confidence: 0.79,
+        predictedEngagement: 3800,
+        sourceType: "MANUAL",
+        createdAt: daysAgo(2),
+      },
+      {
+        id: "camp-2-draft-3",
+        content:
+          "Intent-based DEXs just crossed $12B in monthly volume. Solvers are competing on price and latency instead of bribes. This is how DeFi finally eats the OTC desks — quietly, then all at once.",
+        version: 1,
+        status: "APPROVED",
+        confidence: 0.88,
+        predictedEngagement: 2700,
+        sourceType: "MANUAL",
+        createdAt: daysAgo(1),
+      },
+    ],
+  },
+  {
+    id: "camp-3",
+    name: "L2 Fee Wars — March Recap",
+    description:
+      "Weekly recap thread on L2 fee compression. Blob fees, calldata optimization, and rollup economics.",
+    status: "COMPLETED",
+    draftCount: 5,
+    createdAt: daysAgo(10),
+    drafts: [
+      {
+        id: "camp-3-draft-1",
+        content:
+          "March L2 recap 🧵\n\nBlob fees: -42%\nAvg tx cost: -61%\nDaily active addresses: +28%\n\nThe fee wars are doing exactly what competition is supposed to do. Users win, rollups learn.",
+        version: 1,
+        status: "POSTED",
+        confidence: 0.93,
+        predictedEngagement: 4100,
+        actualEngagement: 4820,
+        sourceType: "REPORT",
+        createdAt: daysAgo(9),
+      },
+      {
+        id: "camp-3-draft-2",
+        content:
+          "Base shipped calldata compression and cut costs in half overnight. Arbitrum followed within 48 hours. Optimism is next. This isn't a race to zero — it's a race to the bottom of the cost curve where only infra matters.",
+        version: 1,
+        status: "POSTED",
+        confidence: 0.89,
+        predictedEngagement: 3400,
+        actualEngagement: 3920,
+        sourceType: "REPORT",
+        createdAt: daysAgo(8),
+      },
+      {
+        id: "camp-3-draft-3",
+        content:
+          "SOL reclaimed the 200d MA and nobody's talking about it. Last three times this happened: +34%, +51%, +72% over the following 90 days. The setup rhymes — just with quieter attention.",
+        version: 2,
+        status: "POSTED",
+        confidence: 0.86,
+        predictedEngagement: 3900,
+        actualEngagement: 4450,
+        sourceType: "MANUAL",
+        createdAt: daysAgo(7),
+      },
+      {
+        id: "camp-3-draft-4",
+        content:
+          "The most underrated L2 metric right now is sequencer uptime. Everyone's optimizing for fees but the real differentiator over the next cycle will be reliability. Downtime is the new rug.",
+        version: 1,
+        status: "POSTED",
+        confidence: 0.81,
+        predictedEngagement: 2500,
+        actualEngagement: 2980,
+        sourceType: "REPORT",
+        createdAt: daysAgo(6),
+      },
+      {
+        id: "camp-3-draft-5",
+        content:
+          "Closing thought: the modular vs monolithic debate is over. The market already voted — with fee dollars. Look at where the activity went in Q1, not where the arguments did.",
+        version: 1,
+        status: "POSTED",
+        confidence: 0.9,
+        predictedEngagement: 3200,
+        actualEngagement: 3610,
+        sourceType: "REPORT",
+        createdAt: daysAgo(5),
+      },
+    ],
+  },
+];
+
 // ── Voice Profile ────────────────────────────────────────────────────────────
 
 const voiceProfile: { profile: VoiceProfile } = {
@@ -621,32 +807,10 @@ const demoData: Record<string, unknown> = {
 
   "/api/users/team": teamMembers,
   "/api/campaigns": {
-    campaigns: [
-      {
-        id: "camp-1",
-        name: "Modular Rollups Report",
-        description: "Report-sourced campaign from Delphi's modular rollups quarterly note — drives the shared sequencer narrative with supporting trending commentary.",
-        status: "ACTIVE" as const,
-        draftCount: 3,
-        createdAt: daysAgo(7),
-      },
-      {
-        id: "camp-2",
-        name: "DeFi Market Update",
-        description: "Working campaign for the upcoming DeFi update — stablecoin payments angle plus the restaking thread idea, both still in DRAFT status.",
-        status: "DRAFT" as const,
-        draftCount: 2,
-        createdAt: daysAgo(3),
-      },
-      {
-        id: "camp-3",
-        name: "L2 Fee Wars — March Recap",
-        description: "Weekly recap thread on L2 fee compression. Blob fees, calldata optimization, and rollup economics.",
-        status: "COMPLETED" as const,
-        draftCount: 6,
-        createdAt: daysAgo(10),
-      },
-    ],
+    campaigns: demoCampaigns.map(({ drafts: campaignDrafts, ...rest }) => ({
+      ...rest,
+      draftCount: campaignDrafts.length,
+    })),
   },
 
   "/api/briefing/history": {
@@ -721,6 +885,74 @@ export function getDemoResponse(path: string, method: string = "GET", body?: unk
     if (cleanPath !== "/api/drafts/team") {
       return { draft: drafts.drafts[0] };
     }
+  }
+
+  // Campaign detail — return full campaign with drafts populated
+  if (method === "GET" && /^\/api\/campaigns\/[^/]+$/.test(cleanPath)) {
+    const id = cleanPath.split("/").pop() as string;
+    const match = demoCampaigns.find((c) => c.id === id);
+    if (match) {
+      return { campaign: match };
+    }
+    // Unknown id (e.g. freshly created in-session) — return a minimal shell
+    // with the first demo draft so the page renders something useful.
+    return {
+      campaign: {
+        id,
+        name: "New Campaign",
+        description: "Campaign created in demo mode.",
+        status: "DRAFT" as const,
+        draftCount: 1,
+        drafts: [drafts.drafts[0]],
+        createdAt: now,
+      },
+    };
+  }
+
+  // Campaign create — return a synthetic campaign the UI can route to
+  if (method === "POST" && cleanPath === "/api/campaigns") {
+    const payload = (body ?? {}) as { name?: string; description?: string };
+    return {
+      campaign: {
+        id: `camp-demo-${Date.now()}`,
+        name: payload.name || "New Campaign",
+        description: payload.description ?? null,
+        status: "DRAFT" as const,
+        draftCount: 0,
+        drafts: [],
+        createdAt: now,
+      },
+    };
+  }
+
+  // Campaign update
+  if (method === "PATCH" && /^\/api\/campaigns\/[^/]+$/.test(cleanPath)) {
+    const id = cleanPath.split("/").pop() as string;
+    const existing = demoCampaigns.find((c) => c.id === id);
+    const payload = (body ?? {}) as Partial<{
+      name: string;
+      description: string | null;
+      status: DemoCampaign["status"];
+    }>;
+    return {
+      campaign: {
+        id,
+        name: payload.name ?? existing?.name ?? "Campaign",
+        description: payload.description ?? existing?.description ?? null,
+        status: payload.status ?? existing?.status ?? ("DRAFT" as const),
+        draftCount: existing?.draftCount ?? 0,
+        drafts: existing?.drafts ?? [],
+        createdAt: existing?.createdAt ?? now,
+      },
+    };
+  }
+
+  // Campaign add/remove draft
+  if (method === "POST" && /^\/api\/campaigns\/[^/]+\/drafts$/.test(cleanPath)) {
+    return { success: true };
+  }
+  if (method === "DELETE" && /^\/api\/campaigns\/[^/]+\/drafts\/[^/]+$/.test(cleanPath)) {
+    return { success: true };
   }
 
   if (method === "POST" && cleanPath === "/api/drafts/generate") {


### PR DESCRIPTION
## Summary
- **Demo drafts populated**: Campaign detail page no longer shows "No posts" in demo mode. Each of the 3 demo campaigns (Modular Rollups, DeFi Update, L2 Fee Wars) now has 3-5 realistic crypto-analyst tweet drafts with confidence + predicted/actual engagement.
- **Crafting → Campaign shortcut**: Active drafts in Crafting Station (DRAFT/APPROVED states) now have an **Add to Campaign** button. Clicking it deep-links to `/campaigns?newCampaign=true&draftId={id}`, which auto-opens the create form with the draft preview and a suggested name. On save, the draft is attached and the user is routed to the new campaign detail.
- **Demo API handlers**: Added dynamic `GET /api/campaigns/{id}`, synthetic `POST /api/campaigns`, `PATCH /api/campaigns/{id}`, and add/remove draft handlers so the whole wizard flow works offline for the Wednesday all-hands demo.

## Files
- `src/lib/demo-data.ts` — `demoCampaigns` with full drafts + dynamic demo handlers
- `src/app/crafting/page.tsx` — new **Add to Campaign** action button
- `src/app/campaigns/page.tsx` — reads `newCampaign` / `draftId` query params, previews linked draft, attaches on create

## Test plan
- [ ] Enable demo mode, visit `/campaigns` → see 3 campaigns with post counts
- [ ] Click into any campaign → see 3-5 drafts rendered (not the empty state)
- [ ] Campaign Progress card shows engagement totals
- [ ] In `/crafting`, open a DRAFT or APPROVED draft → click **Add to Campaign** → lands on `/campaigns?newCampaign=true&draftId=...` with form pre-opened
- [ ] Linked draft preview is visible; name prefilled from first line
- [ ] Click **Create Campaign & Attach Draft** → lands on `/campaigns/{new-id}` with the draft attached
- [ ] `npm run build` passes (verified locally)