### PR TITLE
fix(voice-profiles): role-gate blend controls to MANAGER/ADMIN

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -97,6 +97,10 @@ export default function VoiceProfilesPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useAuth();
+  // Role gate: blend create/edit controls are only available to MANAGER/ADMIN.
+  // ANALYST users can still view recipe cards, preview, and apply blends —
+  // they just can't mutate them.
+  const canManageBlends = user?.role === "MANAGER" || user?.role === "ADMIN";
   const [profile, setProfile] = useState<VoiceProfile | null>(null);
   const [referenceAccounts, setReferenceAccounts] = useState<ReferenceAccount[]>(
     REFERENCE_ACCOUNT_FALLBACK
@@ -629,8 +633,16 @@ export default function VoiceProfilesPage() {
             userHandle={user?.handle}
             onSelect={() => setSelectedVoiceId(PERSONAL_VOICE_ID)}
             onUse={() => handleUseVoice(PERSONAL_VOICE_ID)}
-            onBlend={() => handleBlendSelect(PERSONAL_VOICE_ID)}
-            blendTargetMode={blendSelectMode && blendSourceId !== PERSONAL_VOICE_ID}
+            onBlend={
+              canManageBlends
+                ? () => handleBlendSelect(PERSONAL_VOICE_ID)
+                : undefined
+            }
+            blendTargetMode={
+              canManageBlends &&
+              blendSelectMode &&
+              blendSourceId !== PERSONAL_VOICE_ID
+            }
           />
           {recipeCards.map(({ blend, notableDimensions }) => (
             <VoiceCard
@@ -643,8 +655,12 @@ export default function VoiceProfilesPage() {
               userHandle={user?.handle}
               onSelect={() => setSelectedVoiceId(blend.id)}
               onUse={() => handleUseVoice(blend.id)}
-              onBlend={() => handleBlendSelect(blend.id)}
-              blendTargetMode={blendSelectMode && blendSourceId !== blend.id}
+              onBlend={
+                canManageBlends ? () => handleBlendSelect(blend.id) : undefined
+              }
+              blendTargetMode={
+                canManageBlends && blendSelectMode && blendSourceId !== blend.id
+              }
             />
           ))}
           {blends.length === 0 && references.length > 0 && (
@@ -654,7 +670,7 @@ export default function VoiceProfilesPage() {
               <p className="mt-1 text-[11px] text-atlas-text-muted">Combine inspirations to create your own style</p>
             </div>
           )}
-          {references.length > 0 && (
+          {references.length > 0 && canManageBlends && (
             <button
               type="button"
               onClick={() => setEditorMode("create")}
@@ -719,16 +735,20 @@ export default function VoiceProfilesPage() {
                   previewError={blendPreviewErrors[blend.id]}
                   previewLoading={previewingBlendId === blend.id}
                   previewText={blendPreviews[blend.id]}
-                  onEdit={() => {
-                    setEditorBlendId(blend.id);
-                    setEditorMode("edit-blend");
-                  }}
+                  onEdit={
+                    canManageBlends
+                      ? () => {
+                          setEditorBlendId(blend.id);
+                          setEditorMode("edit-blend");
+                        }
+                      : undefined
+                  }
                 />
               ))}
             </div>
           )}
 
-          {references.length > 0 && (
+          {references.length > 0 && canManageBlends && (
             <button
               type="button"
               onClick={() => setEditorMode("create")}

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -23,7 +23,7 @@ interface RecipeCardProps {
   fingerprintDescription: string;
   notableDimensions: VoiceDimensionSnapshot[];
   isActive: boolean;
-  onEdit: () => void;
+  onEdit?: () => void;
   onPreviewSample: () => void;
   onUse: () => void;
   previewError?: string | null;
@@ -317,14 +317,16 @@ export default function RecipeCard({
           <Sparkles className="h-4 w-4" />
           {isActive ? "Active in Crafting" : "Use in Crafting"}
         </button>
-        <button
-          type="button"
-          onClick={onEdit}
-          className="inline-flex items-center gap-2 rounded-xl border border-glass-border bg-transparent px-4 py-2 text-sm font-semibold text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text"
-        >
-          <PencilLine className="h-4 w-4" />
-          Edit
-        </button>
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="inline-flex items-center gap-2 rounded-xl border border-glass-border bg-transparent px-4 py-2 text-sm font-semibold text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text"
+          >
+            <PencilLine className="h-4 w-4" />
+            Edit
+          </button>
+        )}
       </div>
 
       {previewText || previewError ? (


### PR DESCRIPTION
## Summary
- Hide blend create/edit affordances on Voice Studio from ANALYST users
- ANALYST can still view recipe cards, preview samples, and apply saved blends — they just can't mutate them
- Gate applied via `canManageBlends = user.role === 'MANAGER' || user.role === 'ADMIN'`

## Changes
**`src/app/voice-profiles/page.tsx`**
- Derive `canManageBlends` from `useAuth().user.role`
- Gate the "New Voice" grid button and the large "Create a Blend" card behind `canManageBlends`
- Gate `RecipeCard.onEdit` so the Edit action is only wired for managers
- Pass `onBlend` / `blendTargetMode` as undefined on VoiceCard for non-managers, so the pair-select blend flow is unreachable

**`src/components/voice-profiles/RecipeCard.tsx`**
- Make `onEdit` prop optional
- Skip rendering the Edit button when `onEdit` is undefined

## What did NOT change
- DimensionBar, VoiceDimensionSections, and VoiceEditorModal are untouched — the range-input onChange chain already correctly calls `setDimensions((prev) => ({ ...prev, [field]: value }))` via `Number(event.target.value)`. Sliders update local modal state on drag; persistence in edit-blend mode is still gated by the pre-existing `saveDisabled` lock and the documented API limitation that blend dimensions are derived (not directly mutable).
- No ANALYST-visible surface changed — profile view, recipe cards, Use-this-voice, preview, and the Voice Comparison section all render identically for all roles.

## Test plan
- [ ] Log in as ANALYST → /voice-profiles should show recipe cards + preview + Use in Crafting, but no "New Voice", no "Create a Blend" card, no Edit button on RecipeCards, no Blend action on VoiceCards
- [ ] Log in as MANAGER or ADMIN → all blend controls visible and functional as before
- [ ] Slider drag in VoiceEditorModal (manager) → dimension value updates live

## Build
- `npm run build` → Compiled successfully, 0 TS errors

Note: branch suffix `-46776` is because another session was holding `fix/voice-profiles-blend-sliders`. Functionally equivalent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>