### PR TITLE
fix(voice-lab): save avatarUrl when adding reference voices

### DIFF
--- a/src/components/voice-profiles/ImportFromXFollowsModal.tsx
+++ b/src/components/voice-profiles/ImportFromXFollowsModal.tsx
@@ -115,7 +115,8 @@ export default function ImportFromXFollowsModal({
     try {
       const response = await api.voice.addReference(
         follow.displayName || follow.handle || "Reference",
-        follow.handle || undefined
+        follow.handle || undefined,
+        follow.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [follow.id]: "added" }));
       onReferenceAdded(response.voice);

--- a/src/components/voice-profiles/ImportFromXLikesModal.tsx
+++ b/src/components/voice-profiles/ImportFromXLikesModal.tsx
@@ -109,7 +109,11 @@ export default function ImportFromXLikesModal({
     });
 
     try {
-      const response = await api.voice.addReference(creator.handle, creator.handle);
+      const response = await api.voice.addReference(
+        creator.handle,
+        creator.handle,
+        creator.avatarUrl || undefined,
+      );
       setRowStatus((current) => ({ ...current, [creator.handle]: "added" }));
       onReferenceAdded(response.voice);
     } catch (addError: unknown) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -376,8 +376,8 @@ export const api = {
       request<{ accounts: ReferenceAccount[] }>("/api/voice/reference-accounts"),
     getReferences: () =>
       request<{ voices: ReferenceVoice[] }>("/api/voice/references"),
-    addReference: (name: string, handle?: string) =>
-      request<{ voice: ReferenceVoice }>("/api/voice/references", { method: "POST", body: { name, handle } }),
+    addReference: (name: string, handle?: string, avatarUrl?: string) =>
+      request<{ voice: ReferenceVoice }>("/api/voice/references", { method: "POST", body: { name, handle, avatarUrl } }),
     getBlends: () =>
       request<{ blends: SavedBlend[] }>("/api/voice/blends"),
     createBlend: (name: string, voices: BlendVoiceInput[]) =>


### PR DESCRIPTION
## Summary
- Adds `avatarUrl` to `POST /api/voice/references` backend endpoint (schema validation + Prisma create)
- Updates `api.voice.addReference()` client to accept and forward `avatarUrl`
- Passes creator avatar when adding references from X Follows and X Likes import modals

## Root cause
Reference voice cards showed initials/fallback instead of creator avatars because `avatarUrl` was never persisted — the Prisma schema had the field but the endpoint silently dropped it.

## Test plan
- [ ] Import a creator from X Follows — avatar should now appear on the reference card
- [ ] Import a creator from X Likes — avatar should now appear on the reference card
- [ ] Existing reference cards without avatarUrl continue to show initials fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)