### PR TITLE
fix(crafting): null guard for trending topics + voice-library e2e fixes

### DIFF
--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -145,11 +145,11 @@ test.describe("Voice Lab (voice-profiles) — recipe cards + blend UI", () => {
     await expect(page.getByText("My voice").first()).toBeVisible({ timeout: 5000 });
   });
 
-  test("Voice Lab page is reachable via /voice-lab nav label", async ({ page }) => {
+  test("Voice Lab page is reachable via /voices nav label", async ({ page }) => {
     await page.goto("/voice-profiles", { waitUntil: "domcontentloaded" });
 
-    // The nav should show "Voice Lab" (renamed from "Voices")
-    const navVoiceLab = page.getByRole("link", { name: /Voice Lab/i });
-    await expect(navVoiceLab).toBeVisible({ timeout: 5000 });
+    // The nav shows "Voices" (DM-322 label)
+    const navVoices = page.getByRole("link", { name: /^Voices$/i });
+    await expect(navVoices).toBeVisible({ timeout: 5000 });
   });
 });

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -397,7 +397,7 @@ function CraftingPage() {
   const loadTrending = useCallback(async () => {
     try {
       const { topics } = await api.trending.topics();
-      setTrendingTopics(topics);
+      setTrendingTopics(topics ?? []);
     } catch {
       // Trending is optional — do not block the page.
     }

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -40,7 +40,7 @@ export const navLinks = [
   { label: "Feed", href: "/feed", icon: Rss },
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Crafting", href: "/crafting", icon: PenTool },
-  { label: "Voice Lab", href: "/voice-profiles", icon: Mic2 },
+  { label: "Voices", href: "/voice-profiles", icon: Mic2 },
   { label: "Analytics", href: "/analytics", icon: BarChart3 },
   { label: "Briefing", href: "/briefing", icon: Newspaper },
   { label: "Signals", href: "/alerts", icon: Zap },


### PR DESCRIPTION
- Adds null guard for trending topics API response in crafting\n- Fixes voice-library test for Voices nav label\n- Nav rename fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)