### PR TITLE
Tweak copy/tone from Anil feedback

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -140,8 +140,8 @@ function AnalyticsPage() {
     return (
       <AppShell>
         <div className="flex flex-col items-center justify-center py-24 text-center">
-          <h2 className="font-heading font-bold tracking-tight text-2xl text-atlas-text">No analytics data yet</h2>
-          <p className="mt-2 text-atlas-text-secondary">Start crafting drafts to see your analytics here.</p>
+          <h2 className="font-heading font-bold tracking-tight text-2xl text-atlas-text">Nothing here yet</h2>
+          <p className="mt-2 text-atlas-text-secondary">Craft your first draft and the numbers will start rolling in.</p>
         </div>
       </AppShell>
     );
@@ -166,7 +166,7 @@ function AnalyticsPage() {
             Your Analytics
           </h1>
           <p className="text-atlas-text-secondary mt-2 max-w-2xl text-sm leading-relaxed">
-            Track how Atlas learns your voice over time. The charts below show how accurately Atlas predicts your tweet engagement, how your writing style is evolving, and where your best-performing content comes from. The more you draft and give feedback, the sharper these predictions get.
+            See how your voice is evolving and which content hits hardest. Atlas gets sharper with every draft you write and every piece of feedback you give.
           </p>
         </div>
 
@@ -216,12 +216,12 @@ function AnalyticsPage() {
             );
           })() : (
             <div className="mt-6 h-8 flex items-center justify-center">
-              <p className="text-xs text-atlas-text-muted">Activity data will appear as you create drafts</p>
+              <p className="text-xs text-atlas-text-muted">Your activity chart shows up once you start drafting</p>
             </div>
           )}
           <p className="text-atlas-text-muted text-sm italic mt-3">
             {allZero
-              ? "Head to the Crafting Station to create your first draft — your analytics will populate as you go."
+              ? "Drop a report or hot take in the Crafting Station — your stats will light up from there."
               : "The more you use Atlas, the better it gets."}
           </p>
         </div>
@@ -264,7 +264,7 @@ function AnalyticsPage() {
                 }
               ) : (
                 <div className="flex-1 flex items-center justify-center">
-                  <p className="text-xs text-atlas-text-muted italic">Confidence data builds as you create and refine drafts</p>
+                  <p className="text-xs text-atlas-text-muted italic">Confidence scores appear after a few rounds of drafting</p>
                 </div>
               )}
             </div>
@@ -276,7 +276,7 @@ function AnalyticsPage() {
               </p>
             ) : (
               <p className="font-heading font-medium text-base text-atlas-text-muted italic leading-relaxed">
-                Model insights will appear here as your usage history grows.
+                Keep drafting — Atlas will surface patterns in your writing here.
               </p>
             )}
           </div>

--- a/src/app/briefing/page.tsx
+++ b/src/app/briefing/page.tsx
@@ -234,7 +234,7 @@ function BriefingPage() {
               Your Briefings
             </h1>
             <p className="max-w-xl text-sm leading-relaxed text-atlas-text-secondary">
-              Your personalized daily digest. Atlas scans your topics, sources, and the latest market activity to generate a concise briefing you can read in under 2 minutes. Hit Generate Now to create one on demand, or set a delivery time to get them automatically.
+              A quick daily read built from your topics and the latest market moves. Hit Generate Now or schedule them to land automatically.
             </p>
           </div>
           <div className="flex items-center gap-3">

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -38,7 +38,7 @@ export default function CampaignsPage() {
           </h1>
         </div>
         <p className="mt-2 text-sm text-atlas-text-secondary">
-          Define narratives, group your posts, and manage your posting queue.
+          Group your posts around a narrative and schedule them from one place.
         </p>
 
         <Link href="/queue" className="mt-6 flex items-center justify-between rounded-xl border border-glass-border bg-atlas-surface p-4 transition-colors hover:border-atlas-teal/30">
@@ -209,7 +209,7 @@ function CampaignsTab() {
         <GlassCard className="w-full max-w-2xl mx-auto p-10 text-center">
           <Megaphone className="mx-auto mb-3 h-10 w-10 text-atlas-text-muted" />
           <p className="text-sm text-atlas-text-secondary">
-            No campaigns yet. Create one to define a narrative and group posts around it.
+            No campaigns yet. Create one to build a posting thread around a single narrative.
           </p>
         </GlassCard>
       ) : (

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -1262,7 +1262,7 @@ function CraftingPage() {
     <AppShell>
       <div className="mb-6">
         <h1 className="font-heading font-extrabold tracking-tight text-3xl text-atlas-text">Crafting Station</h1>
-        <p className="mt-2 text-atlas-text-secondary max-w-2xl">Turn signals, reports, and ideas into polished tweets in your voice. Atlas generates drafts, you refine them, and the model learns what works.</p>
+        <p className="mt-2 text-atlas-text-secondary max-w-2xl">Drop in a report, signal, or idea — Atlas drafts it in your voice. Refine it, and the model gets sharper every time.</p>
       </div>
 
       <div className="mb-6" data-tour="oracle-banner">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -236,8 +236,7 @@ const searchParams = useSearchParams();
         Welcome back, {user?.handle || "Analyst"}
       </h1>
       <p className="mt-2 max-w-2xl text-atlas-text-secondary">
-        Your command center. See what&apos;s queued, track recent activity, and
-        jump to any part of Atlas from here.
+        See what&apos;s queued, track recent activity, and jump to any part of Atlas from here.
       </p>
 
       {showVoiceCalibratedBanner && (
@@ -351,7 +350,7 @@ const searchParams = useSearchParams();
       </ul>
       {showStatsEmptyState && (
         <p className="text-xs text-atlas-text-muted mt-1">
-          Get started by crafting your first draft
+          Drop your first report or hot take to get rolling
         </p>
       )}
 

--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -59,7 +59,7 @@ function ManagementPage() {
               Team Management
             </h1>
             <p className="mt-1 text-sm text-atlas-text-secondary">
-              Manage roles, permissions, and team voice settings. {team.length} team member{team.length !== 1 ? "s" : ""}.
+              Your team at a glance. {team.length} member{team.length !== 1 ? "s" : ""} and their voice profiles.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -610,7 +610,7 @@ export default function VoiceProfilesPage() {
         <p className="text-sm font-medium uppercase tracking-[0.2em] text-atlas-teal">Voice Studio</p>
         <h1 className="mt-2 font-heading text-2xl font-bold tracking-tight text-atlas-text">Your Voices</h1>
         <p className="mt-1 text-sm text-atlas-text-secondary">
-          Add inspirations, then blend them into voices you can craft with.
+          Pick writers you admire, then mix their style with yours.
         </p>
 
         {/* Inspirations — seed your voice before seeing blends */}


### PR DESCRIPTION
## Summary
- Rewrote subheaders and empty states across 7 pages to be more casual and conversational per Anil's tone preferences (humor 7/10)
- Removed formal/generic copy like "command center", "populate", "as your usage history grows"
- Made CTAs punchier: "Drop a report or hot take" instead of "Head to the Crafting Station to create your first draft"
- Pages touched: analytics, briefing, campaigns, crafting, dashboard, management, voice-profiles

## Test plan
- [x] `next build` passes
- [x] 14/14 smoke tests pass against production
- [x] Screenshots verified for all 9 DoD items

🤖 Generated with [Claude Code](https://claude.com/claude-code)