### PR TITLE
feat: voice lab refinements + onboarding + oracle e2e tests

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -67,8 +67,12 @@ test.describe("Onboarding — X-first flow", () => {
   test("X-connect step appears first — before voice calibration", async ({ page }) => {
     await page.goto("/onboarding", { waitUntil: "domcontentloaded" });
 
-    // "Connect your X account" button should appear at the CONNECT_X step,
-    // which is the first real step after the WELCOME message drains.
+    // WELCOME step drains first — must click "Let's go" to advance to CONNECT_X.
+    const letsGo = page.getByRole("button", { name: /Let's go/i });
+    await expect(letsGo).toBeVisible({ timeout: 12000 });
+    await letsGo.click();
+
+    // "Connect your X account" button should appear at the CONNECT_X step.
     await expect(
       page.getByRole("button", { name: /Connect your X account/i }),
     ).toBeVisible({ timeout: 8000 });
@@ -81,6 +85,11 @@ test.describe("Onboarding — X-first flow", () => {
 
   test("skip path proceeds without X connection", async ({ page }) => {
     await page.goto("/onboarding", { waitUntil: "domcontentloaded" });
+
+    // WELCOME step drains first — must click "Let's go" to advance to CONNECT_X.
+    const letsGo = page.getByRole("button", { name: /Let's go/i });
+    await expect(letsGo).toBeVisible({ timeout: 12000 });
+    await letsGo.click();
 
     // Wait for the Skip for now button (skip-x action)
     const skipButton = page.getByRole("button", { name: /Skip for now/i });

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test, type Route } from "@playwright/test";
+
+// Auth cookies required to bypass middleware on protected routes.
+const AUTH_COOKIES = (hostname: string) => [
+  { name: "atlas_session", value: "1", domain: hostname, path: "/" },
+  { name: "atlas_access_token", value: "1", domain: hostname, path: "/" },
+];
+
+const mockUser = {
+  id: "onboarding-user-1",
+  handle: "",
+  email: "test@example.com",
+  role: "ANALYST" as const,
+  displayName: "Test User",
+  voiceProfile: null,
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubOnboardingApi(page: import("@playwright/test").Page) {
+  await page.route("**/api/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/auth/me")) return json(route, { user: mockUser });
+    if (url.includes("/api/auth/x/authorize"))
+      return json(route, { url: "https://x.com/oauth?mock=1" });
+    if (url.includes("/api/voice/profile"))
+      return json(route, { profile: null });
+    if (url.includes("/api/voice/references"))
+      return json(route, { voices: [] });
+    if (url.includes("/api/voice/blends")) return json(route, { blends: [] });
+    // Catch-all
+    return json(route, {});
+  });
+}
+
+test.describe("Onboarding — X-first flow", () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    const url = new URL(baseURL ?? "http://localhost:3000");
+    await context.addCookies(AUTH_COOKIES(url.hostname));
+
+    // Bypass Vercel deployment protection on preview URLs
+    const bypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    if (bypass) {
+      await context.addCookies([
+        { name: "_vercel_password", value: bypass, domain: url.hostname, path: "/" },
+      ]);
+    }
+
+    await stubOnboardingApi(page);
+  });
+
+  test("renders /onboarding without crashing", async ({ page }) => {
+    await page.goto("/onboarding", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toBeVisible();
+    await expect(page.getByText("Something went wrong", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Page not found", { exact: true })).toHaveCount(0);
+  });
+
+  test("X-connect step appears first — before voice calibration", async ({ page }) => {
+    await page.goto("/onboarding", { waitUntil: "domcontentloaded" });
+
+    // "Connect your X account" button should appear at the CONNECT_X step,
+    // which is the first real step after the WELCOME message drains.
+    await expect(
+      page.getByRole("button", { name: /Connect your X account/i }),
+    ).toBeVisible({ timeout: 8000 });
+
+    // Voice calibration content should NOT be visible yet.
+    await expect(
+      page.getByText(/calibrat/i).first(),
+    ).toHaveCount(0);
+  });
+
+  test("skip path proceeds without X connection", async ({ page }) => {
+    await page.goto("/onboarding", { waitUntil: "domcontentloaded" });
+
+    // Wait for the Skip for now button (skip-x action)
+    const skipButton = page.getByRole("button", { name: /Skip for now/i });
+    await expect(skipButton).toBeVisible({ timeout: 8000 });
+
+    await skipButton.click();
+
+    // After skipping X, should advance to Track B flow — X connect button gone.
+    await expect(
+      page.getByRole("button", { name: /Connect your X account/i }),
+    ).toHaveCount(0, { timeout: 3000 });
+  });
+
+  test("returns from X OAuth with x_connected=true param and advances", async ({ page }) => {
+    // Simulate returning from X OAuth callback
+    await page.goto("/onboarding?x_connected=true&handle=atlasanalyst", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // The X connect button should not appear because xConnected is set to true.
+    await page.waitForTimeout(500);
+    await expect(
+      page.getByRole("button", { name: /Connect your X account/i }),
+    ).toHaveCount(0, { timeout: 3000 });
+  });
+});

--- a/e2e/oracle.spec.ts
+++ b/e2e/oracle.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type Route } from "@playwright/test";
+
+const AUTH_COOKIES = (hostname: string) => [
+  { name: "atlas_session", value: "1", domain: hostname, path: "/" },
+  { name: "atlas_access_token", value: "1", domain: hostname, path: "/" },
+];
+
+const ALL_FLAGS_ENABLED: Record<string, boolean> = {
+  crafting_station: true,
+  voice_lab: true,
+  arena: true,
+  campaigns: true,
+  queue: true,
+  analytics_advanced: true,
+  signals: true,
+  telegram_bot: true,
+  tweet_tinder: true,
+  multi_model: true,
+  super_admin: true,
+  management: true,
+  feed: true,
+  briefing: true,
+  library: true,
+};
+
+const mockUser = {
+  id: "oracle-test-1",
+  handle: "atlasanalyst",
+  email: "atlas@example.com",
+  role: "ADMIN" as const,
+  displayName: "Atlas Analyst",
+  voiceProfile: {
+    id: "voice-1",
+    userId: "oracle-test-1",
+    humor: 58,
+    formality: 46,
+    brevity: 64,
+    contrarianTone: 52,
+    maturity: "INTERMEDIATE" as const,
+    tweetsAnalyzed: 28,
+  },
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubDashboardApi(page: import("@playwright/test").Page) {
+  await page.route("**/api/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/auth/me")) return json(route, { user: mockUser });
+    if (url.includes("/api/voice/profile"))
+      return json(route, { profile: mockUser.voiceProfile });
+    if (url.includes("/api/voice/references"))
+      return json(route, { voices: [] });
+    if (url.includes("/api/voice/blends")) return json(route, { blends: [] });
+    if (url.includes("/api/analytics/summary"))
+      return json(route, { summary: { draftsCreated: 0, draftsPosted: 0, feedbackGiven: 0, refinements: 0, reportsIngested: 0, period: "30d" } });
+    if (url.includes("/api/analytics/learning-log"))
+      return json(route, { entries: [] });
+    if (url.includes("/api/analytics/engagement/daily"))
+      return json(route, { days: [] });
+    if (url.includes("/api/alerts/feed")) return json(route, { alerts: [] });
+    if (url.includes("/api/oracle")) return json(route, { response: "Test oracle response" });
+    return json(route, {});
+  });
+}
+
+test.describe("Oracle widget + Cmd+K", () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    const url = new URL(baseURL ?? "http://localhost:3000");
+    await context.addCookies(AUTH_COOKIES(url.hostname));
+
+    const bypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    if (bypass) {
+      await context.addCookies([
+        { name: "_vercel_password", value: bypass, domain: url.hostname, path: "/" },
+      ]);
+    }
+
+    await context.addInitScript((flags) => {
+      try {
+        window.localStorage.setItem("atlas-feature-flags", JSON.stringify(flags));
+      } catch {
+        // ignore
+      }
+    }, ALL_FLAGS_ENABLED);
+
+    await stubDashboardApi(page);
+    await page.route("https://unavatar.io/**", (route) => route.abort());
+    await page.route("https://pbs.twimg.com/**", (route) => route.abort());
+  });
+
+  test("Oracle widget is visible on /dashboard at bottom-right", async ({ page }) => {
+    await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+
+    // The FloatingOracle renders a button at fixed bottom-right
+    const oracleBtn = page.locator('[aria-label="Open Oracle assistant"]');
+    await expect(oracleBtn).toBeVisible({ timeout: 8000 });
+  });
+
+  test("Cmd+K opens the command palette", async ({ page }) => {
+    await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+
+    // Wait for page to settle
+    await page.waitForTimeout(500);
+
+    // Trigger Cmd+K (Meta+K on Mac, Control+K on others)
+    await page.keyboard.press("Meta+k");
+
+    // Command palette should be visible
+    const palette = page.locator('[role="dialog"]').first();
+    await expect(palette).toBeVisible({ timeout: 3000 });
+  });
+
+  test("typing oracle in command palette surfaces Open Oracle command", async ({ page }) => {
+    await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(500);
+
+    await page.keyboard.press("Meta+k");
+
+    // Type 'oracle' in the search field
+    await page.keyboard.type("oracle");
+
+    // 'Open Oracle' command should appear
+    await expect(
+      page.getByText("Open Oracle", { exact: false }),
+    ).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/e2e/track-b.spec.ts
+++ b/e2e/track-b.spec.ts
@@ -54,7 +54,7 @@ async function stubApi(page: import("@playwright/test").Page) {
     if (url.includes("/api/voice/references"))
       return json(route, { voices: [] });
     if (url.includes("/api/voice/blends")) return json(route, { blends: [] });
-    if (url.includes("/api/voice/accounts"))
+    if (url.includes("/api/voice/reference-accounts"))
       return json(route, { accounts: [] });
     return json(route, {});
   });

--- a/e2e/track-b.spec.ts
+++ b/e2e/track-b.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type Route } from "@playwright/test";
+
+const AUTH_COOKIES = (hostname: string) => [
+  { name: "atlas_session", value: "1", domain: hostname, path: "/" },
+  { name: "atlas_access_token", value: "1", domain: hostname, path: "/" },
+];
+
+const ALL_FLAGS_ENABLED: Record<string, boolean> = {
+  crafting_station: true,
+  voice_lab: true,
+  arena: true,
+  campaigns: true,
+  queue: true,
+  analytics_advanced: true,
+  signals: true,
+  management: true,
+  feed: true,
+  briefing: true,
+  library: true,
+};
+
+const mockUser = {
+  id: "track-b-user-1",
+  handle: "atlasanalyst",
+  email: "atlas@example.com",
+  role: "ANALYST" as const,
+  displayName: "Atlas Analyst",
+  voiceProfile: {
+    id: "voice-1",
+    userId: "track-b-user-1",
+    humor: 58,
+    formality: 46,
+    brevity: 64,
+    contrarianTone: 52,
+    maturity: "INTERMEDIATE" as const,
+    tweetsAnalyzed: 28,
+  },
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubApi(page: import("@playwright/test").Page) {
+  await page.route("**/api/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/auth/me")) return json(route, { user: mockUser });
+    if (url.includes("/api/voice/profile"))
+      return json(route, { profile: mockUser.voiceProfile });
+    if (url.includes("/api/voice/references"))
+      return json(route, { voices: [] });
+    if (url.includes("/api/voice/blends")) return json(route, { blends: [] });
+    if (url.includes("/api/voice/accounts"))
+      return json(route, { accounts: [] });
+    return json(route, {});
+  });
+}
+
+test.describe("Track B — ?prompt=complete-voice-setup redirect", () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    const url = new URL(baseURL ?? "http://localhost:3000");
+    await context.addCookies(AUTH_COOKIES(url.hostname));
+
+    const bypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    if (bypass) {
+      await context.addCookies([
+        { name: "_vercel_password", value: bypass, domain: url.hostname, path: "/" },
+      ]);
+    }
+
+    await context.addInitScript((flags) => {
+      try {
+        window.localStorage.setItem("atlas-feature-flags", JSON.stringify(flags));
+      } catch {
+        // ignore
+      }
+    }, ALL_FLAGS_ENABLED);
+
+    await stubApi(page);
+    await page.route("https://unavatar.io/**", (route) => route.abort());
+  });
+
+  test("?prompt=complete-voice-setup on /voice-profiles shows setup prompt", async ({
+    page,
+  }) => {
+    await page.goto("/voice-profiles?prompt=complete-voice-setup", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // The setup prompt banner should appear
+    await expect(
+      page.getByText("Complete your voice setup"),
+    ).toBeVisible({ timeout: 8000 });
+  });
+
+  test("setup prompt is not shown without the query param", async ({ page }) => {
+    await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
+
+    await page.waitForTimeout(500);
+    await expect(
+      page.getByText("Complete your voice setup"),
+    ).toHaveCount(0);
+  });
+
+  test("setup prompt can be dismissed", async ({ page }) => {
+    await page.goto("/voice-profiles?prompt=complete-voice-setup", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByText("Complete your voice setup"),
+    ).toBeVisible({ timeout: 8000 });
+
+    // Dismiss the prompt
+    const dismissBtn = page.getByLabel("Dismiss voice setup prompt");
+    await expect(dismissBtn).toBeVisible();
+    await dismissBtn.click();
+
+    await expect(
+      page.getByText("Complete your voice setup"),
+    ).toHaveCount(0, { timeout: 3000 });
+  });
+});

--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -86,7 +86,7 @@ async function stubVoiceProfilesApi(page: import("@playwright/test").Page) {
     if (url.includes("/api/voice/references"))
       return json(route, mockVoiceReferences);
     if (url.includes("/api/voice/blends")) return json(route, mockBlends);
-    if (url.includes("/api/voice/accounts"))
+    if (url.includes("/api/voice/reference-accounts"))
       return json(route, { accounts: [] });
     if (url.includes("/api/oracle")) return json(route, { response: "preview text" });
     return json(route, {});

--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Route } from "@playwright/test";
+
+const AUTH_COOKIES = (hostname: string) => [
+  { name: "atlas_session", value: "1", domain: hostname, path: "/" },
+  { name: "atlas_access_token", value: "1", domain: hostname, path: "/" },
+];
+
+const ALL_FLAGS_ENABLED: Record<string, boolean> = {
+  crafting_station: true,
+  voice_lab: true,
+  arena: true,
+  campaigns: true,
+  queue: true,
+  analytics_advanced: true,
+  signals: true,
+  telegram_bot: true,
+  tweet_tinder: true,
+  multi_model: true,
+  super_admin: true,
+  management: true,
+  feed: true,
+  briefing: true,
+  library: true,
+};
+
+const mockUser = {
+  id: "voice-lib-user-1",
+  handle: "atlasanalyst",
+  email: "atlas@example.com",
+  role: "ADMIN" as const,
+  displayName: "Atlas Analyst",
+  voiceProfile: {
+    id: "voice-1",
+    userId: "voice-lib-user-1",
+    humor: 58,
+    formality: 46,
+    brevity: 64,
+    contrarianTone: 52,
+    maturity: "INTERMEDIATE" as const,
+    tweetsAnalyzed: 28,
+  },
+};
+
+const mockBlends = {
+  blends: [
+    {
+      id: "blend-1",
+      name: "Macro Desk",
+      voices: [
+        { label: "My voice", percentage: 60 },
+        { label: "Cobie", percentage: 40 },
+      ],
+    },
+    {
+      id: "blend-2",
+      name: "Research Mode",
+      voices: [
+        { label: "My voice", percentage: 50 },
+        { label: "Hasu", percentage: 50 },
+      ],
+    },
+  ],
+};
+
+const mockVoiceReferences = {
+  voices: [
+    { id: "ref-1", name: "Cobie", handle: "cobie", isActive: true },
+    { id: "ref-2", name: "Hasu", handle: "hasufl", isActive: true },
+  ],
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function stubVoiceProfilesApi(page: import("@playwright/test").Page) {
+  await page.route("**/api/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/auth/me")) return json(route, { user: mockUser });
+    if (url.includes("/api/voice/profile"))
+      return json(route, { profile: mockUser.voiceProfile });
+    if (url.includes("/api/voice/references"))
+      return json(route, mockVoiceReferences);
+    if (url.includes("/api/voice/blends")) return json(route, mockBlends);
+    if (url.includes("/api/voice/accounts"))
+      return json(route, { accounts: [] });
+    if (url.includes("/api/oracle")) return json(route, { response: "preview text" });
+    return json(route, {});
+  });
+}
+
+test.describe("Voice Lab (voice-profiles) — recipe cards + blend UI", () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    const url = new URL(baseURL ?? "http://localhost:3000");
+    await context.addCookies(AUTH_COOKIES(url.hostname));
+
+    const bypass =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+      process.env.VERCEL_PROTECTION_BYPASS;
+    if (bypass) {
+      await context.addCookies([
+        { name: "_vercel_password", value: bypass, domain: url.hostname, path: "/" },
+      ]);
+    }
+
+    await context.addInitScript((flags) => {
+      try {
+        window.localStorage.setItem("atlas-feature-flags", JSON.stringify(flags));
+      } catch {
+        // ignore
+      }
+    }, ALL_FLAGS_ENABLED);
+
+    await stubVoiceProfilesApi(page);
+    await page.route("https://unavatar.io/**", (route) => route.abort());
+  });
+
+  test("renders /voice-profiles without crashing", async ({ page }) => {
+    await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toBeVisible();
+    await expect(page.getByText("Something went wrong", { exact: true })).toHaveCount(0);
+  });
+
+  test("voice recipe cards are visible with blend names", async ({ page }) => {
+    await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
+
+    // Recipe cards for the mock blends should be rendered
+    await expect(page.getByText("Macro Desk")).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText("Research Mode")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("blend pair-select UI appears on /voice-profiles", async ({ page }) => {
+    await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
+
+    // The page renders blend cards showing voice pair percentages
+    await expect(page.getByText("Macro Desk")).toBeVisible({ timeout: 8000 });
+
+    // Each blend shows voice pair labels (My voice + reference)
+    await expect(page.getByText("My voice")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("Voice Lab page is reachable via /voice-lab nav label", async ({ page }) => {
+    await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
+
+    // The nav should show "Voice Lab" (renamed from "Voices")
+    const navVoiceLab = page.getByRole("link", { name: /Voice Lab/i });
+    await expect(navVoiceLab).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ const useLocalWebServer = isLocalBaseURL(baseURL);
 
 export default defineConfig({
   testDir: "./e2e",
-  testMatch: ["smoke.spec.ts", "investor-walkthrough.spec.ts", "demo-mode.spec.ts", "demo-render.spec.ts", "tour.spec.ts", "dashboard.spec.ts"],
+  testMatch: ["smoke.spec.ts", "investor-walkthrough.spec.ts", "demo-mode.spec.ts", "demo-render.spec.ts", "tour.spec.ts", "dashboard.spec.ts", "onboarding.spec.ts", "oracle.spec.ts", "voice-library.spec.ts", "track-b.spec.ts"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Summary

- feat(voice-lab): nudge existing users to re-calibrate when analysis missing
- fix(campaigns): fix TypeScript error — use sessionStorage for auth token in PDF upload  
- fix(a11y): add aria-label to voice comparison select
- test(e2e): fix dashboard Voice Lab locator
- test(onboarding,oracle): **new e2e test coverage** — X-first onboarding (CONNECT_X first step per Anil feedback) and Oracle Cmd+K widget

## Test plan
- [x] Onboarding: CONNECT_X appears before voice calibration
- [x] Onboarding: Skip for now advances without X
- [x] Onboarding: ?x_connected=true param advances flow
- [x] Oracle: widget visible at bottom-right on /dashboard
- [x] Oracle: Cmd+K opens command palette
- [x] Oracle: "oracle" search surfaces Open Oracle command
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)