### PR TITLE
ci(visual): push baselines to feature branch (bypass staging protection)

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-baselines:
@@ -22,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: staging
 
       - uses: actions/setup-node@v4
         with:
@@ -50,7 +52,7 @@ jobs:
           git diff --name-only || true
           git status --short
 
-      - name: Commit baselines
+      - name: Commit and push to feature branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -58,7 +60,23 @@ jobs:
           if git diff --staged --quiet; then
             echo "No snapshot changes to commit."
           else
+            BRANCH="chore/linux-visual-baselines-$(date +%Y%m%d-%H%M)"
+            git checkout -b "$BRANCH"
             git commit -m "${{ inputs.commit_message }}"
-            git push
-            echo "Linux baselines committed and pushed."
+            git push origin "$BRANCH"
+            echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+            echo "Linux baselines committed to branch: $BRANCH"
           fi
+
+      - name: Create PR
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore(visual): Linux visual regression baselines" \
+            --body "Auto-generated Linux visual regression baselines from staging deployment.
+
+Triggered by workflow_dispatch on staging branch." \
+            --base staging \
+            --head "$BRANCH"


### PR DESCRIPTION
## Summary
- Fixes `update-visual-baselines.yml` workflow to push generated Linux baselines to a feature branch instead of directly to `staging`
- Adds automatic PR creation via `gh pr create` after baseline generation
- Previously failed with: `push declined due to repository rule violations` (branch protection requires `check` CI to pass)

## Test plan
- [ ] Re-trigger `Update Visual Baselines (Linux)` workflow after this merges
- [ ] Verify it creates a new branch `chore/linux-visual-baselines-YYYYMMDD-HHMM` with the Linux PNG files
- [ ] Verify it auto-creates a PR to staging

🤖 Generated with [Claude Code](https://claude.ai/claude-code)