### PR TITLE
feat(voice-lab): sort followed creator list by follower count

### DIFF
--- a/src/components/voice-profiles/ImportFromXFollowsModal.tsx
+++ b/src/components/voice-profiles/ImportFromXFollowsModal.tsx
@@ -175,7 +175,11 @@ export default function ImportFromXFollowsModal({
           </p>
         </div>
       ) : (
-        <ul className="flex flex-col divide-y divide-glass-border">
+        <>
+          <p className="mb-3 text-xs text-atlas-text-secondary">
+            {follows.length} account{follows.length !== 1 ? "s" : ""} · sorted by most followers
+          </p>
+          <ul className="flex flex-col divide-y divide-glass-border">
           {follows.map((follow) => {
             const normalizedHandle = normalizeHandle(follow.handle);
             const alreadyAdded =
@@ -250,6 +254,7 @@ export default function ImportFromXFollowsModal({
             );
           })}
         </ul>
+        </>
       )}
     </Modal>
   );


### PR DESCRIPTION
## Summary

- Shows follow count + explicit sort label ("N accounts · sorted by most followers") above the X follows import list
- Sorting by `follower_count` descending was already implemented in 93111f5 (added `sortFollows` + `formatFollowerCount`)
- Backend `/api/twitter/follows` already returns `follower_count` via `public_metrics`
- This PR surfaces the sort order to users so it's clear the list is ranked by most followers

## What's deferred

Backend pagination (fetch >1000 follows pages via `next_token`) is blocked by concurrent task cc-90569/C-3 XOAuth which owns `services/api/src/routes/twitter.ts`. Tracked separately.

## Test plan

- [ ] Connect X account on voice-profiles page
- [ ] Click "Import from X Follows"
- [ ] Verify "N accounts · sorted by most followers" label appears above the list
- [ ] Verify accounts are ordered highest follower count first

🤖 Generated with [Claude Code](https://claude.com/claude-code)