### PR TITLE
fix(a11y): sweep all bg-teal text-white to text-atlas-bg

### DIFF
--- a/src/app/admin/prompts/page.tsx
+++ b/src/app/admin/prompts/page.tsx
@@ -326,7 +326,7 @@ function PromptCard({
             <button
               onClick={onRunTest}
               disabled={test.loading}
-              className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-atlas-teal/20 transition-transform hover:scale-[1.02] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-2 text-xs font-semibold text-atlas-bg shadow-lg shadow-atlas-teal/20 transition-transform hover:scale-[1.02] disabled:cursor-not-allowed disabled:opacity-60"
             >
               {test.loading ? (
                 <>

--- a/src/app/admin/qa/page.tsx
+++ b/src/app/admin/qa/page.tsx
@@ -493,7 +493,7 @@ function QaContent() {
             )}
             <button
               onClick={exportMarkdown}
-              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-1.5 text-xs font-semibold text-white shadow-lg shadow-atlas-teal/20 transition-transform hover:scale-[1.03]"
+              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-1.5 text-xs font-semibold text-atlas-bg shadow-lg shadow-atlas-teal/20 transition-transform hover:scale-[1.03]"
             >
               Export Markdown
             </button>

--- a/src/app/briefing/page.tsx
+++ b/src/app/briefing/page.tsx
@@ -33,7 +33,7 @@ const BRIEF_TYPES = [
 const chipClasses = (selected: boolean) =>
   `inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-all ${
     selected
-      ? "border-atlas-teal bg-atlas-teal text-atlas-text shadow-sm shadow-atlas-teal/30"
+      ? "border-atlas-teal bg-atlas-teal text-atlas-bg shadow-sm shadow-atlas-teal/30"
       : "border-glass-border bg-atlas-surface text-atlas-text-secondary hover:border-atlas-teal/50 hover:text-atlas-text"
   }`;
 

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -2285,7 +2285,7 @@ function CraftingPage() {
                     onClick={handleToggleCompareMode}
                     className={`rounded px-2 py-1 text-xs ${
                       compareMode
-                        ? "bg-atlas-teal text-white"
+                        ? "bg-atlas-teal text-atlas-bg"
                         : "text-atlas-text-secondary hover:text-atlas-text"
                     }`}
                   >

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -38,7 +38,7 @@ export default function GlobalError({
           <button
             type="button"
             onClick={reset}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-white text-sm font-medium rounded-lg hover:scale-105 transition-transform"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-atlas-bg text-sm font-medium rounded-lg hover:scale-105 transition-transform"
           >
             <RotateCcw className="w-4 h-4" />
             Try again

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -104,7 +104,7 @@ function FeedPage() {
             <button
               type="button"
               onClick={() => router.push("/crafting")}
-              className="shrink-0 rounded-lg bg-atlas-teal px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-atlas-teal/80"
+              className="shrink-0 rounded-lg bg-atlas-teal px-4 py-2 text-sm font-semibold text-atlas-bg transition-all hover:bg-atlas-teal/80"
             >
               Post your first draft
             </button>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -33,7 +33,7 @@ export default function GlobalError({
           <button
             type="button"
             onClick={reset}
-            className="mt-8 inline-flex items-center justify-center bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-white rounded-lg px-6 py-3"
+            className="mt-8 inline-flex items-center justify-center bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-atlas-bg rounded-lg px-6 py-3"
           >
             Try again
           </button>

--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -188,7 +188,7 @@ function ManagementPage() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-delphi-teal to-delphi-blue-500 text-sm font-bold text-white">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-delphi-teal to-delphi-blue-500 text-sm font-bold text-atlas-bg">
                         {(member.displayName || member.handle)[0]?.toUpperCase()}
                       </div>
                       <div className="min-w-0">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,7 +8,7 @@ export default function NotFound() {
         <p className="text-atlas-text-secondary text-lg mt-4">Page not found</p>
         <Link
           href="/dashboard"
-          className="mt-8 inline-flex bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-white rounded-lg px-6 py-3 font-medium"
+          className="mt-8 inline-flex bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-atlas-bg rounded-lg px-6 py-3 font-medium"
         >
           Back to Dashboard
         </Link>

--- a/src/components/alerts/InlineDraftCard.tsx
+++ b/src/components/alerts/InlineDraftCard.tsx
@@ -216,7 +216,7 @@ export default function InlineDraftCard({ alert }: InlineDraftCardProps) {
                   <button
                     type="button"
                     onClick={handleEnqueue}
-                    className="rounded-lg bg-gradient-to-r from-delphi-blue-500 to-delphi-teal px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
+                    className="rounded-lg bg-gradient-to-r from-delphi-blue-500 to-delphi-teal px-3 py-2 text-xs font-semibold text-atlas-bg transition-opacity hover:opacity-90"
                   >
                     Add to Queue →
                   </button>

--- a/src/components/alerts/MonitorBuilder.tsx
+++ b/src/components/alerts/MonitorBuilder.tsx
@@ -312,7 +312,7 @@ export default function MonitorBuilder({
             type="button"
             onClick={() => void handleCreate()}
             disabled={creating}
-            className="w-full rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-4 py-3 text-sm font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {creating ? "Creating..." : "Create Monitor"}
           </button>

--- a/src/components/crafting/CraftingAdvisor.tsx
+++ b/src/components/crafting/CraftingAdvisor.tsx
@@ -206,7 +206,7 @@ export function CraftingAdvisor({
               className={`
                 w-full py-3 rounded-xl text-sm font-semibold transition-all duration-200
                 ${canGenerate
-                  ? 'bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-white hover:opacity-90 active:scale-[0.99]'
+                  ? 'bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-atlas-bg hover:opacity-90 active:scale-[0.99]'
                   : 'bg-atlas-surface/50 text-white/30 cursor-not-allowed border border-glass-border'
                 }
               `}

--- a/src/components/onboarding/ReferenceVoiceSelector.tsx
+++ b/src/components/onboarding/ReferenceVoiceSelector.tsx
@@ -127,7 +127,7 @@ export default function ReferenceVoiceSelector({
             onClick={() => setActiveCategory(cat as CategoryFilter)}
             className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
               activeCategory === cat
-                ? "bg-atlas-teal text-white"
+                ? "bg-atlas-teal text-atlas-bg"
                 : "bg-atlas-surface text-atlas-text-secondary"
             }`}
           >
@@ -201,7 +201,7 @@ export default function ReferenceVoiceSelector({
               >
                 {isSelected && (
                   <span className="absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-atlas-teal">
-                    <Check className="h-3.5 w-3.5 text-white" />
+                    <Check className="h-3.5 w-3.5 text-atlas-bg" />
                   </span>
                 )}
                 {avatarUrl && !imgErrors.has(account.id) ? (

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -311,7 +311,7 @@ export default function RecipeCard({
           className={`inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity ${
             isActive
               ? "cursor-default border border-atlas-teal/30 bg-atlas-teal/20 text-atlas-teal"
-              : "bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-white hover:opacity-90"
+              : "bg-gradient-to-r from-delphi-teal to-delphi-teal/60 text-atlas-bg hover:opacity-90"
           }`}
         >
           <Sparkles className="h-4 w-4" />

--- a/src/components/voice-profiles/VoiceEditorModal.tsx
+++ b/src/components/voice-profiles/VoiceEditorModal.tsx
@@ -289,7 +289,7 @@ export default function VoiceEditorModal({
               type="button"
               onClick={() => setStep("tune")}
               disabled={!selectedFollow}
-              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-6 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-6 py-2 text-sm font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Next →
             </button>
@@ -380,7 +380,7 @@ export default function VoiceEditorModal({
               disabled={
                 saveDisabled || saving || (mode !== "edit-personal" && !name.trim())
               }
-              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-6 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-gradient-to-r from-delphi-teal to-delphi-teal/60 px-6 py-2 text-sm font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {saving ? "Saving..." : mode === "create" ? "Create Voice" : "Save Changes"}
             </button>


### PR DESCRIPTION
## Summary
- Sweeps **17 inline a11y contrast failures** across **15 files** — every remaining `bg-(atlas|delphi)-teal` button that hardcodes `text-white` (or `text-atlas-text` = `#ffffff`).
- Single mechanical fix: `text-white` → `text-atlas-bg` on solid teal / teal-gradient backgrounds.
- Stacks on top of #332 (no line overlap — different sites).

## Why
This is the follow-up sweep promised in the PR #332 body. PR #332 fixed the `.gradient-cta` Tailwind helper + 4 inline call sites. Grepping the rest of `src/` surfaced 17 more buttons using the same broken pattern but bypassing the helper.

| Background | `text-white` | `text-atlas-bg` (#010411) |
|---|---|---|
| `#4ecdc4` (atlas-teal / delphi-teal) | ~1.9:1 ❌ | ~12:1 ✅ AAA |
| `#3B82F6` (delphi-blue-500, mixed gradient end) | ~3.7:1 ❌ | ~5.6:1 ✅ AA |

Both ends improved on mixed gradients; no regressions.

## Sites by file (17 LOC across 15 files)

| File | Site |
|---|---|
| `components/onboarding/ReferenceVoiceSelector.tsx` | category chip selected (×1) + Check icon in selected card (×1) |
| `app/crafting/page.tsx` | compare-mode toggle button |
| `app/briefing/page.tsx` | filter chip selected state (`text-atlas-text` alias) |
| `app/feed/page.tsx` | "Post your first draft" CTA |
| `components/alerts/MonitorBuilder.tsx` | "Create Monitor" submit |
| `app/not-found.tsx` | "Back to Dashboard" link |
| `app/global-error.tsx` | "Try again" button |
| `components/crafting/CraftingAdvisor.tsx` | Generate button (active state) |
| `app/management/page.tsx` | member avatar initials (teal→blue gradient) |
| `app/admin/prompts/page.tsx` | Run-test button |
| `components/voice-profiles/VoiceEditorModal.tsx` | Next + Save buttons (×2, identical class string) |
| `app/admin/qa/page.tsx` | Export Markdown button |
| `app/error.tsx` | "Try again" button (root error boundary) |
| `components/voice-profiles/RecipeCard.tsx` | "Use in Crafting" CTA |
| `components/alerts/InlineDraftCard.tsx` | "Add to Queue" button (blue→teal gradient) |

15 files, 17 insertions(+), 17 deletions(-).

## What was deliberately NOT touched
- Decorative dots / progress bars / loader rings using `bg-atlas-teal` with no text on top — no contrast concern.
- `bg-atlas-teal/10`, `/20`, `/5` translucent variants — background is mostly the dark surface beneath, white text fine.
- `text-delphi-teal` text used as foreground on dark surfaces — passes already.

## Test plan
- [ ] CI: typecheck + lint + e2e + e2e-extended (a11y) green
- [ ] Vercel preview deploys cleanly
- [ ] Spot-check pages: `/feed`, `/crafting`, `/briefing`, `/admin/qa`, `/not-found`, `/management`
- [ ] Voice editor modal save/next buttons
- [ ] Reference voice picker selected state

## Stacking
- Independent of #332 — touches different lines in `crafting/page.tsx`, no other file overlap.
- Either order can merge first; the other rebases cleanly.

## Context
Directive: T2 from advisor (`cc-74635`) — "Ship the bg-atlas-teal text-white sweep PR you noted in your follow-up. Same pattern as gradient-cta. Single PR, all instances."
Session: cc-41516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)