### PR TITLE
fix: reorder primary nav for demo flow (DM-322)

### DIFF
--- a/src/__tests__/components/NavBar.test.tsx
+++ b/src/__tests__/components/NavBar.test.tsx
@@ -80,23 +80,26 @@ describe("NavBar", () => {
       "aria-current",
       "page"
     );
-    // Core 4 tabs: Crafting, Voices, Library, Arena
+    // Core 7 tabs visible to all roles (DM-322): Dashboard, Crafting, Voices, Analytics, Signals, Library, Arena
     expect(screen.getByRole("link", { name: "Voices" })).not.toHaveAttribute(
       "aria-current"
     );
+    expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Analytics" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signals" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Library" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Arena" })).toBeInTheDocument();
-    // Hidden tabs should not appear in nav
-    expect(screen.queryByRole("link", { name: "Dashboard" })).not.toBeInTheDocument();
+    // Non-core tabs should not appear in nav
     expect(screen.queryByRole("link", { name: "Feed" })).not.toBeInTheDocument();
   });
 
-  it("hides Analytics and Signals tabs for ANALYST role", () => {
+  it("shows Analytics and Signals for all roles including ANALYST (DM-322)", () => {
     render(<NavBar variant="app" />);
 
-    expect(screen.queryByRole("link", { name: "Analytics" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Signals" })).not.toBeInTheDocument();
-    // Core tabs still visible
+    // DM-322: Analytics and Signals are now core tabs visible to all roles
+    expect(screen.getByRole("link", { name: "Analytics" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signals" })).toBeInTheDocument();
+    // Other core tabs visible
     expect(screen.getByRole("link", { name: "Crafting" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Voices" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Library" })).toBeInTheDocument();

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -37,25 +37,24 @@ export interface NavBarProps {
 }
 
 export const navLinks = [
-  { label: "Feed", href: "/feed", icon: Rss },
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Crafting", href: "/crafting", icon: PenTool },
   { label: "Voices", href: "/voice-profiles", icon: Mic2 },
   { label: "Analytics", href: "/analytics", icon: BarChart3 },
-  { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Signals", href: "/alerts", icon: Zap },
   { label: "Library", href: "/team-library", icon: BookOpen },
   { label: "Arena", href: "/arena", icon: Trophy },
+  { label: "Feed", href: "/feed", icon: Rss },
+  { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Campaigns", href: "/campaigns", icon: CalendarClock },
   { label: "Queue", href: "/queue", icon: ListOrdered },
 ];
 
-// Core tabs always visible in navigation (DM-322).
-// Analytics + Signals are gated behind manager/admin role.
-// Other tabs (Feed, Dashboard, Briefings, Queue, Campaigns) are hidden
-// from nav but their routes/pages remain accessible.
-const CORE_NAV_HREFS = new Set(["/crafting", "/voice-profiles", "/team-library", "/arena"]);
-const MANAGER_NAV_HREFS = new Set(["/analytics", "/alerts"]);
+// Core tabs always visible in navigation (DM-322, updated for demo flow).
+// Demo flow: Dashboard → Crafting → Voices → Analytics → Signals → Library → Arena
+// Other tabs (Feed, Briefings, Queue, Campaigns) are hidden from nav but accessible.
+const CORE_NAV_HREFS = new Set(["/dashboard", "/crafting", "/voice-profiles", "/analytics", "/alerts", "/team-library", "/arena"]);
+const MANAGER_NAV_HREFS = new Set<string>();
 
 export const coreNavLinks = navLinks.filter((link) => CORE_NAV_HREFS.has(link.href));
 


### PR DESCRIPTION
## Summary
- Moves Dashboard, Analytics, and Signals into core nav (visible to all roles, not just managers)
- Reorders nav links: Dashboard → Crafting → Voices → Analytics → Signals → Library → Arena
- Feed, Briefing, Campaigns, and Queue stay accessible via direct URL but are removed from nav bar

## Test plan
- [ ] Nav shows Dashboard, Crafting, Voices, Analytics, Signals, Library, Arena for regular users
- [ ] Order matches demo flow left-to-right
- [ ] Feed/Briefing/Campaigns/Queue pages still load via direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)