### PR TITLE
feat(ui): toast queue provider + alertSocket integration

### DIFF
--- a/src/__tests__/ToastProvider.test.tsx
+++ b/src/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,139 @@
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ToastProvider } from "@/components/ui/ToastProvider";
+import { useToast } from "@/hooks/useToast";
+
+function ToastHarness() {
+  const { dismiss, push } = useToast();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          for (let index = 1; index <= 5; index += 1) {
+            push({
+              id: `toast-${index}`,
+              title: `Toast ${index}`,
+              kind: "info",
+              description: `Description ${index}`,
+            });
+          }
+        }}
+      >
+        Push five
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          push({ id: "toast-1", title: "Toast 1", kind: "info", durationMs: 1000 });
+          push({ id: "toast-2", title: "Toast 2", kind: "info", durationMs: 10000 });
+          push({ id: "toast-3", title: "Toast 3", kind: "info", durationMs: 10000 });
+          push({ id: "toast-4", title: "Toast 4", kind: "info", durationMs: 10000 });
+          push({ id: "toast-5", title: "Toast 5", kind: "info", durationMs: 10000 });
+        }}
+      >
+        Push expiring queue
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          push({
+            id: "default-toast",
+            title: "Default duration toast",
+            kind: "success",
+          })
+        }
+      >
+        Push default
+      </button>
+      <button type="button" onClick={() => dismiss("toast-2")}>
+        Dismiss toast 2
+      </button>
+      <button type="button" onClick={() => dismiss("default-toast")}>
+        Dismiss default
+      </button>
+    </div>
+  );
+}
+
+describe("ToastProvider", () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("shows only four visible toasts while keeping overflow queued", () => {
+    render(
+      <ToastProvider>
+        <ToastHarness />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Push five" }));
+
+    expect(screen.getAllByRole("status")).toHaveLength(4);
+    expect(screen.getByText("Toast 1")).toBeInTheDocument();
+    expect(screen.getByText("Toast 4")).toBeInTheDocument();
+    expect(screen.queryByText("Toast 5")).not.toBeInTheDocument();
+  });
+
+  it("reveals the next queued toast when one is dismissed by id", () => {
+    render(
+      <ToastProvider>
+        <ToastHarness />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Push five" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss toast 2" }));
+
+    expect(screen.queryByText("Toast 2")).not.toBeInTheDocument();
+    expect(screen.getByText("Toast 5")).toBeInTheDocument();
+    expect(screen.getAllByRole("status")).toHaveLength(4);
+  });
+
+  it("promotes queued toasts as visible ones expire", () => {
+    jest.useFakeTimers();
+
+    render(
+      <ToastProvider>
+        <ToastHarness />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Push expiring queue" }));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText("Toast 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Toast 5")).toBeInTheDocument();
+    expect(screen.getAllByRole("status")).toHaveLength(4);
+  });
+
+  it("uses a five second default timeout when duration is omitted", () => {
+    jest.useFakeTimers();
+
+    render(
+      <ToastProvider>
+        <ToastHarness />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Push default" }));
+
+    act(() => {
+      jest.advanceTimersByTime(4999);
+    });
+
+    expect(screen.getByText("Default duration toast")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.queryByText("Default duration toast")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,29 +5,33 @@ import { AlertSocketProvider } from "@/lib/alertSocket";
 import { DemoModeProvider } from "@/lib/demo-mode";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { CommandPaletteProvider } from "@/components/ui/CommandPalette";
-import { ToastProvider } from "@/components/ui/Toast";
+import AlertToastBridge from "@/components/ui/AlertToastBridge";
+import { ToastProvider } from "@/components/ui/ToastProvider";
 import { TourProvider } from "@/components/tour/TourProvider";
 import { OracleAgentProvider } from "@/lib/oracle-agent";
 import { FeatureFlagProvider } from "@/lib/feature-flags";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ToastProvider>
-      <ErrorBoundary>
-        <DemoModeProvider>
-          <CommandPaletteProvider>
-            <AuthProvider>
-              <FeatureFlagProvider>
-                <OracleAgentProvider>
-                  <TourProvider>
-                    <AlertSocketProvider>{children}</AlertSocketProvider>
-                  </TourProvider>
-                </OracleAgentProvider>
-              </FeatureFlagProvider>
-            </AuthProvider>
-          </CommandPaletteProvider>
-        </DemoModeProvider>
-      </ErrorBoundary>
-    </ToastProvider>
+    <ErrorBoundary>
+      <DemoModeProvider>
+        <CommandPaletteProvider>
+          <AuthProvider>
+            <FeatureFlagProvider>
+              <OracleAgentProvider>
+                <TourProvider>
+                  <AlertSocketProvider>
+                    <ToastProvider>
+                      <AlertToastBridge />
+                      {children}
+                    </ToastProvider>
+                  </AlertSocketProvider>
+                </TourProvider>
+              </OracleAgentProvider>
+            </FeatureFlagProvider>
+          </AuthProvider>
+        </CommandPaletteProvider>
+      </DemoModeProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -59,6 +59,9 @@ export default function OracleChat() {
   const [blendSaveStatus, setBlendSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
+  const [tweetRatings, setTweetRatings] = useState<
+    Record<number, "up" | "down" | null>
+  >({});
   // Tracks the persisted blend so future PATCH operations can target it.
   const [, setSavedBlendId] = useState<string | null>(null);
 

--- a/src/components/ui/AlertToastBridge.tsx
+++ b/src/components/ui/AlertToastBridge.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { useToast } from "@/hooks/useToast";
+import { useAlertSocket, type SocketAlert } from "@/lib/alertSocket";
+
+export default function AlertToastBridge() {
+  const { onNewAlert } = useAlertSocket();
+  const { push } = useToast();
+
+  useEffect(() => {
+    return onNewAlert((alert: SocketAlert) => {
+      push({
+        kind: "info",
+        title: alert.title,
+        description: alert.message ?? alert.context ?? undefined,
+        href: "/alerts",
+      });
+    });
+  }, [onNewAlert, push]);
+
+  return null;
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,106 +1,92 @@
 "use client";
 
 import { AlertTriangle, Check, Info, X, type LucideIcon } from "lucide-react";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import type { ReactNode } from "react";
+import type { ToastKind, ToastRecord } from "@/components/ui/ToastProvider";
 
-type ToastType = "success" | "error" | "warning" | "info";
-
-interface ToastItem {
-  id: string;
-  message: string;
-  type: ToastType;
-}
-
-interface ToastContextValue {
-  toast: (message: string, type?: ToastType) => void;
-}
-
-const ToastContext = createContext<ToastContextValue>({ toast: () => undefined });
-
-const icons: Record<ToastType, LucideIcon> = {
-  success: Check,
-  error: X,
-  warning: AlertTriangle,
+const icons: Record<ToastKind, LucideIcon> = {
   info: Info,
+  success: Check,
+  warning: AlertTriangle,
+  error: X,
 };
 
-const colors: Record<ToastType, string> = {
-  success: "border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal",
-  error: "border-atlas-error/30 bg-atlas-error/10 text-atlas-error",
-  warning: "border-atlas-warning/30 bg-atlas-warning/10 text-atlas-warning",
+const toneClasses: Record<ToastKind, string> = {
   info: "border-glass-border bg-atlas-nav text-atlas-text",
+  success: "border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal",
+  warning: "border-atlas-warning/30 bg-atlas-warning/10 text-atlas-warning",
+  error: "border-atlas-error/30 bg-atlas-error/10 text-atlas-error",
 };
 
-export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-  const timeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+export interface ToastItemProps {
+  toast: ToastRecord;
+  onDismiss?: (id: string) => void;
+}
 
-  const removeToast = useCallback((id: string) => {
-    const timeout = timeoutsRef.current[id];
-    if (timeout) {
-      clearTimeout(timeout);
-      delete timeoutsRef.current[id];
-    }
-
-    setToasts((prev) => prev.filter((toast) => toast.id !== id));
-  }, []);
-
-  useEffect(() => {
-    const timeouts = timeoutsRef.current;
-
-    return () => {
-      for (const timeout of Object.values(timeouts)) {
-        clearTimeout(timeout);
-      }
-    };
-  }, []);
-
-  const addToast = useCallback(
-    (message: string, type: ToastType = "success") => {
-      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-      setToasts((prev) => [...prev, { id, message, type }]);
-      timeoutsRef.current[id] = setTimeout(() => {
-        removeToast(id);
-      }, 3000);
-    },
-    [removeToast]
-  );
+export function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  const Icon = icons[toast.kind];
 
   return (
-    <ToastContext.Provider value={{ toast: addToast }}>
-      {children}
-      <div
-        aria-atomic="true"
-        aria-live="polite"
-        className="pointer-events-none fixed inset-x-4 bottom-6 z-50 flex flex-col gap-2 sm:left-auto sm:right-6 sm:max-w-sm"
-      >
-        {toasts.map((toast) => {
-          const Icon = icons[toast.type];
-
-          return (
-            <div
-              key={toast.id}
-              className={`pointer-events-auto flex items-start gap-2 rounded-xl border px-4 py-3 shadow-lg backdrop-blur-sm transition-all duration-200 ${colors[toast.type]}`}
-              role="status"
+    <div
+      className={`pointer-events-auto rounded-2xl border shadow-lg backdrop-blur-xl ${toneClasses[toast.kind]}`}
+      role="status"
+    >
+      <div className="flex items-start gap-3 px-4 py-3">
+        <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="font-body text-sm font-medium leading-5">{toast.title}</p>
+          {toast.description ? (
+            <p className="mt-1 text-sm leading-5 text-current/80">{toast.description}</p>
+          ) : null}
+          {toast.href ? (
+            <a
+              href={toast.href}
+              className="mt-2 inline-flex text-xs font-medium underline underline-offset-2 transition-opacity hover:opacity-80"
             >
-              <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" />
-              <span className="font-body text-sm leading-5">{toast.message}</span>
-            </div>
-          );
-        })}
+              Open alert
+            </a>
+          ) : null}
+        </div>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={() => onDismiss(toast.id)}
+            aria-label={`Dismiss ${toast.title}`}
+            className="rounded-full p-1 text-current/70 transition-colors hover:bg-black/5 hover:text-current"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
-    </ToastContext.Provider>
+    </div>
   );
 }
 
+/**
+ * @deprecated Import `ToastProvider` from `@/components/ui/ToastProvider`.
+ */
+export function ToastProvider(props: { children: ReactNode }) {
+  const { ToastProvider: QueueToastProvider } =
+    require("./ToastProvider") as typeof import("./ToastProvider");
+
+  return <QueueToastProvider {...props} />;
+}
+
+/**
+ * @deprecated Import `useToast` from `@/hooks/useToast`.
+ */
 export function useToast() {
-  return useContext(ToastContext);
+  const { useToast: useToastQueue } =
+    require("../../hooks/useToast") as typeof import("../../hooks/useToast");
+  const { dismiss, push, toasts } = useToastQueue();
+
+  return {
+    dismiss,
+    dismissToast: dismiss,
+    push,
+    pushToast: push,
+    toast: (message: string, kind: ToastKind = "success") =>
+      push({ title: message, kind, durationMs: 3000 }),
+    toasts,
+  };
 }

--- a/src/components/ui/ToastProvider.tsx
+++ b/src/components/ui/ToastProvider.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ToastItem } from "@/components/ui/Toast";
+
+export type ToastKind = "info" | "success" | "warning" | "error";
+
+export interface ToastRecord {
+  id: string;
+  title: string;
+  description?: string;
+  kind: ToastKind;
+  href?: string;
+  durationMs?: number;
+}
+
+export type ToastInput = Omit<ToastRecord, "id"> & { id?: string };
+
+export interface ToastContextValue {
+  toasts: ToastRecord[];
+  pushToast: (toast: ToastInput) => string;
+  dismissToast: (id: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION_MS = 5000;
+const MAX_VISIBLE_TOASTS = 4;
+
+function buildToastId() {
+  return `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [pendingToasts, setPendingToasts] = useState<ToastRecord[]>([]);
+  const timeoutIdsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const dismissToast = useCallback((id: string) => {
+    const timeoutId = timeoutIdsRef.current[id];
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      delete timeoutIdsRef.current[id];
+    }
+
+    setPendingToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const pushToast = useCallback((toast: ToastInput) => {
+    const nextToast: ToastRecord = {
+      ...toast,
+      id: toast.id ?? buildToastId(),
+      durationMs: toast.durationMs ?? DEFAULT_DURATION_MS,
+    };
+
+    setPendingToasts((current) => [...current, nextToast]);
+
+    return nextToast.id;
+  }, []);
+
+  const toasts = pendingToasts.slice(0, MAX_VISIBLE_TOASTS);
+
+  useEffect(() => {
+    const visibleToastIds = new Set(toasts.map((toast) => toast.id));
+
+    for (const toast of toasts) {
+      if (timeoutIdsRef.current[toast.id]) {
+        continue;
+      }
+
+      timeoutIdsRef.current[toast.id] = setTimeout(() => {
+        dismissToast(toast.id);
+      }, toast.durationMs ?? DEFAULT_DURATION_MS);
+    }
+
+    for (const [toastId, timeoutId] of Object.entries(timeoutIdsRef.current)) {
+      if (visibleToastIds.has(toastId)) {
+        continue;
+      }
+
+      clearTimeout(timeoutId);
+      delete timeoutIdsRef.current[toastId];
+    }
+  }, [dismissToast, toasts]);
+
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of Object.values(timeoutIdsRef.current)) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, pushToast, dismissToast }}>
+      {children}
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        className="pointer-events-none fixed bottom-4 left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 flex-col gap-3 sm:bottom-6 sm:left-auto sm:right-6 sm:w-full sm:translate-x-0"
+      >
+        {toasts.map((toast) => (
+          <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/src/hooks/useActionFeedback.ts
+++ b/src/hooks/useActionFeedback.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { useToast } from "@/components/ui/Toast";
+import { useToast } from "@/hooks/useToast";
 
 interface ActionFeedbackOptions<T> {
   successMessage?: string;
@@ -18,7 +18,7 @@ export function getActionErrorMessage(
 }
 
 export function useActionFeedback() {
-  const { toast } = useToast();
+  const { push } = useToast();
   const [loadingActions, setLoadingActions] = useState<Record<string, boolean>>(
     {}
   );
@@ -62,19 +62,19 @@ export function useActionFeedback() {
           options.successMessage ??
           "Action completed";
 
-        toast(message, "success");
+        push({ title: message, kind: "success" });
         options.onResult?.(message, "success");
         return result;
       } catch (error) {
         const errMsg = getActionErrorMessage(error, options.errorMessage ?? "Action failed");
-        toast(errMsg, "error");
+        push({ title: errMsg, kind: "error" });
         options.onResult?.(errMsg, "error");
         return undefined;
       } finally {
         setActionLoading(key, false);
       }
     },
-    [setActionLoading, toast]
+    [push, setActionLoading]
   );
 
   const isLoading = useCallback(

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useContext } from "react";
+import { ToastContext } from "@/components/ui/ToastProvider";
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+
+  return {
+    toasts: context.toasts,
+    push: context.pushToast,
+    dismiss: context.dismissToast,
+  };
+}

--- a/src/lib/alertSocket.tsx
+++ b/src/lib/alertSocket.tsx
@@ -3,21 +3,19 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback } from "react";
 import { io, Socket } from "socket.io-client";
 import { useAuth } from "./auth";
+import type { Alert } from "./api";
 
-interface Alert {
-  id: string;
-  type: string;
-  title: string;
+export type SocketAlert = Omit<Alert, "context"> & {
   context?: string | null;
-  createdAt: string;
-}
+  message?: string | null;
+};
 
 interface AlertSocketState {
   connected: boolean;
   unreadNotifications: number;
-  latestAlert: Alert | null;
+  latestAlert: SocketAlert | null;
   clearUnread: () => void;
-  onNewAlert: (cb: (alert: Alert) => void) => () => void;
+  onNewAlert: (cb: (alert: SocketAlert) => void) => () => void;
 }
 
 const AlertSocketContext = createContext<AlertSocketState>({
@@ -33,10 +31,10 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 export function AlertSocketProvider({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
   const socketRef = useRef<Socket | null>(null);
-  const listenersRef = useRef<Set<(alert: Alert) => void>>(new Set());
+  const listenersRef = useRef<Set<(alert: SocketAlert) => void>>(new Set());
   const [connected, setConnected] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
-  const [latestAlert, setLatestAlert] = useState<Alert | null>(null);
+  const [latestAlert, setLatestAlert] = useState<SocketAlert | null>(null);
 
   useEffect(() => {
     if (!user) {
@@ -57,7 +55,7 @@ export function AlertSocketProvider({ children }: { children: React.ReactNode })
     socket.on("connect", () => setConnected(true));
     socket.on("disconnect", () => setConnected(false));
 
-    socket.on("new-alert", (alert: Alert) => {
+    socket.on("new-alert", (alert: SocketAlert) => {
       setLatestAlert(alert);
       setUnreadNotifications((count) => count + 1);
       listenersRef.current.forEach((cb) => cb(alert));
@@ -74,7 +72,7 @@ export function AlertSocketProvider({ children }: { children: React.ReactNode })
 
   const clearUnread = useCallback(() => setUnreadNotifications(0), []);
 
-  const onNewAlert = useCallback((cb: (alert: Alert) => void) => {
+  const onNewAlert = useCallback((cb: (alert: SocketAlert) => void) => {
     listenersRef.current.add(cb);
     return () => { listenersRef.current.delete(cb); };
   }, []);


### PR DESCRIPTION
## Summary
- add a queued toast provider with overflow handling, responsive placement, and a new `useToast` hook
- keep legacy `Toast.tsx` exports working via a presentational `ToastItem` plus compatibility shims
- bridge `alertSocket` new-alert events into info toasts and add queue coverage tests

Built by Codex (gpt-5.4) via Forge maximizer.