### PR TITLE
feat(voice-lab): Create New Voice starts from single followed creator

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -16,6 +16,7 @@ import {
   type ReferenceAccount,
   type ReferenceVoice,
   type SavedBlend,
+  type TwitterFollow,
   type VoiceProfile,
 } from "@/lib/api";
 import {
@@ -425,7 +426,7 @@ export default function VoiceProfilesPage() {
     ];
   };
 
-  const handleSaveVoice = async (name: string, dimensions: VoiceDimensions) => {
+  const handleSaveVoice = async (name: string, dimensions: VoiceDimensions, selectedFollow: TwitterFollow | null) => {
     try {
       if (editorMode === "edit-personal") {
         const response = await api.voice.updateProfile(dimensions);
@@ -443,8 +444,33 @@ export default function VoiceProfilesPage() {
         return;
       }
 
-      // create mode: build a real blend from saved reference voices and persist.
-      const voices = buildBlendVoicesFromReferences();
+      // create mode: if a single creator was picked, build a 50/50 blend of
+      // the user's personal voice + that one creator. Otherwise fall back to
+      // distributing across all saved reference voices.
+      let voices: BlendVoiceInput[];
+      if (selectedFollow) {
+        // Ensure the creator exists as a reference voice, then use its ID.
+        const existingRef = references.find(
+          (ref) => ref.handle?.replace(/^@/, "").toLowerCase() === selectedFollow.handle.toLowerCase()
+        );
+        let refId: string;
+        if (existingRef) {
+          refId = existingRef.id;
+        } else {
+          const { voice: newRef } = await api.voice.addReference(
+            selectedFollow.displayName || selectedFollow.handle,
+            selectedFollow.handle
+          );
+          refId = newRef.id;
+        }
+        voices = [
+          { label: "My voice", percentage: 50 },
+          { label: selectedFollow.displayName || selectedFollow.handle, percentage: 50, referenceVoiceId: refId },
+        ];
+      } else {
+        voices = buildBlendVoicesFromReferences();
+      }
+
       await api.voice.createBlend(name, voices);
       const response = await api.voice.getBlends();
       setBlends(response.blends);

--- a/src/components/voice-profiles/VoiceEditorModal.tsx
+++ b/src/components/voice-profiles/VoiceEditorModal.tsx
@@ -36,7 +36,7 @@ interface VoiceEditorModalProps {
   initialDimensions?: VoiceDimensions;
   saveDisabled?: boolean;
   saveNotice?: string;
-  onSave: (name: string, dimensions: VoiceDimensions) => Promise<void>;
+  onSave: (name: string, dimensions: VoiceDimensions, selectedFollow: TwitterFollow | null) => Promise<void>;
   onClose: () => void;
 }
 
@@ -150,7 +150,7 @@ export default function VoiceEditorModal({
 
     setSaving(true);
     try {
-      await onSave(voiceName, dimensions);
+      await onSave(voiceName, dimensions, mode === "create" ? selectedFollow : null);
       onClose();
     } finally {
       setSaving(false);


### PR DESCRIPTION
## Summary
- Two-step "Create New Voice" modal already had the creator picker (pick step). This wires the selected follow through to the blend-creation logic.
- New voice is a 50/50 blend of personal voice + the single selected creator (auto-added to reference library if not already saved).
- Mixing multiple creators remains available via the existing blend-pairing flow.
- No UI changes — the modal already had the correct pick/tune step flow. Fix is purely in the page-level save handler.

## Test plan
- [ ] Open Voice Lab → click "New Voice" (requires MANAGER/ADMIN role)
- [ ] Step 1: search follows, pick one creator → Next
- [ ] Step 2: verify "Based on: @handle" badge shown
- [ ] Save → new recipe card appears labeled with the creator's name
- [ ] Recipe card shows 50% personal voice / 50% creator split
- [ ] If creator was not previously in reference library, verify it's added automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)