### PR TITLE
ci(visual): fix baseline workflow — feature branch + PR

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-baselines:
@@ -22,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: staging
 
       - uses: actions/setup-node@v4
         with:
@@ -35,10 +37,7 @@ jobs:
 
       - name: Generate Linux visual baselines
         run: |
-          npx playwright test \
-            --config=playwright-e2e.config.ts \
-            --project=visual \
-            --update-snapshots
+          npx playwright test             --config=playwright-e2e.config.ts             --project=visual             --update-snapshots
         env:
           PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
           VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
@@ -50,7 +49,7 @@ jobs:
           git diff --name-only || true
           git status --short
 
-      - name: Commit baselines
+      - name: Commit and push to feature branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -58,7 +57,19 @@ jobs:
           if git diff --staged --quiet; then
             echo "No snapshot changes to commit."
           else
+            BRANCH="chore/linux-visual-baselines-$(date +%Y%m%d-%H%M)"
+            git checkout -b "$BRANCH"
             git commit -m "${{ inputs.commit_message }}"
-            git push
-            echo "Linux baselines committed and pushed."
+            git push origin "$BRANCH"
+            echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+            echo "Linux baselines committed to branch: $BRANCH"
           fi
+
+      - name: Create PR
+        if: env.BRANCH != ""
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create             --title "chore(visual): Linux visual regression baselines"             --body "Auto-generated Linux visual regression baselines from staging deployment.
+
+Triggered by workflow_dispatch."             --base staging             --head "$BRANCH"


### PR DESCRIPTION
## Summary

- Workflow checked out default branch and tried `git push` directly — fails due to `main` branch protection (required CI check)
- Updated to checkout `staging`, generate Linux baselines, push to feature branch `chore/linux-visual-baselines-YYYYMMDD-HHMM`, and auto-create a PR to staging
- Matches the version already on `staging` (merged via PR #304)

## Test plan
- [ ] Merge this PR so `workflow_dispatch` uses the fixed workflow on main
- [ ] Trigger `Update Visual Baselines (Linux)` workflow → should generate 6 Linux PNGs and auto-create a PR to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)