### PR TITLE
feat(analytics): Top Performing Drafts empty state + clickable rows (#3966)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -282,12 +282,17 @@ function AnalyticsPage() {
           </div>
         </div>
 
-        {topDrafts.length > 0 && (
-          <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface p-4">
-            <h3 className="mb-3 text-sm font-medium text-atlas-text">Top Performing Drafts</h3>
+        <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface p-4">
+          <h3 className="mb-3 text-sm font-medium text-atlas-text">Top Performing Drafts</h3>
+          {topDrafts.length > 0 ? (
             <div className="space-y-3">
               {topDrafts.map((draft, i) => (
-                <div key={draft.id} className="flex items-start gap-3">
+                <Link
+                  key={draft.id}
+                  href="/crafting"
+                  aria-label={`Top draft ${i + 1}: open Crafting Station`}
+                  className="flex items-start gap-3 rounded-xl p-2 -m-2 transition-colors hover:bg-white/[0.04] focus:outline-none focus:ring-2 focus:ring-atlas-teal"
+                >
                   <span
                     className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${
                       i === 0 ? "bg-atlas-teal/20 text-atlas-teal" : "bg-atlas-surface text-atlas-text-muted"
@@ -301,11 +306,23 @@ function AnalyticsPage() {
                       {draft.actualEngagement} engagements
                     </p>
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
-          </div>
-        )}
+          ) : (
+            <div className="py-6 text-center">
+              <p className="text-sm text-atlas-text-muted">
+                Top drafts will appear here once your posted tweets accumulate engagement.
+              </p>
+              <Link
+                href="/crafting"
+                className="mt-3 inline-block text-xs font-medium text-atlas-teal hover:text-atlas-teal/80 transition-colors"
+              >
+                Head to the Crafting Station →
+              </Link>
+            </div>
+          )}
+        </div>
 
         {/* SECTION 6: Learning Log */}
         <div data-tour="analytics-learning" className="mb-6 rounded-xl border border-glass-border bg-atlas-surface p-6 sm:p-8">


### PR DESCRIPTION
## Summary
Completes Notion task #3966 (Clean analytics — remove placeholder crypto tweets). The placeholder Vitalik/EigenLayer content was already removed in a prior commit, but two sub-items remained:

### Empty state for Top Performing Drafts
The section at `analytics/page.tsx:285` was gated behind \`{topDrafts.length > 0 && (...)}\`, so the entire card vanished when a user had no posted drafts — inconsistent with the other analytics widgets that all show \"data will appear once…\" copy. Always render the card now, with an empty state that points users at the Crafting Station.

### Clickable top-draft rows
Each top draft row was a plain \`<div>\` with no handler. Wrapped each in a Next.js \`<Link href=\"/crafting\">\` so users can jump into the Crafting Station to create something similar, matching the UsageStats card pattern already in use elsewhere on the page. Added \`aria-label\` and a focus ring for keyboard users.

### Already done in prior commits (checked but no action needed)
- Placeholder Vitalik/EigenLayer tweets: removed — grep confirms no residual references under \`src/app/analytics/\` or \`src/components/analytics/\`
- \"Head to the Crafting Station\" CTA: already present at line 224 in the Usage Insight section
- Other widgets (activity sparkline, confidence trend, learning log, model reliability) already have consistent empty states

## Test plan
- [ ] Visual check \`/analytics\` for a user with no posted drafts — empty state shows \"Top drafts will appear here…\" with a teal \"Head to the Crafting Station →\" link
- [ ] Visual check \`/analytics\` for a user with top drafts — rows render as before, full card is clickable, hover highlight visible, keyboard focus ring visible
- [ ] Click a top draft row → navigates to \`/crafting\`
- [ ] Keyboard tab through the section → each row reachable, focus ring renders
- [ ] \`next build\` clean (verified locally)
- [ ] Vercel preview build green

## Build
\`next build\` clean. \`/analytics\` route: 8.12 kB / 163 kB first load. AnalyticsPage tests 2/2 still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)