### PR TITLE
staging → main: Voice Lab, PDF fix, management improvements

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -4,7 +4,7 @@ test.describe("Dashboard", () => {
   test("renders heading and navigation cards", async ({ authedPage: page }) => {
     await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
     await expect(page.getByText("Crafting Station")).toBeVisible();
-    await expect(page.getByText("Voice Lab")).toBeVisible();
+    await expect(page.locator("#main-content").getByText("Voice Lab")).toBeVisible();
   });
 
   test("renders stat cards", async ({ authedPage: page }) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -132,6 +132,15 @@ const mockVoiceProfile = { profile: mockUser.voiceProfile };
 const mockAlerts = { alerts: [] };
 const mockSubscriptions = { subscriptions: [] };
 
+const mockArenaLeaderboard = {
+  entries: [
+    { rank: 1, userId: "test-user-1", handle: "testanalyst", displayName: "Test User", tweetsCount: 12, engagementScore: 4800, consistencyScore: 0.9, totalScore: 9.2 },
+    { rank: 2, userId: "u1", handle: "alice", displayName: "Alice", tweetsCount: 10, engagementScore: 3900, consistencyScore: 0.8, totalScore: 7.8 },
+  ],
+  period: "last_30_days",
+  updatedAt: new Date().toISOString(),
+};
+
 function json(route: Route, body: unknown) {
   return route.fulfill({
     status: 200,
@@ -210,6 +219,10 @@ async function stubDataEndpoints(page: Page) {
         return json(route, { accounts: [] });
       case "/api/campaigns":
         return json(route, { campaigns: [] });
+      case "/api/arena/leaderboard":
+        return json(route, mockArenaLeaderboard);
+      case "/api/arena/me":
+        return json(route, { entry: mockArenaLeaderboard.entries[0] ?? null });
       default:
         // Catch-all for any remaining API calls (including briefing, etc.)
         if (route.request().method() === "GET") return json(route, {});
@@ -274,14 +287,6 @@ export const test = base.extend<{ authedPage: Page }>({
 
     await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
     await page.waitForURL("**/dashboard");
-
-    // Seed feature flags so off-by-default features (campaigns, telegram_bot) are enabled in tests
-    await page.evaluate(() => {
-      localStorage.setItem(
-        "atlas-feature-flags",
-        JSON.stringify({ campaigns: true, telegram_bot: true }),
-      );
-    });
 
     await use(page);
   },

--- a/src/app/campaigns/wizard/page.tsx
+++ b/src/app/campaigns/wizard/page.tsx
@@ -46,6 +46,8 @@ const ANGLE_COLORS: Record<string, string> = {
   explainer: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
 };
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://api-production-9bef.up.railway.app";
+
 export default function CampaignWizardPage() {
   const { user } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -76,13 +78,29 @@ export default function CampaignWizardPage() {
       const text = await file.text();
       setContent(text);
     } else if (file.type === "application/pdf" || file.name.endsWith(".pdf")) {
-      // For PDFs, read as text — real PDF parsing happens server-side
-      // but for now we read what we can from the file
-      const text = await file.text();
-      if (text.trim().length > 50) {
-        setContent(text);
-      } else {
+      // Send to backend for proper PDF text extraction
+      try {
+        setStatusText("Extracting PDF text…");
+        const form = new FormData();
+        form.append("file", file);
+        const accessToken = typeof window !== "undefined" ? sessionStorage.getItem("atlas_access_token") : null;
+        const res = await fetch(`${API_URL}/api/upload/extract-text`, {
+          method: "POST",
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+          credentials: "include",
+          body: form,
+        });
+        if (!res.ok) throw new Error("PDF extraction failed");
+        const { text: extracted } = (await res.json()) as { text: string };
+        if (extracted.trim().length > 50) {
+          setContent(extracted);
+        } else {
+          setError("PDF appeared empty. Try pasting the content directly.");
+        }
+      } catch {
         setError("Could not extract text from this PDF. Try pasting the content directly.");
+      } finally {
+        setStatusText("");
       }
     } else {
       const text = await file.text();

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -780,6 +780,7 @@ export default function VoiceProfilesPage() {
                 Compare against
               </label>
               <select
+                aria-label="Compare against a blend"
                 value={previewCompareBlendId ?? ""}
                 onChange={(e) =>
                   setPreviewCompareBlendId(e.target.value || null)

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -110,6 +110,7 @@ export default function VoiceProfilesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dismissedSetupPrompt, setDismissedSetupPrompt] = useState(false);
+  const [dismissedRecalibrateNudge, setDismissedRecalibrateNudge] = useState(false);
   const [showCalibrationInput, setShowCalibrationInput] = useState(false);
   const [previewingBlendId, setPreviewingBlendId] = useState<string | null>(null);
   const [blendPreviewErrors, setBlendPreviewErrors] = useState<
@@ -551,6 +552,38 @@ export default function VoiceProfilesPage() {
             >
               ✕
             </button>
+          </div>
+        )}
+
+        {profile && !profile.analysis && !dismissedRecalibrateNudge && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-6 flex items-start justify-between rounded-xl border border-atlas-teal/20 bg-atlas-teal/10 px-4 py-3 text-sm"
+          >
+            <div>
+              <p className="font-semibold text-atlas-teal">Improve your voice quality</p>
+              <p className="mt-1 text-atlas-text-secondary">
+                Re-calibrate your voice to unlock better draft quality — takes about 30 seconds.
+              </p>
+            </div>
+            <div className="ml-3 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setShowCalibrationInput(true)}
+                className="rounded-lg border border-atlas-teal/30 bg-atlas-teal/15 px-3 py-1.5 text-xs font-semibold text-atlas-teal transition-colors hover:bg-atlas-teal/25"
+              >
+                Re-calibrate
+              </button>
+              <button
+                type="button"
+                onClick={() => setDismissedRecalibrateNudge(true)}
+                aria-label="Dismiss calibration nudge"
+                className="text-atlas-text-secondary hover:text-atlas-text"
+              >
+                ✕
+              </button>
+            </div>
           </div>
         )}
 

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -627,7 +627,7 @@ export default function OracleChat() {
   const actionConfig = getActionZoneConfig();
 
   return (
-    <div className="flex h-screen flex-col bg-gradient-to-b from-atlas-bg via-atlas-nav to-atlas-bg">
+    <div className="flex h-screen flex-col bg-gradient-to-b from-atlas-bg via-atlas-nav to-atlas-bg pt-14">
       <NavBar variant="onboarding" />
 
       {/* Header */}

--- a/src/components/oracle/FloatingOracle.tsx
+++ b/src/components/oracle/FloatingOracle.tsx
@@ -63,6 +63,13 @@ export default function FloatingOracle() {
     }
   }, [isOpen]);
 
+  // Wire Cmd+K "Open Oracle" command palette action
+  useEffect(() => {
+    const handleOracleOpen = () => setIsOpen(true);
+    window.addEventListener("oracle:open", handleOracleOpen);
+    return () => window.removeEventListener("oracle:open", handleOracleOpen);
+  }, []);
+
   const handleSend = useCallback(() => {
     const text = input.trim();
     if (!text || isThinking) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -783,6 +783,7 @@ export interface VoiceProfile {
   selfPromotionalIntensity?: number;
   maturity: "BEGINNER" | "INTERMEDIATE" | "ADVANCED";
   tweetsAnalyzed: number;
+  analysis?: string | null;
 }
 
 export interface CalibrationResult {


### PR DESCRIPTION
## Summary
- Voice Lab layout: inspirations-first, calibration gate, voice comparison preview
- Renamed "Voices" → "Voice Lab" in nav + command palette (DM-323)
- Campaign wizard: fix PDF extraction — use sessionStorage token instead of missing `token` field on AuthState
- Management: descriptive success/error toast messages on all 3 action buttons
- Crafting: surface blend warning when selected blend not found
- Voice Lab: nudge existing users to re-calibrate when analysis is missing
- Tests: updated to match renamed labels and new toast messages

## Test plan
- [ ] Voice Lab loads with calibration gate if no voice profile
- [ ] Uploading a PDF in campaign wizard extracts text (no TS errors)
- [ ] Management push buttons show correct toast messages
- [ ] NavBar shows "Voice Lab" not "Voices"
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)