### PR TITLE
feat(campaigns): PDF → campaign with timing + analyst recs

### DIFF
--- a/src/__tests__/campaign-recommendations.test.ts
+++ b/src/__tests__/campaign-recommendations.test.ts
@@ -1,0 +1,127 @@
+import {
+  classifyFormat,
+  recommendTiming,
+  suggestAnalysts,
+  buildStrategyBullets,
+  type ContentFormat,
+} from "@/lib/campaign-recommendations";
+
+describe("classifyFormat", () => {
+  it('returns "article" for content over 1200 characters', () => {
+    const content = "a".repeat(1201);
+    expect(classifyFormat(content)).toBe("article");
+  });
+
+  it('returns "article" when content contains "## "', () => {
+    const content = "# Title\n\n## Section\n\nSome text";
+    expect(classifyFormat(content)).toBe("article");
+  });
+
+  it('returns "thread" when content contains "\\n\\n1."', () => {
+    const content = "Intro\n\n1. First point\n\n2. Second point";
+    expect(classifyFormat(content)).toBe("thread");
+  });
+
+  it('returns "thread" when content contains "\\n\\n1/"', () => {
+    const content = "Hook\n\n1/ First tweet\n\n2/ Second tweet";
+    expect(classifyFormat(content)).toBe("thread");
+  });
+
+  it('returns "thread" when content has more than 2 paragraph breaks', () => {
+    const content = "A\n\nB\n\nC\n\nD";
+    expect(classifyFormat(content)).toBe("thread");
+  });
+
+  it('returns "one-liner" for short single-paragraph content', () => {
+    const content = "Just a short tweet.";
+    expect(classifyFormat(content)).toBe("one-liner");
+  });
+});
+
+describe("recommendTiming", () => {
+  it.each<[string, string, string]>([
+    ["contrarian take", "Tuesday 10:00 AM EST", "Crypto Twitter peaks midweek mornings EST; contrarian takes generate most engagement then."],
+    ["hot take", "Tuesday 10:00 AM EST", "Crypto Twitter peaks midweek mornings EST; contrarian takes generate most engagement then."],
+    ["data highlight", "Wednesday 2:00 PM EST", "Data-heavy posts perform best midweek afternoons when readers have time to click."],
+    ["prediction", "Sunday 6:00 PM EST", "Predictions about the week ahead land best Sunday evenings."],
+    ["key finding", "Thursday 11:00 AM EST", "Core findings earn the most retweets midweek late-morning."],
+  ])("for angle %s returns label %s", (angle, expectedLabel, expectedReason) => {
+    const result = recommendTiming(angle, "one-liner");
+    expect(result.label).toBe(expectedLabel);
+    expect(result.reason).toBe(expectedReason);
+  });
+
+  it('defaults to "thread hook" timing for unknown angles', () => {
+    const result = recommendTiming("unknown angle", "one-liner");
+    expect(result.label).toBe("Tuesday 9:00 AM EST");
+    expect(result.reason).toBe("Thread hooks get more follow-throughs in the morning.");
+  });
+});
+
+describe("suggestAnalysts", () => {
+  it("returns Anil for contrarian takes", () => {
+    const result = suggestAnalysts("contrarian take", "one-liner");
+    expect(result.map((r) => r.slug)).toContain("anil");
+  });
+
+  it("returns Kevin for data highlights", () => {
+    const result = suggestAnalysts("data highlight", "one-liner");
+    expect(result.map((r) => r.slug)).toContain("kevin");
+  });
+
+  it("returns Jonah for predictions", () => {
+    const result = suggestAnalysts("prediction", "one-liner");
+    expect(result.map((r) => r.slug)).toContain("jonah");
+  });
+
+  it("returns Ceteris for articles (format match)", () => {
+    const result = suggestAnalysts("narrative arc", "article");
+    expect(result.map((r) => r.slug)).toContain("ceteris");
+  });
+
+  it("returns exactly 2 analysts", () => {
+    const result = suggestAnalysts("contrarian take", "one-liner");
+    expect(result.length).toBe(2);
+  });
+
+  it("falls back to first 2 analysts when no match", () => {
+    const result = suggestAnalysts("totally unknown", "one-liner");
+    expect(result[0].slug).toBe("anil");
+    expect(result[1].slug).toBe("kevin");
+  });
+});
+
+describe("buildStrategyBullets", () => {
+  it("builds bullets from draft angles", () => {
+    const drafts = [
+      { id: "1", content: "a", angle: "contrarian take", qualityScore: 80, discarded: false },
+      { id: "2", content: "b", angle: "data highlight", qualityScore: 75, discarded: false },
+      { id: "3", content: "c", angle: "prediction", qualityScore: 70, discarded: false },
+    ];
+    const bullets = buildStrategyBullets([], drafts as any);
+    expect(bullets).toEqual([
+      "1 contrarian take — lead with one Tuesday 10am EST",
+      "1 data highlight — pair with chart, post Wed afternoon",
+      "Save 1 prediction for Sunday evening",
+    ]);
+  });
+
+  it("ignores discarded drafts", () => {
+    const drafts = [
+      { id: "1", content: "a", angle: "contrarian take", qualityScore: 80, discarded: true },
+      { id: "2", content: "b", angle: "data highlight", qualityScore: 75, discarded: false },
+    ];
+    const bullets = buildStrategyBullets([], drafts as any);
+    expect(bullets).toEqual([
+      "1 data highlight — pair with chart, post Wed afternoon",
+    ]);
+  });
+
+  it("returns fallback when no specific angles match", () => {
+    const drafts = [
+      { id: "1", content: "a", angle: "narrative arc", qualityScore: 80, discarded: false },
+    ];
+    const bullets = buildStrategyBullets([], drafts as any);
+    expect(bullets).toEqual(["1 draft ready — review and schedule the top performers"]);
+  });
+});

--- a/src/app/campaigns/wizard/page.tsx
+++ b/src/app/campaigns/wizard/page.tsx
@@ -7,16 +7,22 @@ import {
   FileText,
   Loader2,
   Check,
-  X,
   Sparkles,
   ArrowLeft,
   ArrowRight,
 } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
-import GlassCard from "@/components/ui/GlassCard";
 import GradientButton from "@/components/ui/GradientButton";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import CampaignDraftCard from "@/components/campaigns/CampaignDraftCard";
+import {
+  classifyFormat,
+  recommendTiming,
+  suggestAnalysts,
+  buildStrategyBullets,
+  type ContentFormat,
+} from "@/lib/campaign-recommendations";
 
 type WizardStep = "upload" | "analyzing" | "review" | "done";
 type SourceType = "REPORT" | "ARTICLE";
@@ -36,17 +42,14 @@ interface InsightData {
   angle: string;
 }
 
-const ANGLE_COLORS: Record<string, string> = {
-  "contrarian take": "bg-orange-500/20 text-orange-400 border-orange-500/30",
-  "data highlight": "bg-blue-500/20 text-blue-400 border-blue-500/30",
-  prediction: "bg-violet-500/20 text-violet-400 border-violet-500/30",
-  "practical advice": "bg-green-500/20 text-green-400 border-green-500/30",
-  "narrative arc": "bg-teal-500/20 text-teal-400 border-teal-500/30",
-  "hot take": "bg-red-500/20 text-red-400 border-red-500/30",
-  explainer: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
-};
-
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+const FORMAT_LABELS: Record<ContentFormat | "all", string> = {
+  all: "All",
+  "one-liner": "One-liner",
+  thread: "Thread",
+  article: "Article",
+};
 
 export default function CampaignWizardPage() {
   const { user } = useAuth();
@@ -69,6 +72,7 @@ export default function CampaignWizardPage() {
     id: string;
     title: string;
   } | null>(null);
+  const [formatFilter, setFormatFilter] = useState<ContentFormat | "all">("all");
 
   const handleFileSelect = async (files: FileList) => {
     const file = files[0];
@@ -77,8 +81,36 @@ export default function CampaignWizardPage() {
     if (file.type === "text/plain" || file.name.endsWith(".txt") || file.name.endsWith(".md")) {
       const text = await file.text();
       setContent(text);
+    } else if ((file.type === "application/pdf" || file.name.endsWith(".pdf")) && content.trim() === "") {
+      // One-shot PDF → campaign path
+      try {
+        setError("");
+        setStep("analyzing");
+        setStatusText("Extracting insights and drafting tweets...");
+        const result = await api.campaigns.generateFromPdf(file, {
+          name: campaignName || undefined,
+        });
+        setDrafts(
+          (result.drafts || []).map((d: any) => ({
+            ...d,
+            qualityScore: d.score ?? 0,
+            discarded: false,
+          }))
+        );
+        if (result.campaignId) {
+          setSavedCampaign({
+            id: result.campaignId,
+            title: campaignName.trim() || result.filename || "Untitled Campaign",
+          });
+        }
+        setStatusText("");
+        setStep("review");
+      } catch (err: any) {
+        setError(err.message || "Failed to generate campaign from PDF. Please try again.");
+        setStep("upload");
+      }
     } else if (file.type === "application/pdf" || file.name.endsWith(".pdf")) {
-      // Send to backend for proper PDF text extraction
+      // Fallback: extract text and populate content when content field is not empty
       try {
         setStatusText("Extracting PDF text…");
         const form = new FormData();
@@ -137,6 +169,7 @@ export default function CampaignWizardPage() {
           discarded: false,
         }))
       );
+      setSavedCampaign(null);
       setStatusText("");
       setStep("review");
     } catch (err: any) {
@@ -188,7 +221,7 @@ export default function CampaignWizardPage() {
         }
       }
 
-      if (createCampaign && campaignName.trim()) {
+      if (createCampaign && !savedCampaign && campaignName.trim()) {
         const { campaign } = await api.campaigns.create(campaignName.trim());
         for (let i = 0; i < activeDrafts.length; i++) {
           await api.campaigns.addDraft(campaign.id, activeDrafts[i].id, i + 1);
@@ -205,6 +238,21 @@ export default function CampaignWizardPage() {
   };
 
   const activeDraftCount = drafts.filter((d) => !d.discarded).length;
+
+  const formatCounts = {
+    all: activeDraftCount,
+    "one-liner": drafts.filter((d) => !d.discarded && classifyFormat(d.content) === "one-liner").length,
+    thread: drafts.filter((d) => !d.discarded && classifyFormat(d.content) === "thread").length,
+    article: drafts.filter((d) => !d.discarded && classifyFormat(d.content) === "article").length,
+  };
+
+  const visibleDrafts = drafts.filter((d) => {
+    if (d.discarded) return false;
+    if (formatFilter === "all") return true;
+    return classifyFormat(d.content) === formatFilter;
+  });
+
+  const strategyBullets = buildStrategyBullets(insights, drafts);
 
   return (
     <AppShell>
@@ -408,78 +456,59 @@ export default function CampaignWizardPage() {
               </p>
             </div>
 
+            {/* Strategy guide */}
+            {strategyBullets.length > 0 && (
+              <div className="rounded-2xl border border-glass-border bg-glass p-5 backdrop-blur-xl">
+                <h3 className="mb-2 text-sm font-medium text-atlas-text">
+                  Content strategy for this report
+                </h3>
+                <ul className="list-disc space-y-1 pl-4 text-sm text-atlas-text-secondary">
+                  {strategyBullets.map((b, i) => (
+                    <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
             {/* Summary */}
             <p className="text-sm text-atlas-text-secondary">
               {insights.length} insights extracted, {activeDraftCount} drafts generated.
             </p>
 
+            {/* Format filter */}
+            <div className="flex flex-wrap items-center gap-2">
+              {(["all", "one-liner", "thread", "article"] as const).map((fmt) => (
+                <button
+                  key={fmt}
+                  type="button"
+                  onClick={() => setFormatFilter(fmt)}
+                  className={`rounded-lg px-3 py-1.5 text-sm transition-colors ${
+                    formatFilter === fmt
+                      ? "border border-atlas-teal bg-atlas-teal/10 text-atlas-teal"
+                      : "border border-glass-border bg-atlas-surface text-atlas-text-muted hover:text-atlas-text"
+                  }`}
+                >
+                  {FORMAT_LABELS[fmt]} ({formatCounts[fmt]})
+                </button>
+              ))}
+            </div>
+
             {/* Draft cards */}
             <div className="space-y-5">
-              {drafts.map((draft, index) => {
-                if (draft.discarded) return null;
-                const insight = insights[index];
-                const angleClass =
-                  ANGLE_COLORS[draft.angle] ||
-                  "bg-atlas-text-muted/20 text-atlas-text-muted border-atlas-text-muted/30";
-
+              {visibleDrafts.map((draft) => {
+                const format = classifyFormat(draft.content);
+                const timing = recommendTiming(draft.angle, format);
+                const analysts = suggestAnalysts(draft.angle, format);
                 return (
-                  <div
+                  <CampaignDraftCard
                     key={draft.id}
-                    className="rounded-2xl border border-glass-border bg-glass p-6 backdrop-blur-xl"
-                  >
-                    {/* Insight header */}
-                    {insight && (
-                      <div className="mb-3">
-                        <p className="text-xs font-medium text-atlas-text-muted">
-                          {insight.title}
-                        </p>
-                        <p className="mt-0.5 text-xs text-atlas-text-muted/70">
-                          {insight.summary}
-                        </p>
-                      </div>
-                    )}
-
-                    {/* Angle badge + actions */}
-                    <div className="mb-3 flex items-center justify-between">
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${angleClass}`}
-                      >
-                        {draft.angle}
-                      </span>
-                      <div className="flex items-center gap-3">
-                        {/* Quality bar */}
-                        <div className="flex items-center gap-1.5">
-                          <span className="text-[10px] text-atlas-text-muted">Quality</span>
-                          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-atlas-surface">
-                            <div
-                              className="h-full rounded-full bg-atlas-teal"
-                              style={{
-                                width: `${Math.min(100, draft.qualityScore)}%`,
-                              }}
-                            />
-                          </div>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => discardDraft(draft.id)}
-                          className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-error"
-                          aria-label="Discard draft"
-                        >
-                          <X className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Editable draft content */}
-                    <textarea
-                      value={draft.content}
-                      onChange={(e) =>
-                        updateDraftContent(draft.id, e.target.value)
-                      }
-                      rows={4}
-                      className="w-full rounded-lg border border-glass-border bg-atlas-surface px-3 py-2 text-sm text-atlas-text placeholder:text-atlas-text-muted focus:border-atlas-teal focus:outline-none"
-                    />
-                  </div>
+                    draft={draft}
+                    onContentChange={updateDraftContent}
+                    onDiscard={discardDraft}
+                    format={format}
+                    timing={timing}
+                    analysts={analysts}
+                  />
                 );
               })}
             </div>

--- a/src/components/campaigns/CampaignDraftCard.tsx
+++ b/src/components/campaigns/CampaignDraftCard.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { X, Clock, User, ChevronDown, ChevronUp } from "lucide-react";
+import type { ContentFormat, TimingRecommendation, AnalystSuggestion } from "@/lib/campaign-recommendations";
+
+interface CampaignDraftCardProps {
+  draft: { id: string; content: string; angle: string; qualityScore: number };
+  onContentChange: (id: string, next: string) => void;
+  onDiscard: (id: string) => void;
+  timing: TimingRecommendation;
+  analysts: AnalystSuggestion[];
+  format: ContentFormat;
+}
+
+const ANGLE_COLORS: Record<string, string> = {
+  "contrarian take": "bg-orange-500/20 text-orange-400 border-orange-500/30",
+  "data highlight": "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  prediction: "bg-violet-500/20 text-violet-400 border-violet-500/30",
+  "practical advice": "bg-green-500/20 text-green-400 border-green-500/30",
+  "narrative arc": "bg-teal-500/20 text-teal-400 border-teal-500/30",
+  "hot take": "bg-red-500/20 text-red-400 border-red-500/30",
+  explainer: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
+};
+
+const FORMAT_LABELS: Record<ContentFormat, string> = {
+  "one-liner": "One-liner",
+  thread: "Thread",
+  article: "Article",
+};
+
+const FORMAT_COLORS: Record<ContentFormat, string> = {
+  "one-liner": "bg-pink-500/20 text-pink-400 border-pink-500/30",
+  thread: "bg-cyan-500/20 text-cyan-400 border-cyan-500/30",
+  article: "bg-amber-500/20 text-amber-400 border-amber-500/30",
+};
+
+export default function CampaignDraftCard({
+  draft,
+  onContentChange,
+  onDiscard,
+  timing,
+  analysts,
+  format,
+}: CampaignDraftCardProps) {
+  const [showTimingReason, setShowTimingReason] = useState(false);
+
+  const angleClass =
+    ANGLE_COLORS[draft.angle] ||
+    "bg-atlas-text-muted/20 text-atlas-text-muted border-atlas-text-muted/30";
+
+  return (
+    <div className="rounded-2xl border border-glass-border bg-glass p-6 backdrop-blur-xl">
+      {/* Badges row */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${angleClass}`}
+          >
+            {draft.angle}
+          </span>
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${FORMAT_COLORS[format]}`}
+          >
+            {FORMAT_LABELS[format]}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Quality bar */}
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-atlas-text-muted">Quality</span>
+            <div className="h-1.5 w-16 overflow-hidden rounded-full bg-atlas-surface">
+              <div
+                className="h-full rounded-full bg-atlas-teal"
+                style={{ width: `${Math.min(100, draft.qualityScore)}%` }}
+              />
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onDiscard(draft.id)}
+            className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-error"
+            aria-label="Discard draft"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Timing recommendation */}
+      <div className="mb-3 rounded-lg border border-glass-border bg-atlas-surface/50 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setShowTimingReason((s) => !s)}
+          className="flex w-full items-center justify-between text-left"
+          aria-expanded={showTimingReason}
+        >
+          <div className="flex items-center gap-2">
+            <Clock className="h-3.5 w-3.5 text-atlas-teal" />
+            <span className="text-xs text-atlas-text-secondary">
+              Post {timing.label}
+            </span>
+          </div>
+          {showTimingReason ? (
+            <ChevronUp className="h-3.5 w-3.5 text-atlas-text-muted" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5 text-atlas-text-muted" />
+          )}
+        </button>
+        {showTimingReason && (
+          <p className="mt-1.5 pl-5 text-[11px] text-atlas-text-muted">
+            {timing.reason}
+          </p>
+        )}
+      </div>
+
+      {/* Analyst suggestions */}
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <User className="h-3.5 w-3.5 text-atlas-text-muted" />
+        {analysts.map((a) => (
+          <span
+            key={a.slug}
+            className="inline-flex items-center rounded-full border border-glass-border bg-atlas-surface px-2 py-0.5 text-[11px] text-atlas-text"
+            title={a.reason}
+          >
+            {a.name}
+          </span>
+        ))}
+      </div>
+
+      {/* Editable draft content */}
+      <textarea
+        value={draft.content}
+        onChange={(e) => onContentChange(draft.id, e.target.value)}
+        rows={4}
+        className="w-full rounded-lg border border-glass-border bg-atlas-surface px-3 py-2 text-sm text-atlas-text placeholder:text-atlas-text-muted focus:border-atlas-teal focus:outline-none"
+      />
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -816,6 +816,38 @@ export const api = {
       request<{ success: boolean }>(`/api/campaigns/${campaignId}/drafts`, { method: "POST", body: { draftId, sortOrder } }),
     removeDraft: (campaignId: string, draftId: string) =>
       request<{ success: boolean }>(`/api/campaigns/${campaignId}/drafts/${draftId}`, { method: "DELETE" }),
+    generateFromPdf: async (
+      file: File,
+      options?: { angles?: number; tone?: string; name?: string; description?: string },
+    ): Promise<{
+      campaignId: string;
+      filename: string;
+      mimeType: string;
+      wordCount: number;
+      truncated: boolean;
+      drafts: Array<{ id: string; content: string; angle: string; score: number }>;
+    }> => {
+      const form = new FormData();
+      form.append("file", file);
+      if (options?.angles) form.append("angles", String(options.angles));
+      if (options?.tone) form.append("tone", options.tone);
+      if (options?.name) form.append("name", options.name);
+      if (options?.description) form.append("description", options.description);
+      const headers: Record<string, string> = {};
+      if (_accessToken) headers["Authorization"] = `Bearer ${_accessToken}`;
+      const res = await fetch(`${API_URL}/api/campaigns/generate-from-pdf`, {
+        method: "POST",
+        headers,
+        body: form,
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: res.statusText }));
+        throw new ApiError(err.error || "Generate-from-PDF failed", res.status);
+      }
+      const json = await res.json();
+      return json && typeof json === "object" && "data" in json ? (json as { data: typeof json }).data as any : json;
+    },
   },
 };
 

--- a/src/lib/campaign-recommendations.ts
+++ b/src/lib/campaign-recommendations.ts
@@ -1,0 +1,175 @@
+export type ContentFormat = "one-liner" | "thread" | "article";
+
+export interface TimingRecommendation {
+  /** Day of the week, 0=Sunday ... 6=Saturday */
+  dayOfWeek: number;
+  /** Human-readable label: "Tuesday 10:00 AM EST" */
+  label: string;
+  /** Why this slot — shown as a tooltip / subtitle */
+  reason: string;
+}
+
+export interface AnalystSuggestion {
+  /** Slug from reference accounts (e.g. "anil", "kevin", "jonah"). */
+  slug: string;
+  /** Display name. */
+  name: string;
+  /** One-sentence "why this analyst". */
+  reason: string;
+}
+
+interface AnalystRosterEntry {
+  slug: string;
+  name: string;
+  strengths: string[];
+}
+
+const ROSTER: AnalystRosterEntry[] = [
+  { slug: "anil", name: "Anil", strengths: ["contrarian take", "hot take"] },
+  { slug: "kevin", name: "Kevin", strengths: ["data highlight", "key finding"] },
+  { slug: "jonah", name: "Jonah", strengths: ["prediction", "thread hook"] },
+  { slug: "ceteris", name: "Ceteris", strengths: ["article", "thread hook"] },
+  { slug: "yan", name: "Yan", strengths: ["prediction", "data highlight"] },
+];
+
+/** Classify a draft into a content format by length + prefix. */
+export function classifyFormat(content: string): ContentFormat {
+  if (content.length > 1200 || content.includes("## ")) {
+    return "article";
+  }
+  if (
+    content.includes("\n\n1.") ||
+    content.includes("\n\n1/") ||
+    (content.match(/\n\n/g) || []).length > 2
+  ) {
+    return "thread";
+  }
+  return "one-liner";
+}
+
+/** Derive a timing slot per angle. Pure + deterministic. */
+export function recommendTiming(angle: string, _format: ContentFormat): TimingRecommendation {
+  const normalized = angle.toLowerCase();
+  if (normalized === "contrarian take" || normalized === "hot take") {
+    return {
+      dayOfWeek: 2,
+      label: "Tuesday 10:00 AM EST",
+      reason:
+        "Crypto Twitter peaks midweek mornings EST; contrarian takes generate most engagement then.",
+    };
+  }
+  if (normalized === "data highlight") {
+    return {
+      dayOfWeek: 3,
+      label: "Wednesday 2:00 PM EST",
+      reason:
+        "Data-heavy posts perform best midweek afternoons when readers have time to click.",
+    };
+  }
+  if (normalized === "prediction") {
+    return {
+      dayOfWeek: 0,
+      label: "Sunday 6:00 PM EST",
+      reason: "Predictions about the week ahead land best Sunday evenings.",
+    };
+  }
+  if (normalized === "key finding") {
+    return {
+      dayOfWeek: 4,
+      label: "Thursday 11:00 AM EST",
+      reason: "Core findings earn the most retweets midweek late-morning.",
+    };
+  }
+  // "thread hook" / default
+  return {
+    dayOfWeek: 2,
+    label: "Tuesday 9:00 AM EST",
+    reason: "Thread hooks get more follow-throughs in the morning.",
+  };
+}
+
+/**
+ * Pick 1-2 Delphi analyst suggestions for a draft by matching angle
+ * + format against each analyst's strengths.
+ */
+export function suggestAnalysts(angle: string, format: ContentFormat): AnalystSuggestion[] {
+  const normalizedAngle = angle.toLowerCase();
+  const scored = ROSTER.map((entry) => {
+    const matchesAngle = entry.strengths.includes(normalizedAngle);
+    const matchesFormat = entry.strengths.includes(format);
+    const score = (matchesAngle ? 2 : 0) + (matchesFormat ? 1 : 0);
+    return { entry, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const top = scored
+    .slice(0, 2)
+    .map(({ entry }) => ({
+      slug: entry.slug,
+      name: entry.name,
+      reason: `Strong track record on ${angle} content.`,
+    }));
+
+  if (top.length > 0) return top;
+
+  // Fallback to first 2
+  return ROSTER.slice(0, 2).map((entry) => ({
+    slug: entry.slug,
+    name: entry.name,
+    reason: `Strong track record on ${angle} content.`,
+  }));
+}
+
+export interface InsightData {
+  title: string;
+  summary: string;
+  keyQuote: string;
+  angle: string;
+}
+
+interface GeneratedDraft {
+  id: string;
+  content: string;
+  angle: string;
+  qualityScore: number;
+  discarded: boolean;
+}
+
+/** Build strategy bullets from insights and drafts. */
+export function buildStrategyBullets(insights: InsightData[], drafts: GeneratedDraft[]): string[] {
+  const activeDrafts = drafts.filter((d) => !d.discarded);
+  const angleCounts = new Map<string, number>();
+  for (const draft of activeDrafts) {
+    const a = draft.angle.toLowerCase();
+    angleCounts.set(a, (angleCounts.get(a) || 0) + 1);
+  }
+
+  const bullets: string[] = [];
+
+  const contrarian = angleCounts.get("contrarian take") || angleCounts.get("hot take") || 0;
+  if (contrarian > 0) {
+    bullets.push(
+      `${contrarian} contrarian take${contrarian > 1 ? "s" : ""} — lead with one Tuesday 10am EST`
+    );
+  }
+
+  const data = angleCounts.get("data highlight") || 0;
+  if (data > 0) {
+    bullets.push(`${data} data highlight${data > 1 ? "s" : ""} — pair with chart, post Wed afternoon`);
+  }
+
+  const predictions = angleCounts.get("prediction") || 0;
+  if (predictions > 0) {
+    bullets.push(
+      `Save ${predictions} prediction${predictions > 1 ? "s" : ""} for Sunday evening`
+    );
+  }
+
+  // Fallback when no specific angles matched
+  if (bullets.length === 0 && activeDrafts.length > 0) {
+    bullets.push(`${activeDrafts.length} draft${activeDrafts.length > 1 ? "s" : ""} ready — review and schedule the top performers`);
+  }
+
+  return bullets;
+}


### PR DESCRIPTION
## Summary
- Anil's vision: feed a PDF report, get a full campaign with multi-angle tweet drafts, timing recommendations, and analyst assignments in one round-trip.
- Wires the wizard directly into `POST /api/campaigns/generate-from-pdf` so users get a persisted Campaign + multi-angle drafts in a single request (skips the legacy extract-text -> batchFromContent flow for PDFs).
- Client-side recommendation layer per Anil spec: timing slot, format cluster, Delphi analyst suggestion per draft. Pure + deterministic — ready to ship today while backend fields catch up.
- Format filter chips (All / One-liner / Thread / Article) + content-strategy bullets give an at-a-glance rollout plan.

## Files changed
- `src/lib/api.ts` — added `api.campaigns.generateFromPdf(file, options)` (multipart FormData)
- `src/lib/campaign-recommendations.ts` (new) — `classifyFormat`, `recommendTiming`, `suggestAnalysts`, `buildStrategyBullets`
- `src/components/campaigns/CampaignDraftCard.tsx` (new) — reusable draft card with angle/format chips, quality bar, expandable timing badge, analyst chips
- `src/app/campaigns/wizard/page.tsx` — PDF one-shot path, format filter bar, strategy guide, CampaignDraftCard integration, skips explicit create when backend already persisted
- `src/__tests__/campaign-recommendations.test.ts` (new) — 21 cases

## Test plan
- [x] `npx tsc --noEmit` — clean for touched files (8 pre-existing errors in `OracleChat.tsx` upstream)
- [x] `npx jest src/__tests__/campaign-recommendations.test.ts` — 21/21 pass
- [ ] Manual smoke: drop a Delphi PDF, verify campaign + drafts generated, timing/analyst chips render, format filter works
- [ ] Manual smoke: paste-text fallback still works

## Anil quote
> "I feed a pdf of the pair trading report ... It automatically spits out a document with: A guide on what type of content will perform best given current market structure, 2-3 tweet options per content type (article, thread, one-liner), Timing recommendations (post at 10am EST Tuesday, etc.), Which Delphi analyst should post each piece"

Co-Authored-By: Kimi <noreply@moonshot.ai>