### PR TITLE
fix(dashboard): resolve bugs #1, #2, #9, #11

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "./fixtures";
 test.describe("Dashboard", () => {
   test("renders heading and navigation cards", async ({ authedPage: page }) => {
     await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
-    await expect(page.getByText("Crafting Station")).toBeVisible();
+    await expect(page.getByTestId("nav-card-crafting-station")).toBeVisible();
     await expect(page.locator("#main-content").getByText("Voice Lab")).toBeVisible();
   });
 
@@ -23,7 +23,7 @@ test.describe("Dashboard", () => {
   });
 
   test("navigation to crafting works", async ({ authedPage: page }) => {
-    await page.getByText("Crafting Station").click();
+    await page.getByTestId("nav-card-crafting-station").click();
     await page.waitForURL("**/crafting", { waitUntil: "domcontentloaded" });
     await expect(page).toHaveURL(/\/crafting/);
   });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -364,11 +364,12 @@ const searchParams = useSearchParams();
       </Link>
       )}
 
-      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         {visibleNavCards.map((card) => (
           <Link
             key={card.label}
             href={card.href}
+            data-testid={`nav-card-${card.label.toLowerCase().replace(/\s+/g, "-")}`}
             className="card-interactive flex flex-col items-center gap-3 rounded-2xl border border-glass-border bg-atlas-surface p-6 text-center text-atlas-text"
           >
             <card.icon className="w-5 h-5 text-atlas-teal" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Bug #9: Change nav card grid from `lg:grid-cols-4` to `lg:grid-cols-3` to eliminate orphaned card
- Bug #2: Add `data-testid` to dashboard nav card links for strict-mode safe e2e targeting
- Bug #1, #11: Rolled up with the above dashboard fixes
- Updates `e2e/dashboard.spec.ts` to use `getByTestId("nav-card-crafting-station")` instead of brittle text selectors

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] `npx playwright test e2e/dashboard.spec.ts` passes on Vercel preview
- [ ] Visual check: dashboard nav cards render in 3-col grid on lg screens with no orphaned card

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>