### PR TITLE
perf(p0): add width/height to avatar <img> tags to prevent CLS

### DIFF
--- a/src/components/onboarding/BlendRatioSlider.tsx
+++ b/src/components/onboarding/BlendRatioSlider.tsx
@@ -208,6 +208,8 @@ function RefAvatar({ handle, name }: { handle?: string; name: string }) {
     <img
       src={`https://unavatar.io/twitter/${cleanHandle}`}
       alt={name}
+      width={32}
+      height={32}
       onError={() => setErrored(true)}
       className="h-8 w-8 shrink-0 rounded-full object-cover border border-atlas-text-secondary/20 bg-atlas-surface"
     />

--- a/src/components/onboarding/ReferenceVoiceSelector.tsx
+++ b/src/components/onboarding/ReferenceVoiceSelector.tsx
@@ -209,6 +209,8 @@ export default function ReferenceVoiceSelector({
                   <img
                     src={avatarUrl}
                     alt={`${label} avatar`}
+                    width={64}
+                    height={64}
                     className="mx-auto h-16 w-16 rounded-full object-cover"
                     onError={() => setImgErrors((prev) => new Set(prev).add(account.id))}
                   />

--- a/src/components/tweet-tinder/TweetCard.tsx
+++ b/src/components/tweet-tinder/TweetCard.tsx
@@ -106,9 +106,12 @@ export default function TweetCard({ tweet, onSwipe, isTop, stackIndex }: TweetCa
             {/* Author row */}
             <div className="flex items-center gap-3">
               {tweet.author_avatar ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
                 <img
                   src={tweet.author_avatar}
                   alt={tweet.author_handle}
+                  width={32}
+                  height={32}
                   className="h-8 w-8 rounded-full object-cover"
                 />
               ) : (

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -241,6 +241,8 @@ export default function NavBar({ variant }: NavBarProps) {
                   <img
                     src={user.avatarUrl}
                     alt={`${user.displayName || user.handle} avatar`}
+                    width={32}
+                    height={32}
                     className="h-full w-full rounded-full object-cover"
                   />
                 ) : (

--- a/src/components/voice-profiles/ReferenceVoicesSection.tsx
+++ b/src/components/voice-profiles/ReferenceVoicesSection.tsx
@@ -290,6 +290,8 @@ export default function ReferenceVoicesSection({
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
                       alt={`${account.displayName || account.name || account.handle} avatar`}
+                      width={48}
+                      height={48}
                       className="h-12 w-12 rounded-full border border-glass-border object-cover"
                       onError={() =>
                         setAvatarErrors((current) => ({

--- a/src/components/voice-profiles/VoiceLabInspirationPicker.tsx
+++ b/src/components/voice-profiles/VoiceLabInspirationPicker.tsx
@@ -460,6 +460,8 @@ export default function VoiceLabInspirationPicker({
                         <img
                           src={follow.avatarUrl}
                           alt={`${follow.displayName} avatar`}
+                          width={56}
+                          height={56}
                           className="h-14 w-14 rounded-full border border-glass-border object-cover"
                         />
                       ) : (


### PR DESCRIPTION
## Summary
Six above-the-fold avatar `<img>` tags render with no `width`/`height` attributes, so the browser reserves **zero layout space** until the image loads — every avatar on first paint causes a Cumulative Layout Shift. Added explicit dimensions matching the existing Tailwind class sizes.

| Component | Route(s) | Dims |
|---|---|---|
| `NavBar.tsx` | every authenticated page | 32×32 |
| `TweetCard.tsx` | `/tweet-tinder` | 32×32 |
| `ReferenceVoicesSection.tsx` | `/voice-profiles` | 48×48 |
| `BlendRatioSlider.tsx` | onboarding blend | 32×32 |
| `ReferenceVoiceSelector.tsx` | onboarding voice picker | 64×64 |
| `VoiceLabInspirationPicker.tsx` | voice-lab follow cards | 56×56 |

Pairs with the Atlas Perf P0 wave (a13xperi/atlas-portal#331). Biggest wins: `/dashboard` (NavBar avatar on first paint) and `/voice-profiles` (reference grid).

13 LOC added, 6 files. Standalone PR — rebased onto `staging`, not stacked on #331.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `next build` green — 37/37 pages generate, no new lint warnings
- [x] Previous `<img>` lint warning on `TweetCard.tsx` now suppressed with `eslint-disable-next-line` since we intentionally keep `<img>` for remote CDN avatars (no `next/image` domain allowlist churn)
- [ ] Vercel preview: visually confirm no layout shift on `/dashboard` first paint
- [ ] Lighthouse CLS score improves on `/dashboard`, `/voice-profiles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)