### PR TITLE
fix(e2e): resolve Vercel SSO bypass flakiness on PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,8 @@ jobs:
       - run: npx playwright test --config=playwright-e2e.config.ts --project=${{ matrix.project }}
         continue-on-error: ${{ matrix.continue_on_error == true }}
         env:
-          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET || secrets.VERCEL_PROTECTION_BYPASS }}
+          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET || secrets.VERCEL_PROTECTION_BYPASS }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/e2e/demo-mode/playwright.config.ts
+++ b/e2e/demo-mode/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { resolvePlaywrightBaseURL, resolveVercelBypassHeaders } from "../playwright-env";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "https://delphi-atlas.vercel.app";
+const baseURL = resolvePlaywrightBaseURL("https://delphi-atlas.vercel.app");
 
 export default defineConfig({
   testDir: ".",
@@ -14,9 +15,7 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   use: {
     baseURL,
-    extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS
-      ? { "x-vercel-protection-bypass": process.env.VERCEL_PROTECTION_BYPASS }
-      : {},
+    extraHTTPHeaders: resolveVercelBypassHeaders() ?? {},
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },

--- a/e2e/demo-mode/tier1.spec.ts
+++ b/e2e/demo-mode/tier1.spec.ts
@@ -14,7 +14,7 @@
  * Plus an auth-gate test (no cookies → redirect to /).
  */
 
-import { test as fixtureTest, expect, stubAuth, stubDataEndpoints } from "../fixtures";
+import { test as fixtureTest, expect, stubAuth, stubDataEndpoints, vercelBypassCookies } from "../fixtures";
 import { type Page } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
@@ -29,6 +29,7 @@ const test = fixtureTest.extend<{ demoPage: Page }>({
     await context.addCookies([
       { name: "atlas_access_token", value: "1", domain: url.hostname, path: "/" },
       { name: "atlas_session", value: "1", domain: url.hostname, path: "/" },
+      ...vercelBypassCookies(url.hostname),
     ]);
 
     // Stub auth + data endpoints (network never touched)

--- a/e2e/playwright-env.ts
+++ b/e2e/playwright-env.ts
@@ -29,7 +29,10 @@ export function resolveVercelBypassSecret() {
 export function resolveVercelBypassHeaders() {
   const bypassSecret = resolveVercelBypassSecret();
   return bypassSecret
-    ? { "x-vercel-protection-bypass": bypassSecret }
+    ? {
+        "x-vercel-protection-bypass": bypassSecret,
+        "x-vercel-set-bypass-cookie": "samesitenone",
+      }
     : undefined;
 }
 


### PR DESCRIPTION
## Summary
- Added `x-vercel-set-bypass-cookie: samesitenone` header to shared bypass helper — fixes client-side navigation being blocked after initial page load on preview deployments
- Added missing bypass cookies to `e2e/demo-mode/tier1.spec.ts` — was completely unprotected
- Added `VERCEL_AUTOMATION_BYPASS_SECRET` to `e2e-extended` CI job (was only passing legacy env var)
- Migrated `demo-mode/playwright.config.ts` to use shared `resolveVercelBypassHeaders()` instead of inline env check

## Test plan
- [ ] CI e2e and e2e-extended jobs pass on this PR's preview deployment
- [ ] demo-mode tier1 tests no longer fail on protected previews
- [ ] a11y, errors, performance extended tests pass with new env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)