### PR TITLE
fix(oracle): wire Cmd+K → FloatingOracle via oracle:open event

### DIFF
--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -627,7 +627,7 @@ export default function OracleChat() {
   const actionConfig = getActionZoneConfig();
 
   return (
-    <div className="flex h-screen flex-col bg-gradient-to-b from-atlas-bg via-atlas-nav to-atlas-bg">
+    <div className="flex h-screen flex-col bg-gradient-to-b from-atlas-bg via-atlas-nav to-atlas-bg pt-14">
       <NavBar variant="onboarding" />
 
       {/* Header */}

--- a/src/components/oracle/FloatingOracle.tsx
+++ b/src/components/oracle/FloatingOracle.tsx
@@ -63,6 +63,13 @@ export default function FloatingOracle() {
     }
   }, [isOpen]);
 
+  // Wire Cmd+K "Open Oracle" command palette action
+  useEffect(() => {
+    const handleOracleOpen = () => setIsOpen(true);
+    window.addEventListener("oracle:open", handleOracleOpen);
+    return () => window.removeEventListener("oracle:open", handleOracleOpen);
+  }, []);
+
   const handleSend = useCallback(() => {
     const text = input.trim();
     if (!text || isThinking) return;


### PR DESCRIPTION
The Cmd+K command palette had an "Open Oracle" action that dispatched `oracle:open` — but FloatingOracle never listened for it. Added a 7-line `useEffect` to listen and set `isOpen(true)`.

**Result:** Cmd+K → "Open Oracle" now actually opens the persistent Oracle copilot on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)