### PR TITLE
fix(security): whitelist Twitter avatar domains in CSP img-src

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,7 +73,7 @@ export function middleware(request: NextRequest) {
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "img-src 'self' data: blob:",
+      "img-src 'self' data: blob: https://pbs.twimg.com https://unavatar.io",
       `connect-src 'self' ${apiOrigin} https://zoirudjyqfqvpxsrxepr.supabase.co wss:`,
       "font-src 'self' https://fonts.gstatic.com",
       "frame-ancestors 'self'",


### PR DESCRIPTION
## Summary
- CSP `img-src` was missing `pbs.twimg.com` and `unavatar.io`, causing all Twitter avatars to be blocked by the browser
- Affects: X OAuth callback success card, voice profile reference voices, X follows import modal
- One-line fix in `src/middleware.ts`

## Test plan
- [ ] Deploy preview — verify avatars load on `/auth/x/callback` after connecting X
- [ ] Check reference voice avatars on `/voice-profiles`
- [ ] Confirm no CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)