### PR TITLE
fix(ui): vertically center static DimensionBar thumb handle

### DIFF
--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -82,7 +82,7 @@ export default function DimensionBar({
           />
         ) : (
           <div
-            className="pointer-events-none absolute h-4 w-4 -translate-x-1/2 rounded-full border-2 border-atlas-bg bg-atlas-teal shadow-md transition-all duration-200"
+            className="pointer-events-none absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-atlas-bg bg-atlas-teal shadow-md transition-all duration-200"
             style={{ left: `${clampedPercentage}%` }}
           />
         )}


### PR DESCRIPTION
## Problem
The static (read-only) slider thumb was missing vertical centering CSS. It had `-translate-x-1/2` for horizontal centering but no `top-1/2 -translate-y-1/2`, causing it to sit at the top of the 24px container instead of being centered on the 4px track.

## Fix
Added `top-1/2 -translate-y-1/2` to the static thumb `div` in `DimensionBar.tsx`.

Fixes: #PF-05 (blend slider handle vertical alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)