### PR TITLE
fix: staging → main (Apr 11) — reference voice avatars + links

### DIFF
--- a/src/components/voice-profiles/ImportFromXFollowsModal.tsx
+++ b/src/components/voice-profiles/ImportFromXFollowsModal.tsx
@@ -119,7 +119,11 @@ export default function ImportFromXFollowsModal({
         follow.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [follow.id]: "added" }));
-      onReferenceAdded(response.voice);
+      onReferenceAdded({
+        ...response.voice,
+        handle: response.voice.handle ?? follow.handle ?? undefined,
+        avatarUrl: response.voice.avatarUrl ?? follow.avatarUrl ?? undefined,
+      });
     } catch (addError: unknown) {
       setRowStatus((current) => ({ ...current, [follow.id]: "error" }));
       setRowError((current) => ({

--- a/src/components/voice-profiles/ImportFromXLikesModal.tsx
+++ b/src/components/voice-profiles/ImportFromXLikesModal.tsx
@@ -115,7 +115,11 @@ export default function ImportFromXLikesModal({
         creator.avatarUrl || undefined,
       );
       setRowStatus((current) => ({ ...current, [creator.handle]: "added" }));
-      onReferenceAdded(response.voice);
+      onReferenceAdded({
+        ...response.voice,
+        handle: response.voice.handle ?? creator.handle ?? undefined,
+        avatarUrl: response.voice.avatarUrl ?? creator.avatarUrl ?? undefined,
+      });
     } catch (addError: unknown) {
       setRowStatus((current) => ({ ...current, [creator.handle]: "error" }));
       setRowError((current) => ({


### PR DESCRIPTION
## Summary
- **PR #302**: X-imported reference voices now show avatar + clickable Twitter link in Voice Profiles Inspirations section (fixes display regression)

## Test plan
- [ ] CI passing
- [ ] Reference voices from X imports show avatars in Voices → Inspirations
- [ ] Reference voice handles are clickable links to Twitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)