### PR TITLE
feat: staging → main (Apr 11) — nav reorder, voice copy, CI fixes

### DIFF
--- a/src/__tests__/components/NavBar.test.tsx
+++ b/src/__tests__/components/NavBar.test.tsx
@@ -80,23 +80,26 @@ describe("NavBar", () => {
       "aria-current",
       "page"
     );
-    // Core 4 tabs: Crafting, Voices, Library, Arena
+    // Core 7 tabs visible to all roles (DM-322): Dashboard, Crafting, Voices, Analytics, Signals, Library, Arena
     expect(screen.getByRole("link", { name: "Voices" })).not.toHaveAttribute(
       "aria-current"
     );
+    expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Analytics" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signals" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Library" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Arena" })).toBeInTheDocument();
-    // Hidden tabs should not appear in nav
-    expect(screen.queryByRole("link", { name: "Dashboard" })).not.toBeInTheDocument();
+    // Non-core tabs should not appear in nav
     expect(screen.queryByRole("link", { name: "Feed" })).not.toBeInTheDocument();
   });
 
-  it("hides Analytics and Signals tabs for ANALYST role", () => {
+  it("shows Analytics and Signals for all roles including ANALYST (DM-322)", () => {
     render(<NavBar variant="app" />);
 
-    expect(screen.queryByRole("link", { name: "Analytics" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Signals" })).not.toBeInTheDocument();
-    // Core tabs still visible
+    // DM-322: Analytics and Signals are now core tabs visible to all roles
+    expect(screen.getByRole("link", { name: "Analytics" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signals" })).toBeInTheDocument();
+    // Other core tabs visible
     expect(screen.getByRole("link", { name: "Crafting" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Voices" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Library" })).toBeInTheDocument();

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -16,6 +16,7 @@ import {
   type ReferenceAccount,
   type ReferenceVoice,
   type SavedBlend,
+  type TwitterFollow,
   type VoiceProfile,
 } from "@/lib/api";
 import {
@@ -425,7 +426,7 @@ export default function VoiceProfilesPage() {
     ];
   };
 
-  const handleSaveVoice = async (name: string, dimensions: VoiceDimensions) => {
+  const handleSaveVoice = async (name: string, dimensions: VoiceDimensions, selectedFollow: TwitterFollow | null) => {
     try {
       if (editorMode === "edit-personal") {
         const response = await api.voice.updateProfile(dimensions);
@@ -443,8 +444,33 @@ export default function VoiceProfilesPage() {
         return;
       }
 
-      // create mode: build a real blend from saved reference voices and persist.
-      const voices = buildBlendVoicesFromReferences();
+      // create mode: if a single creator was picked, build a 50/50 blend of
+      // the user's personal voice + that one creator. Otherwise fall back to
+      // distributing across all saved reference voices.
+      let voices: BlendVoiceInput[];
+      if (selectedFollow) {
+        // Ensure the creator exists as a reference voice, then use its ID.
+        const existingRef = references.find(
+          (ref) => ref.handle?.replace(/^@/, "").toLowerCase() === selectedFollow.handle.toLowerCase()
+        );
+        let refId: string;
+        if (existingRef) {
+          refId = existingRef.id;
+        } else {
+          const { voice: newRef } = await api.voice.addReference(
+            selectedFollow.displayName || selectedFollow.handle,
+            selectedFollow.handle
+          );
+          refId = newRef.id;
+        }
+        voices = [
+          { label: "My voice", percentage: 50 },
+          { label: selectedFollow.displayName || selectedFollow.handle, percentage: 50, referenceVoiceId: refId },
+        ];
+      } else {
+        voices = buildBlendVoicesFromReferences();
+      }
+
       await api.voice.createBlend(name, voices);
       const response = await api.voice.getBlends();
       setBlends(response.blends);

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -722,8 +722,8 @@ export default function VoiceProfilesPage() {
                   dimensions={dimensions}
                   fingerprintDescription={
                     blend.voices.length === 1
-                      ? "Built directly from your personal voice profile."
-                      : "Estimated from your personal voice plus matched reference archetypes in the library."
+                      ? "Derived directly from your personal voice profile."
+                      : "A blend of your personal voice and the inspirations you added."
                   }
                   notableDimensions={notableDimensions}
                   isActive={activeVoiceId === blend.id}

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -37,25 +37,24 @@ export interface NavBarProps {
 }
 
 export const navLinks = [
-  { label: "Feed", href: "/feed", icon: Rss },
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Crafting", href: "/crafting", icon: PenTool },
   { label: "Voices", href: "/voice-profiles", icon: Mic2 },
   { label: "Analytics", href: "/analytics", icon: BarChart3 },
-  { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Signals", href: "/alerts", icon: Zap },
   { label: "Library", href: "/team-library", icon: BookOpen },
   { label: "Arena", href: "/arena", icon: Trophy },
+  { label: "Feed", href: "/feed", icon: Rss },
+  { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Campaigns", href: "/campaigns", icon: CalendarClock },
   { label: "Queue", href: "/queue", icon: ListOrdered },
 ];
 
-// Core tabs always visible in navigation (DM-322).
-// Analytics + Signals are gated behind manager/admin role.
-// Other tabs (Feed, Dashboard, Briefings, Queue, Campaigns) are hidden
-// from nav but their routes/pages remain accessible.
-const CORE_NAV_HREFS = new Set(["/crafting", "/voice-profiles", "/team-library", "/arena"]);
-const MANAGER_NAV_HREFS = new Set(["/analytics", "/alerts"]);
+// Core tabs always visible in navigation (DM-322, updated for demo flow).
+// Demo flow: Dashboard → Crafting → Voices → Analytics → Signals → Library → Arena
+// Other tabs (Feed, Briefings, Queue, Campaigns) are hidden from nav but accessible.
+const CORE_NAV_HREFS = new Set(["/dashboard", "/crafting", "/voice-profiles", "/analytics", "/alerts", "/team-library", "/arena"]);
+const MANAGER_NAV_HREFS = new Set<string>();
 
 export const coreNavLinks = navLinks.filter((link) => CORE_NAV_HREFS.has(link.href));
 

--- a/src/components/voice-profiles/ImportFromXFollowsModal.tsx
+++ b/src/components/voice-profiles/ImportFromXFollowsModal.tsx
@@ -115,7 +115,8 @@ export default function ImportFromXFollowsModal({
     try {
       const response = await api.voice.addReference(
         follow.displayName || follow.handle || "Reference",
-        follow.handle || undefined
+        follow.handle || undefined,
+        follow.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [follow.id]: "added" }));
       onReferenceAdded(response.voice);

--- a/src/components/voice-profiles/ImportFromXLikesModal.tsx
+++ b/src/components/voice-profiles/ImportFromXLikesModal.tsx
@@ -109,7 +109,11 @@ export default function ImportFromXLikesModal({
     });
 
     try {
-      const response = await api.voice.addReference(creator.handle, creator.handle);
+      const response = await api.voice.addReference(
+        creator.handle,
+        creator.handle,
+        creator.avatarUrl || undefined,
+      );
       setRowStatus((current) => ({ ...current, [creator.handle]: "added" }));
       onReferenceAdded(response.voice);
     } catch (addError: unknown) {

--- a/src/components/voice-profiles/VoiceEditorModal.tsx
+++ b/src/components/voice-profiles/VoiceEditorModal.tsx
@@ -36,7 +36,7 @@ interface VoiceEditorModalProps {
   initialDimensions?: VoiceDimensions;
   saveDisabled?: boolean;
   saveNotice?: string;
-  onSave: (name: string, dimensions: VoiceDimensions) => Promise<void>;
+  onSave: (name: string, dimensions: VoiceDimensions, selectedFollow: TwitterFollow | null) => Promise<void>;
   onClose: () => void;
 }
 
@@ -150,7 +150,7 @@ export default function VoiceEditorModal({
 
     setSaving(true);
     try {
-      await onSave(voiceName, dimensions);
+      await onSave(voiceName, dimensions, mode === "create" ? selectedFollow : null);
       onClose();
     } finally {
       setSaving(false);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -376,8 +376,8 @@ export const api = {
       request<{ accounts: ReferenceAccount[] }>("/api/voice/reference-accounts"),
     getReferences: () =>
       request<{ voices: ReferenceVoice[] }>("/api/voice/references"),
-    addReference: (name: string, handle?: string) =>
-      request<{ voice: ReferenceVoice }>("/api/voice/references", { method: "POST", body: { name, handle } }),
+    addReference: (name: string, handle?: string, avatarUrl?: string) =>
+      request<{ voice: ReferenceVoice }>("/api/voice/references", { method: "POST", body: { name, handle, avatarUrl } }),
     getBlends: () =>
       request<{ blends: SavedBlend[] }>("/api/voice/blends"),
     createBlend: (name: string, voices: BlendVoiceInput[]) =>


### PR DESCRIPTION
## Summary
- **PR #300** (fix/nav-ia-reorder): Reorder nav to demo flow — Dashboard → Crafting → Voices → Analytics → Signals → Library → Arena. All 7 tabs now core for all roles (DM-322).
- **PR #299** (fix/voice-lab-jargon-copy): Replace jargon copy in blend fingerprint — "matched reference archetypes" → "A blend of your personal voice and the inspirations you added."
- **NavBar tests updated** for new 7-tab core nav structure (cc-49733/#125902)

## Test plan
- [ ] CI passing on both merged PRs
- [ ] Nav shows 7 tabs in correct demo order for ANALYST role
- [ ] Voice profile blend fingerprint copy is accessible language
- [ ] Anil demo account seeded (separate backend step — complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)