### PR TITLE
chore(ci): generate responsive Linux baselines in gen-linux-baselines workflow

### DIFF
--- a/.github/workflows/gen-linux-baselines.yml
+++ b/.github/workflows/gen-linux-baselines.yml
@@ -35,11 +35,12 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
-      - name: Generate Linux visual baselines
+      - name: Generate Linux visual + responsive baselines
         run: |
           npx playwright test \
             --config=playwright-e2e.config.ts \
             --project=visual \
+            --project=responsive \
             --update-snapshots
         env:
           PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
@@ -58,6 +59,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add e2e/visual/visual-regression.spec.ts-snapshots/
+          git add e2e/responsive/responsive.spec.ts-snapshots/
           if git diff --staged --quiet; then
             echo "No snapshot changes to commit."
             echo "branch=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Adds `--project=responsive` to the Playwright run in `gen-linux-baselines.yml`
- Also stages `e2e/responsive/responsive.spec.ts-snapshots/` so responsive Linux baselines are included in the auto-created PR alongside visual baselines

## Why
CI shards fail with `snapshot doesn't exist` for both visual chromium and all responsive tests on Linux. The workflow was only generating visual baselines. Now it covers both in a single run.

## After merge
Trigger `Gen Linux Visual Baselines` workflow_dispatch from main — it will generate and PR all 23 missing Linux baseline files (5 visual chromium + 18 responsive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)