### PR TITLE
security(auth): drop query-string JWT handling in X callback

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -2,12 +2,20 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { setAccessToken, api } from "@/lib/api";
+import { api } from "@/lib/api";
 
 /**
  * /auth/callback — handles server-side OAuth redirects.
- * Backend redirects here with ?token=JWT&provider=twitter after successful OAuth.
- * Stores the token, validates the session, and redirects to dashboard.
+ *
+ * Security (C-5): Backend sets an HttpOnly `atlas_session` cookie via
+ * setAuthCookies() BEFORE redirecting the browser here. The portal no longer
+ * reads a JWT from the query string — doing so would expose the token in
+ * URL history, referer headers, and server/CDN logs.
+ *
+ * Backend now redirects to `/auth/callback?provider=twitter` (no ?token=).
+ * We validate the session by calling /me (which sends the HttpOnly cookie
+ * automatically via `credentials: "include"`) and route to dashboard or
+ * onboarding based on the user's state.
  */
 export default function AuthCallbackPage() {
   const router = useRouter();
@@ -16,8 +24,6 @@ export default function AuthCallbackPage() {
   const [message, setMessage] = useState("Signing you in...");
 
   useEffect(() => {
-    const token = searchParams.get("token");
-    const provider = searchParams.get("provider");
     const error = searchParams.get("error");
 
     if (error) {
@@ -32,18 +38,14 @@ export default function AuthCallbackPage() {
       return;
     }
 
-    if (!token) {
-      setStatus("error");
-      setMessage("Missing authentication token. Please try again.");
-      return;
-    }
-
-    // Store the JWT
-    setAccessToken(token);
-    document.cookie = "atlas_access_token=1; path=/; max-age=86400; SameSite=Lax";
+    // Mirror the HttpOnly atlas_session cookie set by the backend with a
+    // client-readable flag so the Next.js middleware can gate protected
+    // routes on the frontend origin. The HttpOnly cookie (set by the
+    // backend domain) carries the real credential; this is a hint only.
     document.cookie = "atlas_session=1; path=/; max-age=604800; SameSite=Lax";
 
-    // Validate session by calling /me
+    // Validate session by calling /me — this sends the HttpOnly cookie
+    // via `credentials: "include"` in the api client.
     api.auth.me()
       .then((res) => {
         setStatus("success");
@@ -62,7 +64,6 @@ export default function AuthCallbackPage() {
       .catch(() => {
         setStatus("error");
         setMessage("Session validation failed. Please try again.");
-        setAccessToken(null);
         document.cookie = "atlas_session=; path=/; max-age=0";
       });
   }, [searchParams, router]);


### PR DESCRIPTION
## Summary

Security fix **C-5** (portal side). Removes query-string JWT handling from the X OAuth callback handler — the portal now relies exclusively on the HttpOnly `atlas_session` cookie set by the backend via `setAuthCookies()` before redirect.

Companion to atlas-backend C-5, which removes `?token=<jwt>` from the X OAuth callback redirect. Backend will redirect to `/auth/callback?provider=twitter` only.

## Why

Putting the JWT in the query string exposes it in:
- Browser URL history
- HTTP `Referer` headers sent to any third-party assets loaded on the callback page
- Server / CDN / proxy access logs
- Analytics beacons and error trackers (Sentry, etc.)

The HttpOnly cookie set by the backend already carries the real credential. The callback just needs to validate the session and route the user.

## What Changed

`src/app/auth/callback/page.tsx`:
- Removed `searchParams.get("token")` read
- Removed `setAccessToken(token)` call and the `atlas_access_token` flag cookie write
- Removed the "missing authentication token" error branch (no token in URL anymore)
- Removed `setAccessToken` import (unused)
- Kept the client-readable `atlas_session=1` hint cookie — Next.js middleware on the frontend origin still uses it to gate protected routes (the real HttpOnly cookie lives on the backend origin)
- Kept `/me` validation via `credentials: "include"` — the HttpOnly session cookie is sent automatically
- Updated JSDoc to document the security rationale

No changes to `src/middleware.ts` — it already reads `request.cookies.has("atlas_session")` at line 17 to gate protected routes, which is exactly what this flow needs.

## Middleware Audit

`src/middleware.ts:17` reads the `atlas_session` cookie:

```ts
const hasSession = request.cookies.has("atlas_session");
if (!hasSession && !isPublicPath(pathname)) {
  return NextResponse.redirect(new URL("/", request.url));
}
```

Both `/auth/callback` and `/auth/x/callback` are in `PUBLIC_PATHS` so the callback can render before the cookie flag is set client-side. After validation, the user gets routed to `/dashboard` or `/onboarding` and the middleware permits access.

## Follow-up (out of scope for this PR)

The portal's `atlas_session=1` client-readable flag cookie is set on the **frontend origin** (e.g. `delphi-atlas.vercel.app`) to act as a hint to the Next.js middleware. The backend's HttpOnly `atlas_session` cookie lives on the **backend origin** (`api-production-9bef.up.railway.app`), where the middleware cannot read it cross-origin.

This means the flag cookie is still the only thing the middleware sees. If a user clears cookies on the portal domain but keeps the backend cookie, middleware will boot them back to login even though `/me` would still succeed. Fine for v1, but worth a follow-up issue to either:
1. Set a parent-domain cookie once a custom Atlas domain exists, or
2. Replace the middleware hint with a server-side session probe (/me) on the Vercel edge.

Not touching this in this PR — scope creep.

## Test plan

- [ ] Unit: `npx tsc --noEmit` — clean
- [ ] Lint: `npx next lint --file src/app/auth/callback/page.tsx` — clean
- [ ] Manual: once atlas-backend C-5 PR lands, start X OAuth flow → confirm backend redirects to `/auth/callback?provider=twitter` (no `?token=`) → portal calls `/me` successfully → user lands on `/dashboard` or `/onboarding`
- [ ] Manual: verify error path: hit `/auth/callback?error=access_denied` → error card renders, "Back to Login" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)