### PR TITLE
fix(voice-lab): enrich X-imported reference voices with avatar and handle

### DIFF
--- a/src/components/voice-profiles/ImportFromXFollowsModal.tsx
+++ b/src/components/voice-profiles/ImportFromXFollowsModal.tsx
@@ -119,7 +119,11 @@ export default function ImportFromXFollowsModal({
         follow.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [follow.id]: "added" }));
-      onReferenceAdded(response.voice);
+      onReferenceAdded({
+        ...response.voice,
+        handle: response.voice.handle ?? follow.handle ?? undefined,
+        avatarUrl: response.voice.avatarUrl ?? follow.avatarUrl ?? undefined,
+      });
     } catch (addError: unknown) {
       setRowStatus((current) => ({ ...current, [follow.id]: "error" }));
       setRowError((current) => ({

--- a/src/components/voice-profiles/ImportFromXLikesModal.tsx
+++ b/src/components/voice-profiles/ImportFromXLikesModal.tsx
@@ -115,7 +115,11 @@ export default function ImportFromXLikesModal({
         creator.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [creator.handle]: "added" }));
-      onReferenceAdded(response.voice);
+      onReferenceAdded({
+        ...response.voice,
+        handle: response.voice.handle ?? creator.handle ?? undefined,
+        avatarUrl: response.voice.avatarUrl ?? creator.avatarUrl ?? undefined,
+      });
     } catch (addError: unknown) {
       setRowStatus((current) => ({ ...current, [creator.handle]: "error" }));
       setRowError((current) => ({


### PR DESCRIPTION
## Summary
- X-imported reference voices (from Follows/Likes modals) were displayed without avatars or clickable Twitter links in the Inspirations section
- Root cause: `onReferenceAdded` was called with the raw backend response, which had no `avatarUrl` (backend never received it) and sometimes a missing `handle`
- Fix: merge the local `TwitterFollow`/`LikedCreator` avatar + handle into the response voice before calling `onReferenceAdded` — cards immediately show correct avatar and link
- `api.ts` already has `avatarUrl` in the `addReference` signature (was already on staging); the modals now pass `follow.avatarUrl` and `creator.avatarUrl` through

## Test plan
- [ ] Link X account, go to Voice Profiles → Inspirations
- [ ] Click "Import from X Follows" — add an account
- [ ] New card should show the real Twitter avatar (not initials) and a clickable `@handle` link
- [ ] Click "From Your Likes" — add a creator
- [ ] Same: real avatar + clickable handle link appear immediately
- [ ] Reload page — cards re-render from `api.voice.getReferences()` (backend now stores avatarUrl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)