### PR TITLE
Add voice blend preview panel with mock fallback

### DIFF
--- a/src/__tests__/mock-blend-preview.test.ts
+++ b/src/__tests__/mock-blend-preview.test.ts
@@ -1,0 +1,63 @@
+import { DEFAULT_VOICE_DIMENSIONS } from "@/lib/voice-profile-dimensions";
+import { generateMockBlendPreview } from "@/lib/mock-blend-preview";
+
+const PROMPTS = [
+  "ETH rally to 4k",
+  "Rollup TPS comparison",
+  "Why L2s matter for adoption",
+];
+
+describe("generateMockBlendPreview", () => {
+  it("returns deterministic output for the same input", () => {
+    const blend = {
+      voices: [
+        { handle: "atlas", percentage: 60 },
+        { handle: "hasufl", percentage: 40 },
+      ],
+      dimensions: { ...DEFAULT_VOICE_DIMENSIONS, humor: 78, technicalDepth: 72 },
+    };
+
+    expect(generateMockBlendPreview(blend, PROMPTS)).toEqual(
+      generateMockBlendPreview(blend, PROMPTS)
+    );
+  });
+
+  it("returns one preview per prompt", () => {
+    const result = generateMockBlendPreview(
+      {
+        voices: [{ handle: "atlas", percentage: 100 }],
+        dimensions: DEFAULT_VOICE_DIMENSIONS,
+      },
+      PROMPTS
+    );
+
+    expect(result.mode).toBe("mock");
+    expect(result.tweets).toHaveLength(3);
+    expect(result.tweets.map((tweet) => tweet.prompt)).toEqual(PROMPTS);
+  });
+
+  it("changes flavor text when dimensions change", () => {
+    const humorous = generateMockBlendPreview(
+      {
+        voices: [{ handle: "atlas", percentage: 100 }],
+        dimensions: { ...DEFAULT_VOICE_DIMENSIONS, humor: 92, formality: 12 },
+      },
+      PROMPTS
+    );
+    const formal = generateMockBlendPreview(
+      {
+        voices: [{ handle: "atlas", percentage: 100 }],
+        dimensions: { ...DEFAULT_VOICE_DIMENSIONS, humor: 8, formality: 92 },
+      },
+      PROMPTS
+    );
+
+    expect(humorous.tweets[0].text).not.toEqual(formal.tweets[0].text);
+    expect(humorous.tweets[0].text).toMatch(
+      /Chart goblin take:|Timeline take:|Low-key take:/
+    );
+    expect(formal.tweets[0].text).toMatch(
+      /Base case:|Working view:|Read-through:/
+    );
+  });
+});

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -268,6 +268,18 @@ export default function VoiceProfilesPage() {
     () => getActiveRecipeLabel(activeVoiceId, blends),
     [activeVoiceId, blends]
   );
+  const editorPreviewContext = useMemo(
+    () => ({
+      personalHandle: user?.handle ?? null,
+      blendVoices: selectedBlendForEditor?.blend.voices.map((voice) => ({
+        handle:
+          voice.referenceVoice?.handle ??
+          (voice.referenceVoiceId ? voice.label : user?.handle ?? voice.label),
+        percentage: voice.percentage,
+      })),
+    }),
+    [selectedBlendForEditor, user?.handle]
+  );
 
   const handlePreviewBlend = useCallback(
     async (blend: SavedBlend, dimensions: VoiceDimensions) => {
@@ -1099,6 +1111,7 @@ export default function VoiceProfilesPage() {
               ? personalDimensions
               : selectedBlendForEditor?.dimensions ?? DEFAULT_VOICE_DIMENSIONS
           }
+          previewContext={editorPreviewContext}
           saveDisabled={editorMode === "edit-blend"}
           saveNotice={
             editorMode === "edit-blend"

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -56,6 +56,9 @@ export default function OracleChat() {
   const drainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [oauthLoading, setOauthLoading] = useState(false);
   const [resumeTrackAAfterOAuth, setResumeTrackAAfterOAuth] = useState(false);
+  const [tweetRatings, setTweetRatings] = useState<
+    Record<number, "up" | "down" | null>
+  >({});
   const [blendSaveStatus, setBlendSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");

--- a/src/components/voice-profiles/BlendPreviewPanel.tsx
+++ b/src/components/voice-profiles/BlendPreviewPanel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+import { api } from "@/lib/api";
+import { generateMockBlendPreview } from "@/lib/mock-blend-preview";
+import type {
+  BlendPreviewRequest,
+  BlendPreviewResult,
+} from "@/types/voice-profile-preview";
+
+const PROMPTS = [
+  "ETH rally to 4k",
+  "Rollup TPS comparison",
+  "Why L2s matter for adoption",
+];
+
+const previewBlendApi = (
+  api.voice as typeof api.voice & {
+    previewBlend?: (request: BlendPreviewRequest) => Promise<BlendPreviewResult>;
+  }
+).previewBlend;
+
+interface BlendPreviewPanelProps {
+  blend: BlendPreviewRequest["blend"];
+  onRegenerate?: () => void;
+}
+
+export default function BlendPreviewPanel({
+  blend,
+  onRegenerate,
+}: BlendPreviewPanelProps) {
+  const [result, setResult] = useState<BlendPreviewResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const requestKey = JSON.stringify(blend);
+  const composition = blend.voices
+    .map((voice) => `${voice.percentage}% @${voice.handle.replace(/^@/, "")}`)
+    .join(" + ");
+
+  useEffect(() => {
+    let cancelled = false;
+    const request: BlendPreviewRequest = {
+      blend: JSON.parse(requestKey) as BlendPreviewRequest["blend"],
+      prompts: PROMPTS,
+    };
+
+    setLoading(true);
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = previewBlendApi
+          ? await previewBlendApi(request)
+          : generateMockBlendPreview(request.blend, request.prompts);
+        if (!cancelled) {
+          setResult(
+            previewBlendApi ? { ...response, mode: response.mode ?? "live" } : response
+          );
+        }
+      } catch {
+        if (!cancelled) {
+          setResult(generateMockBlendPreview(request.blend, request.prompts));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 180);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [refreshToken, requestKey]);
+
+  return (
+    <aside className="rounded-2xl border border-glass-border bg-glass p-5 backdrop-blur-xl">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-atlas-teal">
+            Preview this blend
+          </p>
+          <h3 className="mt-2 font-heading text-xl font-semibold text-atlas-text">
+            Cross-check tone before you save
+          </h3>
+          <p className="mt-2 text-xs leading-5 text-atlas-text-secondary">{composition}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onRegenerate?.();
+            setRefreshToken((value) => value + 1);
+          }}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs font-medium text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          Regenerate
+        </button>
+      </div>
+
+      {result?.mode === "mock" && (
+        <span className="mt-4 inline-flex rounded-full border border-atlas-teal/25 bg-atlas-teal/10 px-2.5 py-1 text-[11px] font-semibold text-atlas-teal">
+          Preview Mode
+        </span>
+      )}
+
+      <div className="mt-4 space-y-3">
+        {loading
+          ? PROMPTS.map((prompt) => (
+              <div key={prompt} className="animate-pulse rounded-2xl border border-glass-border bg-atlas-surface/40 p-4">
+                <div className="h-3 w-32 rounded bg-atlas-surface" />
+                <div className="mt-3 h-3 rounded bg-atlas-surface" />
+                <div className="mt-2 h-3 w-11/12 rounded bg-atlas-surface" />
+              </div>
+            ))
+          : result?.tweets.map((tweet) => (
+              <article key={tweet.prompt} className="rounded-2xl border border-glass-border bg-atlas-surface/40 p-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-atlas-text-muted">
+                  {tweet.prompt}
+                </p>
+                <p className="mt-3 text-sm leading-6 text-atlas-text">{tweet.text}</p>
+              </article>
+            ))}
+        {!loading && !result && (
+          <div className="flex items-center gap-2 rounded-2xl border border-glass-border bg-atlas-surface/40 p-4 text-sm text-atlas-text-secondary">
+            <Loader2 className="h-4 w-4 text-atlas-teal" />
+            Preview unavailable right now.
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/voice-profiles/VoiceEditorModal.tsx
+++ b/src/components/voice-profiles/VoiceEditorModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft, Check, Loader2, Search } from "lucide-react";
 import Modal from "@/components/ui/Modal";
+import BlendPreviewPanel from "@/components/voice-profiles/BlendPreviewPanel";
 import VoiceDimensionSections from "@/components/voice-profiles/VoiceDimensionSections";
 import { api, type TwitterFollow } from "@/lib/api";
 import {
@@ -10,6 +11,7 @@ import {
   VoiceDimensionField,
   VoiceDimensions,
 } from "@/lib/voice-profile-dimensions";
+import type { BlendPreviewRequest } from "@/types/voice-profile-preview";
 
 const VOICE_PRESETS: Array<{ label: string; values: VoiceDimensions }> = [
   {
@@ -34,6 +36,10 @@ interface VoiceEditorModalProps {
   mode: EditorMode;
   initialName?: string;
   initialDimensions?: VoiceDimensions;
+  previewContext?: {
+    blendVoices?: BlendPreviewRequest["blend"]["voices"];
+    personalHandle?: string | null;
+  };
   saveDisabled?: boolean;
   saveNotice?: string;
   onSave: (name: string, dimensions: VoiceDimensions, selectedFollow: TwitterFollow | null) => Promise<void>;
@@ -57,6 +63,7 @@ export default function VoiceEditorModal({
   mode,
   initialName = "",
   initialDimensions,
+  previewContext,
   saveDisabled = false,
   saveNotice,
   onSave,
@@ -175,6 +182,33 @@ export default function VoiceEditorModal({
       : "Configure your voice dimensions";
 
   const showPickStep = mode === "create" && step === "pick";
+  const previewBlend = useMemo<BlendPreviewRequest["blend"] | null>(() => {
+    if (showPickStep) return null;
+
+    const personalHandle =
+      previewContext?.personalHandle?.replace(/^@/, "") || "myvoice";
+
+    if (mode === "create") {
+      if (!selectedFollow?.handle) return null;
+      return {
+        voices: [
+          { handle: personalHandle, percentage: 50 },
+          { handle: selectedFollow.handle, percentage: 50 },
+        ],
+        dimensions,
+      };
+    }
+
+    if (mode === "edit-personal") {
+      return {
+        voices: [{ handle: personalHandle, percentage: 100 }],
+        dimensions,
+      };
+    }
+
+    if (!previewContext?.blendVoices?.length) return null;
+    return { voices: previewContext.blendVoices, dimensions };
+  }, [dimensions, mode, previewContext, selectedFollow, showPickStep]);
 
   return (
     <Modal
@@ -359,6 +393,8 @@ export default function VoiceEditorModal({
             interactive
             onChange={handleDimensionChange}
           />
+
+          {previewBlend && <BlendPreviewPanel blend={previewBlend} />}
 
           {saveNotice && (
             <p className="rounded-2xl border border-glass-border/70 bg-atlas-surface/50 px-4 py-3 text-sm text-atlas-text-secondary">

--- a/src/lib/mock-blend-preview.ts
+++ b/src/lib/mock-blend-preview.ts
@@ -1,0 +1,155 @@
+import { pickVoiceDimensions } from "@/lib/voice-profile-dimensions";
+import type {
+  BlendPreviewRequest,
+  BlendPreviewResult,
+} from "@/types/voice-profile-preview";
+
+const TOPIC_LIBRARY = {
+  eth: {
+    theses: [
+      "ETH pressing toward $4k matters because quality beta usually reclaims leadership before the rest of the complex wakes up.",
+      "ETH near $4k is a positioning reset, not just a pretty chart.",
+      "ETH back at $4k only sticks if the market is rotating into conviction instead of pure reflex.",
+    ],
+    technical: [
+      "Watch ETF flows, staking demand, and fee burn before calling it a clean breakout.",
+      "The useful confirmation is spot-led demand plus healthier fee capture across the stack.",
+      "If basis stays sane while validator demand improves, the move has real room.",
+    ],
+    accessible: [
+      "Price is the headline; follow-through is whether users and capital both keep showing up.",
+      "The candle is nice, but participation is what changes positioning.",
+      "The real tell is whether the move brings actual activity back onchain.",
+    ],
+  },
+  rollups: {
+    theses: [
+      "Rollup TPS charts are helpful marketing, but raw throughput is the lazy metric.",
+      "TPS comparisons between rollups miss the point if you ignore what that throughput costs.",
+      "Not all rollup TPS is created equal; the benchmark only matters if users can actually sustain it.",
+    ],
+    technical: [
+      "I care more about DA efficiency, time-to-finality, and state growth than headline burst capacity.",
+      "Compression quality, finality, and fee consistency tell you more than the screenshot number.",
+      "The real spread is in proving costs, DA overhead, and how ugly performance gets under load.",
+    ],
+    accessible: [
+      "The winner is the chain people can keep using, not the one with the loudest dashboard.",
+      "Throughput without cheap repeat usage is just a benchmark flex.",
+      "Users feel cost and latency long before they care about the leaderboard graphic.",
+    ],
+  },
+  adoption: {
+    theses: [
+      "L2s matter for adoption because they turn onchain actions from special occasions into default behavior.",
+      "Adoption does not scale on ideology; it scales when execution gets cheap enough to feel normal.",
+      "L2s are the bridge between crypto's ambition and something regular users will actually touch.",
+    ],
+    technical: [
+      "Cheap blockspace, fast confirmations, and sane onboarding loops are what convert curiosity into retained usage.",
+      "The unlock is low-cost execution paired with app distribution that does not punish experimentation.",
+      "When confirmation times and fee variance compress, product teams can finally optimize for retention instead of apology copy.",
+    ],
+    accessible: [
+      "If sending, swapping, and minting feel instant and cheap, more people try it twice.",
+      "Lower fees are not cosmetic; they are what make habit formation possible.",
+      "Cheaper transactions are how onchain behavior stops feeling like a premium hobby.",
+    ],
+  },
+} as const;
+
+const HUMOR_LEADS = ["Chart goblin take:", "Timeline take:", "Low-key take:"];
+const FORMAL_LEADS = ["Base case:", "Working view:", "Read-through:"];
+const NEUTRAL_LEADS = ["My take:", "Net/net:", "View:"];
+const HUMOR_TAILS = [
+  "The timeline will call it obvious after the candle closes.",
+  "Everyone becomes a macro genius once the chart agrees.",
+  "Somebody will still post a victory lap from the wrong thesis.",
+];
+const FORMAL_TAILS = [
+  "That is the signal stack worth underwriting.",
+  "That is the adoption vector worth monitoring.",
+  "That is the cleaner framework for sizing the move.",
+];
+const WARM_TAILS = [
+  "That is the part normal users actually feel.",
+  "That is how the UX gap finally narrows.",
+  "That is what makes the product click for newcomers.",
+];
+const NEUTRAL_TAILS = [
+  "That is the real unlock.",
+  "That is the part I care about.",
+  "That is the section the market reprices.",
+];
+
+function hashString(input: string) {
+  let hash = 2166136261;
+  for (const char of input) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function pick(options: readonly string[], seed: number) {
+  return options[seed % options.length];
+}
+
+function detectTopic(prompt: string) {
+  const normalized = prompt.toLowerCase();
+  if (normalized.includes("eth")) return TOPIC_LIBRARY.eth;
+  if (normalized.includes("rollup") || normalized.includes("tps")) return TOPIC_LIBRARY.rollups;
+  if (normalized.includes("l2")) return TOPIC_LIBRARY.adoption;
+  return TOPIC_LIBRARY.adoption;
+}
+
+function buildLead(dimensions: ReturnType<typeof pickVoiceDimensions>, seed: number) {
+  if (dimensions.formality >= 70) return pick(FORMAL_LEADS, seed);
+  if (dimensions.humor >= 70) return pick(HUMOR_LEADS, seed);
+  return pick(NEUTRAL_LEADS, seed);
+}
+
+function buildTail(dimensions: ReturnType<typeof pickVoiceDimensions>, seed: number) {
+  if (dimensions.humor >= 70) return pick(HUMOR_TAILS, seed);
+  if (dimensions.formality >= 70) return pick(FORMAL_TAILS, seed);
+  if (dimensions.warmth >= 60) return pick(WARM_TAILS, seed);
+  return pick(NEUTRAL_TAILS, seed);
+}
+
+function trimTweet(text: string) {
+  return text.length <= 280 ? text : `${text.slice(0, 277)}...`;
+}
+
+export function generateMockBlendPreview(
+  blend: BlendPreviewRequest["blend"],
+  prompts: string[]
+): BlendPreviewResult {
+  const dimensions = pickVoiceDimensions(blend.dimensions);
+  const voiceSignature = blend.voices
+    .map((voice) => `${voice.handle.replace(/^@/, "").toLowerCase()}:${voice.percentage}`)
+    .join("|");
+  const baseSeed = hashString(`${voiceSignature}|${JSON.stringify(dimensions)}`);
+
+  return {
+    mode: "mock",
+    tweets: prompts.map((prompt, index) => {
+      const topic = detectTopic(prompt);
+      const seed = baseSeed + index * 97;
+      const detailPool =
+        dimensions.technicalDepth >= 60 || dimensions.evidenceOrientation >= 60
+          ? topic.technical
+          : topic.accessible;
+      return {
+        prompt,
+        text: trimTweet(
+          [
+            buildLead(dimensions, seed),
+            pick(topic.theses, seed + 11),
+            pick(detailPool, seed + 23),
+            buildTail(dimensions, seed + 31),
+          ].join(" ")
+        ),
+      };
+    }),
+  };
+}

--- a/src/types/voice-profile-preview.ts
+++ b/src/types/voice-profile-preview.ts
@@ -1,0 +1,20 @@
+export interface BlendPreviewVoice {
+  handle: string;
+  percentage: number;
+}
+
+export interface BlendPreviewRequest {
+  blend: {
+    voices: BlendPreviewVoice[];
+    dimensions?: Record<string, number>;
+  };
+  prompts: string[];
+}
+
+export interface BlendPreviewResult {
+  mode: "live" | "mock";
+  tweets: Array<{
+    prompt: string;
+    text: string;
+  }>;
+}


### PR DESCRIPTION
## Summary
- add a "Preview this blend" panel to the Voice Lab editor so unsaved voice mixes render three sample tweets before save
- add typed blend preview request/result models plus a deterministic mock generator fallback when `api.voice.previewBlend` is unavailable
- add focused tests for deterministic output and dimension-driven flavor text, and restore the missing `tweetRatings` state in onboarding so `tsc --noEmit` runs clean

## Validation
- `npx jest src/__tests__/mock-blend-preview.test.ts`
- `npx tsc --noEmit`

Built by Codex (gpt-5.4) via Forge maximizer.