### PR TITLE
fix(voice-profiles): role-gate blend controls to MANAGER/ADMIN

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -97,6 +97,10 @@ export default function VoiceProfilesPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useAuth();
+  // Role gate: blend create/edit controls are only available to MANAGER/ADMIN.
+  // ANALYST users can still view recipe cards, preview, and apply blends —
+  // they just can't mutate them.
+  const canManageBlends = user?.role === "MANAGER" || user?.role === "ADMIN";
   const [profile, setProfile] = useState<VoiceProfile | null>(null);
   const [referenceAccounts, setReferenceAccounts] = useState<ReferenceAccount[]>(
     REFERENCE_ACCOUNT_FALLBACK
@@ -629,8 +633,16 @@ export default function VoiceProfilesPage() {
             userHandle={user?.handle}
             onSelect={() => setSelectedVoiceId(PERSONAL_VOICE_ID)}
             onUse={() => handleUseVoice(PERSONAL_VOICE_ID)}
-            onBlend={() => handleBlendSelect(PERSONAL_VOICE_ID)}
-            blendTargetMode={blendSelectMode && blendSourceId !== PERSONAL_VOICE_ID}
+            onBlend={
+              canManageBlends
+                ? () => handleBlendSelect(PERSONAL_VOICE_ID)
+                : undefined
+            }
+            blendTargetMode={
+              canManageBlends &&
+              blendSelectMode &&
+              blendSourceId !== PERSONAL_VOICE_ID
+            }
           />
           {recipeCards.map(({ blend, notableDimensions }) => (
             <VoiceCard
@@ -643,8 +655,12 @@ export default function VoiceProfilesPage() {
               userHandle={user?.handle}
               onSelect={() => setSelectedVoiceId(blend.id)}
               onUse={() => handleUseVoice(blend.id)}
-              onBlend={() => handleBlendSelect(blend.id)}
-              blendTargetMode={blendSelectMode && blendSourceId !== blend.id}
+              onBlend={
+                canManageBlends ? () => handleBlendSelect(blend.id) : undefined
+              }
+              blendTargetMode={
+                canManageBlends && blendSelectMode && blendSourceId !== blend.id
+              }
             />
           ))}
           {blends.length === 0 && references.length > 0 && (
@@ -654,7 +670,7 @@ export default function VoiceProfilesPage() {
               <p className="mt-1 text-[11px] text-atlas-text-muted">Combine inspirations to create your own style</p>
             </div>
           )}
-          {references.length > 0 && (
+          {references.length > 0 && canManageBlends && (
             <button
               type="button"
               onClick={() => setEditorMode("create")}
@@ -719,16 +735,20 @@ export default function VoiceProfilesPage() {
                   previewError={blendPreviewErrors[blend.id]}
                   previewLoading={previewingBlendId === blend.id}
                   previewText={blendPreviews[blend.id]}
-                  onEdit={() => {
-                    setEditorBlendId(blend.id);
-                    setEditorMode("edit-blend");
-                  }}
+                  onEdit={
+                    canManageBlends
+                      ? () => {
+                          setEditorBlendId(blend.id);
+                          setEditorMode("edit-blend");
+                        }
+                      : undefined
+                  }
                 />
               ))}
             </div>
           )}
 
-          {references.length > 0 && (
+          {references.length > 0 && canManageBlends && (
             <button
               type="button"
               onClick={() => setEditorMode("create")}

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -23,7 +23,7 @@ interface RecipeCardProps {
   fingerprintDescription: string;
   notableDimensions: VoiceDimensionSnapshot[];
   isActive: boolean;
-  onEdit: () => void;
+  onEdit?: () => void;
   onPreviewSample: () => void;
   onUse: () => void;
   previewError?: string | null;
@@ -317,14 +317,16 @@ export default function RecipeCard({
           <Sparkles className="h-4 w-4" />
           {isActive ? "Active in Crafting" : "Use in Crafting"}
         </button>
-        <button
-          type="button"
-          onClick={onEdit}
-          className="inline-flex items-center gap-2 rounded-xl border border-glass-border bg-transparent px-4 py-2 text-sm font-semibold text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text"
-        >
-          <PencilLine className="h-4 w-4" />
-          Edit
-        </button>
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="inline-flex items-center gap-2 rounded-xl border border-glass-border bg-transparent px-4 py-2 text-sm font-semibold text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text"
+          >
+            <PencilLine className="h-4 w-4" />
+            Edit
+          </button>
+        )}
       </div>
 
       {previewText || previewError ? (


### PR DESCRIPTION
## Summary
- Gates blend create/edit affordances behind `canManageBlends = user?.role === "MANAGER" || user?.role === "ADMIN"`
- ANALYST users can still view recipe cards, preview samples, and apply blends — just can't create/edit them
- `RecipeCard.onEdit` made optional; Edit button hidden when no handler provided

Clean rebase of #286 onto current staging (picks up "Voices" NavBar rename from #275).

## Test plan
- [ ] ANALYST user: New Voice button and Create a Blend card are hidden
- [ ] MANAGER user: All blend controls visible
- [ ] Voice profiles page renders without errors for all roles