### PR TITLE
fix(e2e): fix 4 comprehensive spec failures (X OAuth, voice profiles)

### DIFF
--- a/e2e/comprehensive.spec.ts
+++ b/e2e/comprehensive.spec.ts
@@ -23,12 +23,11 @@ test.describe("Comprehensive Coverage", () => {
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   test.describe("Authentication", () => {
-    test("register new account → form visible on landing page", async ({ page }) => {
+    test("landing page shows X login button", async ({ page }) => {
+      // Atlas uses X OAuth — no email/password form. Just "Continue with X".
       await page.goto("/");
       await expect(page.getByRole("heading", { name: "ATLAS" })).toBeVisible();
-      await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
-      await expect(page.getByPlaceholder("Min 6 characters")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+      await expect(page.getByRole("button", { name: /Continue with X/i })).toBeVisible();
     });
 
     test("login with valid credentials → redirects to dashboard", async ({ page, context }) => {
@@ -45,21 +44,9 @@ test.describe("Comprehensive Coverage", () => {
       await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
     });
 
-    test("login with invalid credentials → shows error", async ({ page }) => {
-      await page.route("**/api/auth/me", (route) =>
-        route.fulfill({ status: 401, contentType: "application/json", body: JSON.stringify({ error: "Unauthorized" }) })
-      );
-      await page.route("**/api/auth/refresh", (route) =>
-        route.fulfill({ status: 401, contentType: "application/json", body: JSON.stringify({ error: "Invalid refresh token" }) })
-      );
-      await page.route("**/api/auth/login", (route) =>
-        route.fulfill({ status: 401, contentType: "application/json", body: JSON.stringify({ error: "Invalid credentials" }) })
-      );
-      await page.goto("/");
-      await page.getByPlaceholder("you@example.com").fill("wrong@email.com");
-      await page.getByPlaceholder("Min 6 characters").fill("badpassword");
-      await page.getByRole("button", { name: "Sign In" }).click();
-      await expect(page.getByText("Invalid credentials")).toBeVisible({ timeout: 8000 });
+    test.skip("login with invalid credentials → shows error", async () => {
+      // Atlas uses X OAuth — no email/password login form exists.
+      // Error handling for failed X OAuth is tested via the /auth/x/callback path.
     });
 
     test.skip("logout → clears session and redirects to login", async () => {

--- a/e2e/comprehensive.spec.ts
+++ b/e2e/comprehensive.spec.ts
@@ -190,21 +190,22 @@ test.describe("Comprehensive Coverage", () => {
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   test.describe("Voice Profiles", () => {
-    test("12 dimension sliders render", async ({ authedPage: page }) => {
+    test("voice studio page renders with heading", async ({ authedPage: page }) => {
+      // Voice profiles page shows "Your Voices" — sliders live inside
+      // the VoiceEditorModal (opened per-recipe), not on the main page.
       await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
       await page.waitForTimeout(1000);
       await expect(page.locator("body")).toBeVisible();
       await expect(page.getByText("Something went wrong", { exact: true })).toHaveCount(0);
-      await expect(page.getByText("Humor").first()).toBeVisible({ timeout: 8000 });
-      await expect(page.getByText("Formality").first()).toBeVisible({ timeout: 5000 });
+      await expect(
+        page.getByText("Your Voices").or(page.getByText("Voice Studio")).first()
+      ).toBeVisible({ timeout: 8000 });
     });
 
-    test("dimension sliders are interactive", async ({ authedPage: page }) => {
-      await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
-      await page.waitForTimeout(1000);
-      const sliders = page.locator('input[type="range"]');
-      const count = await sliders.count();
-      expect(count).toBeGreaterThan(0);
+    test.skip("dimension sliders are interactive", async () => {
+      // Voice dimension sliders live inside VoiceEditorModal (opened per-recipe).
+      // Requires clicking a recipe card to open the modal.
+      // TODO: Add a mock blend to stubDataEndpoints, click recipe card, then verify sliders.
     });
 
     test("reference voices section renders", async ({ authedPage: page }) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -225,8 +225,8 @@ const mockSubscriptions = { subscriptions: [] };
 
 const mockArenaLeaderboard = {
   entries: [
-    { rank: 1, userId: "test-user-1", handle: "testanalyst", displayName: "Test User", tweetsCount: 12, engagementScore: 4800, consistencyScore: 0.9, totalScore: 9.2 },
-    { rank: 2, userId: "u1", handle: "alice", displayName: "Alice", tweetsCount: 10, engagementScore: 3900, consistencyScore: 0.8, totalScore: 7.8 },
+    { rank: 1, userId: "test-user-1", displayName: "Test User", avatarUrl: null, tweetsPublished: 12, totalEngagement: 4800, consistencyStreak: 9, badge: "Top Analyst" },
+    { rank: 2, userId: "u1", displayName: "Alice", avatarUrl: null, tweetsPublished: 10, totalEngagement: 3900, consistencyStreak: 8, badge: null },
   ],
   period: "last_30_days",
   updatedAt: new Date().toISOString(),
@@ -330,7 +330,7 @@ async function stubDataEndpoints(target: RouteTarget) {
       case "/api/arena/leaderboard":
         return json(route, mockArenaLeaderboard);
       case "/api/arena/me":
-        return json(route, { entry: mockArenaLeaderboard.entries[0] ?? null });
+        return json(route, mockArenaLeaderboard.entries[0] ?? null);
       default:
         // Catch-all for any remaining API calls (including briefing, etc.)
         if (route.request().method() === "GET") return json(route, {});


### PR DESCRIPTION
## Summary

- **Auth tests**: Landing page uses X OAuth (`Continue with X` button), not email/password. Updated `register new account` test to check for X button; skipped `login with invalid credentials` test (no email/password form exists)
- **Voice profile tests**: Dimension sliders are inside `VoiceEditorModal` (per-recipe), not on the main page. Updated test to check for `Your Voices` heading; skipped slider-interactive test with TODO
- **Arena stubs**: Aligned `mockArenaLeaderboard` field names with `ArenaLeaderboardEntry` type (`tweetsPublished`, `totalEngagement`, `consistencyStreak`, `badge`, `avatarUrl`); fixed `/api/arena/me` to return flat entry not `{ entry: ... }`

Fixes all 4 `e2e/comprehensive.spec.ts` failures blocking multiple PRs.

## Test plan
- [ ] CI e2e green on this PR
- [ ] CI e2e unblocked on PRs #273, #275, and other branches carrying these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)