### PR TITLE
feat(onboarding): differentiate Track A vs Track B UI

### DIFF
--- a/src/__tests__/app/TrackAPage.test.tsx
+++ b/src/__tests__/app/TrackAPage.test.tsx
@@ -1,23 +1,23 @@
 import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
 
-const mockRedirect = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  redirect: (...args: unknown[]) => {
-    mockRedirect(...args);
-    throw new Error("NEXT_REDIRECT");
-  },
+  useRouter: () => ({ replace: mockReplace }),
+  redirect: jest.fn(),
 }));
 
-const TrackAPage = require("@/app/onboarding/track-a/page").default;
+const TrackAStarter = require("@/app/onboarding/track-a/page").default;
 
 describe("TrackARedirect", () => {
   beforeEach(() => {
-    mockRedirect.mockClear();
+    mockReplace.mockClear();
   });
 
-  it("redirects to /onboarding", () => {
-    expect(() => TrackAPage()).toThrow("NEXT_REDIRECT");
-    expect(mockRedirect).toHaveBeenCalledWith("/onboarding");
+  it("renders without crashing and calls router.replace on mount", () => {
+    render(React.createElement(TrackAStarter));
+    expect(mockReplace).toHaveBeenCalledWith("/onboarding");
   });
 });

--- a/src/__tests__/app/TrackBPage.test.tsx
+++ b/src/__tests__/app/TrackBPage.test.tsx
@@ -1,23 +1,23 @@
 import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
 
-const mockRedirect = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  redirect: (...args: unknown[]) => {
-    mockRedirect(...args);
-    throw new Error("NEXT_REDIRECT");
-  },
+  useRouter: () => ({ replace: mockReplace }),
+  redirect: jest.fn(),
 }));
 
-const TrackBPage = require("@/app/onboarding/track-b/page").default;
+const TrackBStarter = require("@/app/onboarding/track-b/page").default;
 
 describe("TrackBRedirect", () => {
   beforeEach(() => {
-    mockRedirect.mockClear();
+    mockReplace.mockClear();
   });
 
-  it("redirects to /onboarding", () => {
-    expect(() => TrackBPage()).toThrow("NEXT_REDIRECT");
-    expect(mockRedirect).toHaveBeenCalledWith("/onboarding");
+  it("renders without crashing and calls router.replace on mount", () => {
+    render(React.createElement(TrackBStarter));
+    expect(mockReplace).toHaveBeenCalledWith("/onboarding");
   });
 });

--- a/src/app/onboarding/track-a/page.tsx
+++ b/src/app/onboarding/track-a/page.tsx
@@ -1,5 +1,25 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function TrackARedirect() {
-  redirect("/onboarding");
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Deep-link entry point for the X-Powered onboarding path. Stores the
+ * pre-selected track in sessionStorage so OracleChat can auto-advance
+ * past the welcome/skip prompt, then redirects to /onboarding where
+ * the chat UI lives.
+ */
+export default function TrackAStarter() {
+  const router = useRouter();
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem("atlas_preselected_track", "a");
+    } catch {
+      /* storage unavailable — OracleChat handles the fallback path */
+    }
+    router.replace("/onboarding");
+  }, [router]);
+
+  return null;
 }

--- a/src/app/onboarding/track-b/page.tsx
+++ b/src/app/onboarding/track-b/page.tsx
@@ -1,5 +1,25 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function TrackBRedirect() {
-  redirect("/onboarding");
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Deep-link entry point for the Hand-Crafted onboarding path. Stores the
+ * pre-selected track in sessionStorage so OracleChat can skip the X-first
+ * prompt and go straight to manual style selection, then redirects to
+ * /onboarding where the chat UI lives.
+ */
+export default function TrackBStarter() {
+  const router = useRouter();
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem("atlas_preselected_track", "b");
+    } catch {
+      /* storage unavailable — OracleChat handles the fallback path */
+    }
+    router.replace("/onboarding");
+  }, [router]);
+
+  return null;
 }

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -7,7 +7,9 @@ import { useAuth } from "@/lib/auth";
 import { api } from "@/lib/api";
 import {
   canAdvance,
+  getContinueLabel,
   getOnboardingCompletionHref,
+  getTrackMeta,
   initialOracleState,
   oracleReducer,
 } from "@/lib/oracle";
@@ -20,6 +22,7 @@ import {
 
 import OracleAvatar from "./OracleAvatar";
 import OracleMessage from "./OracleMessage";
+import TrackBadge from "./TrackBadge";
 import TypingIndicator from "./TypingIndicator";
 import ActionZone from "./ActionZone";
 import NavBar from "@/components/ui/NavBar";
@@ -60,6 +63,27 @@ export default function OracleChat() {
       dispatch({ type: "SET_HANDLE", handle: user.handle.replace(/^@/, "") });
     }
   }, [user?.handle, state.xHandle]);
+
+  // Deep-link pre-select: /onboarding/track-a|track-b stores the chosen
+  // track in sessionStorage before redirecting here. Pick it up on mount
+  // so the chat skips the welcome prompt and enters the right path.
+  useEffect(() => {
+    if (state.track !== null || state.currentStep !== "WELCOME") return;
+    let preselected: string | null = null;
+    try {
+      preselected = sessionStorage.getItem("atlas_preselected_track");
+    } catch {
+      preselected = null;
+    }
+    if (preselected === "a" || preselected === "b") {
+      try {
+        sessionStorage.removeItem("atlas_preselected_track");
+      } catch {
+        /* ignore */
+      }
+      dispatch({ type: "SET_TRACK", track: preselected });
+    }
+  }, [state.track, state.currentStep]);
 
   // Detect OAuth callback return from X
   useEffect(() => {
@@ -600,7 +624,7 @@ export default function OracleChat() {
       return {
         actions: [
           {
-            label: "Continue",
+            label: getContinueLabel(step, state.track),
             value: "continue",
             variant: "primary" as const,
           },
@@ -613,6 +637,7 @@ export default function OracleChat() {
   };
 
   const actionConfig = getActionZoneConfig();
+  const trackMeta = getTrackMeta(state.track);
 
   return (
     <div className="flex h-screen flex-col bg-gradient-to-b from-atlas-bg via-atlas-nav to-atlas-bg pt-14">
@@ -621,12 +646,13 @@ export default function OracleChat() {
       {/* Header */}
       <div className="flex items-center gap-3 px-4 sm:px-6 py-3 border-b border-glass-border bg-atlas-nav/50 backdrop-blur-xl">
         <OracleAvatar size="md" />
-        <div>
+        <div className="flex-1 min-w-0">
           <h1 className="font-heading font-bold text-sm text-atlas-text">
             The Oracle
           </h1>
           <p className="text-xs text-atlas-teal">DELPHI OS</p>
         </div>
+        <TrackBadge meta={trackMeta} />
       </div>
 
       {/* Message list */}

--- a/src/components/onboarding/TrackBadge.tsx
+++ b/src/components/onboarding/TrackBadge.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Sparkles, Brush } from "lucide-react";
+import type { TrackMeta } from "@/lib/oracle";
+
+interface TrackBadgeProps {
+  meta: TrackMeta | null;
+}
+
+/**
+ * Visual track indicator shown in the onboarding header once the user has
+ * picked a path. Human-first: labels describe what the track *does*
+ * ("X-Powered", "Hand-Crafted") rather than exposing letter codes. The
+ * full tagline is surfaced via the native tooltip on hover.
+ */
+export default function TrackBadge({ meta }: TrackBadgeProps) {
+  if (!meta) return null;
+
+  const Icon = meta.iconKey === "sparkles" ? Sparkles : Brush;
+
+  return (
+    <span
+      data-testid="onboarding-track-badge"
+      data-track={meta.id}
+      className={`inline-flex items-center gap-1.5 rounded-full border bg-atlas-surface/60 px-2.5 py-1 text-[11px] font-medium backdrop-blur-sm ${meta.accent}`}
+      title={meta.tagline}
+      aria-label={`Onboarding path: ${meta.label}. ${meta.tagline}`}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span>{meta.label}</span>
+    </span>
+  );
+}

--- a/src/lib/oracle-messages.ts
+++ b/src/lib/oracle-messages.ts
@@ -152,12 +152,69 @@ export const ORACLE_MESSAGES: Record<OracleStep, ChatMessage[]> = {
   ],
 };
 
+/**
+ * Per-track overrides for steps where the Oracle should speak differently
+ * depending on which path the user is on. Track-agnostic steps fall
+ * through to ORACLE_MESSAGES so this map only lists the intentional
+ * divergences. Human-first framing: concrete language about what the
+ * user did and what happens next.
+ */
+const TRACK_MESSAGE_OVERRIDES: Partial<
+  Record<OracleStep, Record<"a" | "b", ChatMessage[]>>
+> = {
+  REFERENCES: {
+    a: [
+      msg(
+        "oracle",
+        "I have your voice from the tweets I scanned. Now pick who you're in conversation with — people whose writing sharpens yours. You can add more later.",
+        {
+          component: { type: "references" },
+        }
+      ),
+    ],
+    b: [
+      msg(
+        "oracle",
+        "Pick a voice you want to grow toward. I'll use their style as a north star when I craft your tweets — you can swap it out anytime.",
+        {
+          component: { type: "references" },
+        }
+      ),
+    ],
+  },
+  HANDOFF: {
+    a: [
+      msg(
+        "oracle",
+        "Your voice is dialed in from real tweets. Time to craft — I'll keep learning from every draft you ship.\n\nI'm the same brain on Telegram. Drop me a report, a link, or a voice note anytime.",
+        {
+          component: { type: "handoff-telegram" },
+        }
+      ),
+    ],
+    b: [
+      msg(
+        "oracle",
+        "Your starter voice is set. We'll sharpen it every time you craft — the more you write, the tighter we get.\n\nI'm the same brain on Telegram. Drop me a report, a link, or a voice note anytime.",
+        {
+          component: { type: "handoff-telegram" },
+        }
+      ),
+    ],
+  },
+};
+
 /** Stamp messages with current time and unique IDs */
-export function prepareMessages(step: OracleStep): ChatMessage[] {
+export function prepareMessages(
+  step: OracleStep,
+  track: "a" | "b" | null = null
+): ChatMessage[] {
   const now = Date.now();
-  return ORACLE_MESSAGES[step].map((m, i) => ({
+  const override = track ? TRACK_MESSAGE_OVERRIDES[step]?.[track] : undefined;
+  const template = override ?? ORACLE_MESSAGES[step];
+  return template.map((m, i) => ({
     ...m,
-    id: `${step}-${i}-${now}`,
+    id: `${step}-${track ?? "-"}-${i}-${now}`,
     timestamp: now + i,
   }));
 }

--- a/src/lib/oracle.ts
+++ b/src/lib/oracle.ts
@@ -2,6 +2,80 @@ import type { OracleAction, OracleState, OracleStep } from "./oracle-types";
 import { DEFAULT_VOICE_DIMENSIONS } from "./voice-profile-dimensions";
 import { prepareMessages } from "./oracle-messages";
 
+// ── Track metadata — human-first, visible to users ───────────────
+export interface TrackMeta {
+  id: "a" | "b";
+  /** Backend Prisma enum value this UI track maps to. */
+  backendEnum: "TRACK_A" | "TRACK_B";
+  /** Short badge label shown in the onboarding header. */
+  label: string;
+  /** One-sentence "what this track does" tagline — used as badge title. */
+  tagline: string;
+  /** Icon key — TrackBadge picks a lucide icon from this. */
+  iconKey: "sparkles" | "brush";
+  /** Tailwind utility applied to the badge border + text. */
+  accent: string;
+}
+
+/**
+ * Track metadata keyed by local frontend state.track value.
+ *
+ * Frontend "a" = X-first path (Connect X → scan tweets → refine).
+ * Frontend "b" = Manual path (pick a style → dial in from scratch).
+ *
+ * User-facing labels are functional ("X-Powered", "Hand-Crafted"),
+ * not letter-coded, so the copy reads naturally regardless of how the
+ * local state ids map to backend enum values.
+ */
+export const TRACK_META: Record<"a" | "b", TrackMeta> = {
+  a: {
+    id: "a",
+    backendEnum: "TRACK_B",
+    label: "X-Powered",
+    tagline: "I scan your tweets to learn your voice, then you refine.",
+    iconKey: "sparkles",
+    accent: "border-atlas-teal text-atlas-teal",
+  },
+  b: {
+    id: "b",
+    backendEnum: "TRACK_A",
+    label: "Hand-Crafted",
+    tagline: "Pick a starter style and we dial it in together from scratch.",
+    iconKey: "brush",
+    accent: "border-delphi-teal text-delphi-teal",
+  },
+};
+
+export function getTrackMeta(track: OracleState["track"]): TrackMeta | null {
+  if (!track) return null;
+  return TRACK_META[track];
+}
+
+/**
+ * Track-aware continue CTA label for each step. Human-first verbs tell
+ * the user exactly what clicking the button will do next — "Continue" is
+ * the silent fallback.
+ */
+export function getContinueLabel(
+  step: OracleStep,
+  track: OracleState["track"],
+): string {
+  switch (step) {
+    case "TRACK_A_RESULT":
+      return "Looks right — continue";
+    case "TRACK_B_STYLE":
+      return "Use this as my starting point";
+    case "TRACK_B_DIMENSIONS":
+      return "Lock in these dimensions";
+    case "REFERENCES":
+      return track === "a"
+        ? "These are my people"
+        : "These voices feel right";
+    default:
+      return "Continue";
+  }
+}
+
 // ── Step transition map ────────────────────────────────────────────
 const NEXT_STEP: Record<OracleStep, OracleStep | null> = {
   WELCOME: "CONNECT_X",
@@ -64,7 +138,7 @@ export function initialOracleState(): OracleState {
     currentStep: "WELCOME",
     track: null,
     messages: [],
-    pendingMessages: prepareMessages("WELCOME"),
+    pendingMessages: prepareMessages("WELCOME", null),
     isTyping: false,
     xHandle: "",
     xConnected: false,
@@ -99,7 +173,7 @@ export function oracleReducer(
         track,
         currentStep: nextStep,
         messages: [...state.messages, userMsg],
-        pendingMessages: prepareMessages(nextStep),
+        pendingMessages: prepareMessages(nextStep, track),
         selfPercentage: track === "a" ? 50 : 30,
       };
     }
@@ -125,7 +199,7 @@ export function oracleReducer(
         messages: userMsg
           ? [...state.messages, userMsg]
           : state.messages,
-        pendingMessages: prepareMessages(next),
+        pendingMessages: prepareMessages(next, state.track),
         stepHistory: newHistory,
       };
     }


### PR DESCRIPTION
Clean rebase of #284 onto current staging. Original branch had pre-Voices-rename NavBar causing e2e failure.

## Changes
- Track A vs Track B onboarding differentiation UI
- TrackBadge component
- Fixed TrackA/B tests for useRouter client component pattern

## Notes
- PR #284 closed as stale (based on old staging without Voices rename)
- Cherry-picked `4931af2` + `49ecc61` onto current staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)