### PR TITLE
fix(a11y): add aria-label to voice comparison select

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -780,6 +780,7 @@ export default function VoiceProfilesPage() {
                 Compare against
               </label>
               <select
+                aria-label="Compare against a blend"
                 value={previewCompareBlendId ?? ""}
                 onChange={(e) =>
                   setPreviewCompareBlendId(e.target.value || null)


### PR DESCRIPTION
## Summary
- Adds `aria-label="Compare against a blend"` to the `<select>` in the voice preview comparison section on `/voice-profiles`
- Fixes `[critical] select-name` axe-core violation introduced by PR #249 (the `<label>Compare against</label>` sibling was not linked via `htmlFor`/`id`)

## Test plan
- [ ] CI a11y job passes on the preview URL
- [ ] No regression in voice comparison preview functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)