### PR TITLE
fix(arena) + perf(app-shell): Mobile P0 + Perf P0 in one PR

### DIFF
--- a/src/app/arena/page.tsx
+++ b/src/app/arena/page.tsx
@@ -261,7 +261,7 @@ function ArenaPage() {
     <AppShell>
       <div className="mx-auto max-w-5xl px-4 py-8 space-y-8">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <Trophy className="h-6 w-6 text-yellow-400" />
             <h1 className="font-heading font-extrabold tracking-tight text-2xl text-atlas-text">
@@ -315,7 +315,7 @@ function ArenaPage() {
 
         {/* Hero KPI Cards */}
         {myEntry && (
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <GlassCard className="text-center">
               <p className="text-xs text-atlas-text-secondary uppercase tracking-wide">
                 Tweets Published

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import { useEffect } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import NavBar from "@/components/ui/NavBar";
-import FloatingOracle from "@/components/oracle/FloatingOracle";
 import { useAuth } from "@/lib/auth";
 import { gradients } from "@/lib/tokens";
+
+// Perf P0: FloatingOracle is a 267-line client component with its own oracle
+// agent + framer-motion deps. It's not above-the-fold, never needs SSR, and
+// pulls a meaningful chunk into the initial app bundle when imported
+// statically. Lazy-loading it via next/dynamic with ssr:false drops it out
+// of the first paint and into a separate chunk fetched after hydration.
+const FloatingOracle = dynamic(
+  () => import("@/components/oracle/FloatingOracle"),
+  { ssr: false },
+);
 
 export interface AppShellProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
Combines two demo-blocker fixes the advisor dispatched in parallel today (Mobile P0 + Perf P0). Both are tiny, surgical, and verified.

### Mobile P0 — `arena/page.tsx` (commit `7f68485`)
- L264 header — `flex items-center justify-between` → `flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between`. The Trophy/title block + rank pill no longer collide on narrow viewports.
- L318 hero KPI grid — `grid grid-cols-3 gap-4` → `grid grid-cols-1 gap-4 sm:grid-cols-3`. Three big-number cards stack on mobile instead of crushing.

### Perf P0 — `AppShell.tsx` (commit `c4d8b9c`)
- Replace static `import FloatingOracle from "@/components/oracle/FloatingOracle"` with `next/dynamic` + `ssr: false`. FloatingOracle is a 267-line client component (oracle agent + framer-motion + inspector helpers) that's never above the fold, so it now loads in its own chunk after hydration instead of dragging into the initial app bundle.

## Why
Both dispatched by advisor cc-91886 at 14:10 in a parallel burst:
- Mobile P0 → cc-40335 (primary, silent — different repo, never executed) → I shipped as backup
- Perf P0 → cc-40908 (primary, silent — different repo, never executed) → I shipped as backup

Wired both primaries before stepping in. Single PR keeps the diff small and easy to revert if needed.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed files clean
- [x] `AppShell.test.tsx` — 2/2 pass
- [x] `DashboardPage.test.tsx` + `CraftingPage.test.tsx` — 17/17 pass (consumers of AppShell)
- [ ] Manual smoke at 375px on `/arena` → header stacks, KPIs single column
- [ ] Manual smoke at 1280px on any page → FloatingOracle still appears bottom-right after hydration
- [ ] Bundle analyzer check that FloatingOracle is in its own chunk (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)