### PR TITLE
feat(oracle): persist conversation history across page reloads

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -700,6 +700,7 @@ export const api = {
     agent: (body: {
       messages: Array<{ role: "user" | "oracle"; content: string }>;
       page?: string;
+      sessionId?: string;
       actionResults?: Array<{
         actionId: string;
         type: string;
@@ -719,6 +720,32 @@ export const api = {
         }>;
         serverResults?: Array<{ toolCallId: string; result: unknown }>;
       }>("/api/oracle/agent", { method: "POST", body }),
+
+    /**
+     * Load the authenticated user's persistent Oracle session.
+     * Returns the last DB-persisted session (if any) plus recent messages.
+     * Used by the floating widget to hydrate conversation history on mount.
+     */
+    getSession: () =>
+      request<{
+        sessionId: string;
+        messages: Array<{
+          role: "user" | "assistant";
+          content: string;
+          timestamp: string;
+        }>;
+        context: Record<string, unknown> | null;
+      }>("/api/oracle/session"),
+
+    clearSession: () =>
+      request<{
+        sessionId: string;
+        messages: Array<{
+          role: "user" | "assistant";
+          content: string;
+          timestamp: string;
+        }>;
+      }>("/api/oracle/session", { method: "DELETE" }),
   },
 
   admin: {

--- a/src/lib/oracle-agent.tsx
+++ b/src/lib/oracle-agent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -45,6 +46,117 @@ function msgId() {
   return `msg-${Date.now()}-${++nextId}`;
 }
 
+// ── Persistent session storage ───────────────────────────────────
+// The backend /api/oracle/agent endpoint is currently stateless, so we
+// persist conversation history in localStorage so the floating widget
+// survives page reloads. The sessionId is forwarded to the backend on
+// every call so the server can start persisting per-session state
+// without a frontend change later.
+
+const STORAGE_KEY_MESSAGES = "atlas_oracle_messages";
+const STORAGE_KEY_SESSION = "atlas_oracle_session_id";
+// Keep the transcript bounded — we only need enough context for the
+// user to recognise the thread, and the agent itself slices to the
+// last 20 messages when it calls the backend.
+const MAX_PERSISTED_MESSAGES = 50;
+
+function generateSessionId(): string {
+  // Avoid crypto.randomUUID typings inside SSR — fall back to Date+random.
+  if (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+      ?.randomUUID === "function"
+  ) {
+    try {
+      return (
+        globalThis as { crypto: { randomUUID: () => string } }
+      ).crypto.randomUUID();
+    } catch {
+      /* fall through */
+    }
+  }
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function safeGetLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function loadPersistedMessages(): AgentChatMessage[] {
+  const storage = safeGetLocalStorage();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(STORAGE_KEY_MESSAGES);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Shape-check each entry defensively — localStorage is untrusted.
+    return parsed
+      .filter(
+        (m: unknown): m is AgentChatMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          typeof (m as AgentChatMessage).id === "string" &&
+          typeof (m as AgentChatMessage).text === "string" &&
+          ((m as AgentChatMessage).role === "user" ||
+            (m as AgentChatMessage).role === "oracle") &&
+          typeof (m as AgentChatMessage).timestamp === "number",
+      )
+      // Strip any stale pending actions — confirmation flow cannot
+      // resume across reloads, so we only keep the textual record.
+      .map((m) => ({
+        id: m.id,
+        role: m.role,
+        text: m.text,
+        timestamp: m.timestamp,
+        actionResults: m.actionResults,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function persistMessages(messages: AgentChatMessage[]): void {
+  const storage = safeGetLocalStorage();
+  if (!storage) return;
+  try {
+    const trimmed = messages.slice(-MAX_PERSISTED_MESSAGES);
+    storage.setItem(STORAGE_KEY_MESSAGES, JSON.stringify(trimmed));
+  } catch {
+    /* quota or serialization error — silently skip persistence */
+  }
+}
+
+function loadOrCreateSessionId(): string {
+  const storage = safeGetLocalStorage();
+  if (!storage) return generateSessionId();
+  try {
+    const existing = storage.getItem(STORAGE_KEY_SESSION);
+    if (existing && existing.length > 0) return existing;
+    const fresh = generateSessionId();
+    storage.setItem(STORAGE_KEY_SESSION, fresh);
+    return fresh;
+  } catch {
+    return generateSessionId();
+  }
+}
+
+function clearPersistedSession(): void {
+  const storage = safeGetLocalStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY_MESSAGES);
+    storage.removeItem(STORAGE_KEY_SESSION);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function OracleAgentProvider({
   children,
 }: {
@@ -57,6 +169,26 @@ export function OracleAgentProvider({
   const [pendingActions, setPendingActions] = useState<OracleAgentAction[]>([]);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
+  const sessionIdRef = useRef<string | null>(null);
+  const hydratedRef = useRef(false);
+
+  // Hydrate from localStorage on mount. Any failure silently falls back
+  // to a fresh session so the widget is never blocked on startup.
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    hydratedRef.current = true;
+    sessionIdRef.current = loadOrCreateSessionId();
+    const persisted = loadPersistedMessages();
+    if (persisted.length > 0) {
+      setMessages(persisted);
+    }
+  }, []);
+
+  // Persist messages on every change so a reload loses at most one tick.
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    persistMessages(messages);
+  }, [messages]);
 
   const executeActions = useCallback(
     async (actions: OracleAgentAction[]): Promise<OracleActionResult[]> => {
@@ -102,6 +234,7 @@ export function OracleAgentProvider({
         const res = await api.oracle.agent({
           messages: history,
           page: pathname,
+          sessionId: sessionIdRef.current ?? undefined,
         });
 
         const oracleActions = (res.actions ?? []) as OracleAgentAction[];
@@ -151,6 +284,7 @@ export function OracleAgentProvider({
               const continuation = await api.oracle.agent({
                 messages: continuationHistory,
                 page: pathname,
+                sessionId: sessionIdRef.current ?? undefined,
                 actionResults: results.map((r) => ({
                   actionId: r.actionId,
                   type: r.type,
@@ -225,6 +359,7 @@ export function OracleAgentProvider({
               },
             ],
             page: pathname,
+            sessionId: sessionIdRef.current ?? undefined,
             actionResults: results.map((r) => ({
               actionId: r.actionId,
               type: r.type,
@@ -275,6 +410,10 @@ export function OracleAgentProvider({
     setMessages([]);
     setPendingActions([]);
     setIsThinking(false);
+    clearPersistedSession();
+    // Rotate the session id so the backend treats the next turn as a
+    // brand-new thread instead of continuing the prior one.
+    sessionIdRef.current = loadOrCreateSessionId();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- The floating Oracle widget previously lost all state on page reload because `OracleAgentProvider` stored messages only in React state.
- Conversations now survive reloads via `localStorage`, with a rotating session id forwarded to `/api/oracle/agent` so server-side persistence can be layered in later without a frontend change.
- No UI changes — `FloatingOracle.tsx` is untouched; all work is in `src/lib/oracle-agent.tsx` and `src/lib/api.ts`.

## Changes
- `src/lib/oracle-agent.tsx`
  - Hydrate messages from `localStorage` (`atlas_oracle_messages`) on mount; shape-validate every entry and silently fall back to a fresh session on any parse / quota / SSR error.
  - Persist up to the last 50 messages after every state change.
  - Generate a session id (UUID when `crypto.randomUUID` is available, `sess-{ts}-{rand}` fallback) stored under `atlas_oracle_session_id`; forward it to `api.oracle.agent({ sessionId })` on every call including continuation + confirmation turns.
  - `reset()` now clears `localStorage` and rotates the session id so the next turn starts a brand-new thread.
  - Strip stale `pendingActions` from persisted messages — the confirm-flow cannot resume across reloads, only the textual record does.
- `src/lib/api.ts`
  - `api.oracle.agent` accepts an optional `sessionId` (Zod default on the backend strips unknown keys, so this is a safe, forward-compatible addition).
  - Added `api.oracle.getSession` / `clearSession` helpers for the existing `/api/oracle/session` endpoint so future work can hydrate from the backend session store.

## Why localStorage (not backend hydration)
The backend exposes `GET /api/oracle/session`, but the `/api/oracle/agent` endpoint is currently **stateless** — it never writes to `OracleSession`. Hydrating from the DB would show an empty history for the floating widget's primary flow. localStorage gives an instant fix today; the `sessionId` we now forward lets the backend start persisting agent turns later without a client change.

## Test plan
- [ ] Open the floating Oracle, send a few messages, reload the page — messages should reappear.
- [ ] Confirm a pending action (where applicable), reload — transcript persists, pending confirmation does not.
- [ ] Trigger `reset()` — transcript clears and a new session id is minted (visible in DevTools → Application → Local Storage).
- [ ] Open the widget in a private / incognito window to verify the silent fallback when `localStorage` is disabled.
- [ ] `npx tsc --noEmit` — clean (verified locally).
- [ ] `npx next lint` on touched files — clean (verified locally).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>