### PR TITLE
ci(visual): add workflow to generate Linux baselines

### DIFF
--- a/.github/workflows/gen-linux-baselines.yml
+++ b/.github/workflows/gen-linux-baselines.yml
@@ -1,0 +1,82 @@
+name: Gen Linux Visual Baselines
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to run visual tests against"
+        required: false
+        default: "https://staging-delphi-atlas.vercel.app"
+      commit_message:
+        description: "Commit message for baseline update"
+        required: false
+        default: "chore(visual): update Linux visual regression baselines"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  gen-baselines:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: staging
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Generate Linux visual baselines
+        run: |
+          npx playwright test \
+            --config=playwright-e2e.config.ts \
+            --project=visual \
+            --update-snapshots
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
+          CI: "true"
+
+      - name: Show generated snapshots
+        run: |
+          echo "=== Snapshot files changed ==="
+          git diff --name-only || true
+          git status --short
+
+      - name: Commit and push to feature branch
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add e2e/visual/visual-regression.spec.ts-snapshots/
+          if git diff --staged --quiet; then
+            echo "No snapshot changes to commit."
+            echo "branch=" >> $GITHUB_OUTPUT
+          else
+            BRANCH="chore/linux-visual-baselines-$(date +%Y%m%d-%H%M)"
+            git checkout -b "$BRANCH"
+            git commit -m "${{ inputs.commit_message }}"
+            git push origin "$BRANCH"
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+            echo "Linux baselines committed to branch: $BRANCH"
+          fi
+
+      - name: Create PR to staging
+        if: steps.commit.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore(visual): Linux visual regression baselines" \
+            --body "Auto-generated Linux visual regression baselines from staging deployment." \
+            --base staging \
+            --head "${{ steps.commit.outputs.branch }}"


### PR DESCRIPTION
## Summary

- Adds `gen-linux-baselines.yml` as a replacement for the stuck `update-visual-baselines.yml` workflow
- Previous workflow ID (259295149) returns 422 on `workflow_dispatch` API despite having the trigger in the YAML
- Fresh workflow file = new GitHub workflow ID = clean dispatch capability
- Checkout `staging`, run playwright `--update-snapshots`, push to feature branch, auto-PR to staging

## Test plan
- [ ] Merge → trigger `Gen Linux Visual Baselines` workflow → 6 Linux PNGs generated → auto-PR to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)