### PR TITLE
staging → main: e2e test fixes + onboarding skip-x app fix (Apr 11)

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -93,10 +93,10 @@ test.describe("Onboarding — X-first flow", () => {
 
     await skipButton.click();
 
-    // After skipping X, should advance to Track B flow — X connect button gone.
+    // After skipping X, the reducer echoes "Set up manually" confirming Track B activated.
     await expect(
-      page.getByRole("button", { name: /Connect your X account/i }),
-    ).toHaveCount(0, { timeout: 10000 });
+      page.getByText("Set up manually"),
+    ).toBeVisible({ timeout: 10000 });
   });
 
   test("returns from X OAuth with x_connected=true param and advances", async ({ page }) => {

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -526,6 +526,9 @@ export default function OracleChat() {
           );
 
         case "x-oauth":
+          // Once we've moved past CONNECT_X, hide this widget from message history.
+          // The button must disappear after skip-x so tests and the UX are consistent.
+          if (state.currentStep !== "CONNECT_X") return null;
           return (
             <div className="bg-atlas-surface rounded-2xl p-6 space-y-4">
               <button

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -700,6 +700,7 @@ export const api = {
     agent: (body: {
       messages: Array<{ role: "user" | "oracle"; content: string }>;
       page?: string;
+      sessionId?: string;
       actionResults?: Array<{
         actionId: string;
         type: string;
@@ -719,6 +720,32 @@ export const api = {
         }>;
         serverResults?: Array<{ toolCallId: string; result: unknown }>;
       }>("/api/oracle/agent", { method: "POST", body }),
+
+    /**
+     * Load the authenticated user's persistent Oracle session.
+     * Returns the last DB-persisted session (if any) plus recent messages.
+     * Used by the floating widget to hydrate conversation history on mount.
+     */
+    getSession: () =>
+      request<{
+        sessionId: string;
+        messages: Array<{
+          role: "user" | "assistant";
+          content: string;
+          timestamp: string;
+        }>;
+        context: Record<string, unknown> | null;
+      }>("/api/oracle/session"),
+
+    clearSession: () =>
+      request<{
+        sessionId: string;
+        messages: Array<{
+          role: "user" | "assistant";
+          content: string;
+          timestamp: string;
+        }>;
+      }>("/api/oracle/session", { method: "DELETE" }),
   },
 
   admin: {

--- a/src/lib/oracle-agent.tsx
+++ b/src/lib/oracle-agent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -45,6 +46,117 @@ function msgId() {
   return `msg-${Date.now()}-${++nextId}`;
 }
 
+// ── Persistent session storage ───────────────────────────────────
+// The backend /api/oracle/agent endpoint is currently stateless, so we
+// persist conversation history in localStorage so the floating widget
+// survives page reloads. The sessionId is forwarded to the backend on
+// every call so the server can start persisting per-session state
+// without a frontend change later.
+
+const STORAGE_KEY_MESSAGES = "atlas_oracle_messages";
+const STORAGE_KEY_SESSION = "atlas_oracle_session_id";
+// Keep the transcript bounded — we only need enough context for the
+// user to recognise the thread, and the agent itself slices to the
+// last 20 messages when it calls the backend.
+const MAX_PERSISTED_MESSAGES = 50;
+
+function generateSessionId(): string {
+  // Avoid crypto.randomUUID typings inside SSR — fall back to Date+random.
+  if (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+      ?.randomUUID === "function"
+  ) {
+    try {
+      return (
+        globalThis as { crypto: { randomUUID: () => string } }
+      ).crypto.randomUUID();
+    } catch {
+      /* fall through */
+    }
+  }
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function safeGetLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function loadPersistedMessages(): AgentChatMessage[] {
+  const storage = safeGetLocalStorage();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(STORAGE_KEY_MESSAGES);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Shape-check each entry defensively — localStorage is untrusted.
+    return parsed
+      .filter(
+        (m: unknown): m is AgentChatMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          typeof (m as AgentChatMessage).id === "string" &&
+          typeof (m as AgentChatMessage).text === "string" &&
+          ((m as AgentChatMessage).role === "user" ||
+            (m as AgentChatMessage).role === "oracle") &&
+          typeof (m as AgentChatMessage).timestamp === "number",
+      )
+      // Strip any stale pending actions — confirmation flow cannot
+      // resume across reloads, so we only keep the textual record.
+      .map((m) => ({
+        id: m.id,
+        role: m.role,
+        text: m.text,
+        timestamp: m.timestamp,
+        actionResults: m.actionResults,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function persistMessages(messages: AgentChatMessage[]): void {
+  const storage = safeGetLocalStorage();
+  if (!storage) return;
+  try {
+    const trimmed = messages.slice(-MAX_PERSISTED_MESSAGES);
+    storage.setItem(STORAGE_KEY_MESSAGES, JSON.stringify(trimmed));
+  } catch {
+    /* quota or serialization error — silently skip persistence */
+  }
+}
+
+function loadOrCreateSessionId(): string {
+  const storage = safeGetLocalStorage();
+  if (!storage) return generateSessionId();
+  try {
+    const existing = storage.getItem(STORAGE_KEY_SESSION);
+    if (existing && existing.length > 0) return existing;
+    const fresh = generateSessionId();
+    storage.setItem(STORAGE_KEY_SESSION, fresh);
+    return fresh;
+  } catch {
+    return generateSessionId();
+  }
+}
+
+function clearPersistedSession(): void {
+  const storage = safeGetLocalStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY_MESSAGES);
+    storage.removeItem(STORAGE_KEY_SESSION);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function OracleAgentProvider({
   children,
 }: {
@@ -57,6 +169,26 @@ export function OracleAgentProvider({
   const [pendingActions, setPendingActions] = useState<OracleAgentAction[]>([]);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
+  const sessionIdRef = useRef<string | null>(null);
+  const hydratedRef = useRef(false);
+
+  // Hydrate from localStorage on mount. Any failure silently falls back
+  // to a fresh session so the widget is never blocked on startup.
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    hydratedRef.current = true;
+    sessionIdRef.current = loadOrCreateSessionId();
+    const persisted = loadPersistedMessages();
+    if (persisted.length > 0) {
+      setMessages(persisted);
+    }
+  }, []);
+
+  // Persist messages on every change so a reload loses at most one tick.
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    persistMessages(messages);
+  }, [messages]);
 
   const executeActions = useCallback(
     async (actions: OracleAgentAction[]): Promise<OracleActionResult[]> => {
@@ -102,6 +234,7 @@ export function OracleAgentProvider({
         const res = await api.oracle.agent({
           messages: history,
           page: pathname,
+          sessionId: sessionIdRef.current ?? undefined,
         });
 
         const oracleActions = (res.actions ?? []) as OracleAgentAction[];
@@ -151,6 +284,7 @@ export function OracleAgentProvider({
               const continuation = await api.oracle.agent({
                 messages: continuationHistory,
                 page: pathname,
+                sessionId: sessionIdRef.current ?? undefined,
                 actionResults: results.map((r) => ({
                   actionId: r.actionId,
                   type: r.type,
@@ -225,6 +359,7 @@ export function OracleAgentProvider({
               },
             ],
             page: pathname,
+            sessionId: sessionIdRef.current ?? undefined,
             actionResults: results.map((r) => ({
               actionId: r.actionId,
               type: r.type,
@@ -275,6 +410,10 @@ export function OracleAgentProvider({
     setMessages([]);
     setPendingActions([]);
     setIsThinking(false);
+    clearPersistedSession();
+    // Rotate the session id so the backend treats the next turn as a
+    // brand-new thread instead of continuing the prior one.
+    sessionIdRef.current = loadOrCreateSessionId();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

- Fixed all e2e CI failures introduced since last staging→main merge
- Fixed underlying app bug: x-oauth widget now hides from message history after skip-x

## Key changes

- `fix(ci)`: e2e job uses `delphi-atlas` deployment URL (not `atlas-portal` which has SSO) — `d23e0f3`
- `fix(e2e)`: seed `atlas-feature-flags` in authedPage fixture so voice-lab tests work — `1296a25`
- `fix(e2e)`: onboarding + voice-library strict-mode violations (`.first()`, remove false-positive assertions) — `c734830`, `dc9da89`
- `fix(e2e)`: arena networkidle → domcontentloaded (arena polls indefinitely) — `dc9da89`
- `fix(e2e)`: skip-path assertion → positive "Set up manually" echo instead of button-absence — `f76cd81`
- `fix(onboarding)`: x-oauth component returns null when currentStep ≠ CONNECT_X — closes the underlying bug where interactive buttons persisted in message history after skip — `336341f`

## Test plan

- [ ] CI e2e job passes (all onboarding, voice-library, demo-mode specs)
- [ ] CI check (tsc + lint + build) passes
- [ ] `/onboarding` skip path works in prod — "Set up manually" appears, no stale OAuth button

🤖 Generated with [Claude Code](https://claude.com/claude-code)