### PR TITLE
fix(voice): resolve user avatar in blends via isSelfVoice predicate

### DIFF
--- a/src/__tests__/lib/voice-avatar.test.ts
+++ b/src/__tests__/lib/voice-avatar.test.ts
@@ -1,0 +1,91 @@
+import { resolveVoiceAvatar, isSelfVoice, voiceInitials } from "@/lib/voice-avatar";
+
+const makeVoice = (overrides: Partial<any> = {}) => ({
+  id: "v1",
+  label: "Test",
+  percentage: 50,
+  referenceVoiceId: null,
+  referenceVoice: null,
+  ...overrides,
+});
+
+describe("isSelfVoice", () => {
+  it("true when explicit isSelf flag", () => {
+    expect(isSelfVoice(makeVoice({ isSelf: true, referenceVoiceId: "x" }))).toBe(true);
+  });
+  it("true when no referenceVoice and no referenceVoiceId", () => {
+    expect(isSelfVoice(makeVoice({ label: "whatever" }))).toBe(true);
+  });
+  it("true when label is 'My voice' even with referenceVoice attached (defensive)", () => {
+    expect(
+      isSelfVoice(
+        makeVoice({ label: "My voice", referenceVoiceId: "ref", referenceVoice: { id: "ref", name: "X", handle: "foo", avatarUrl: "http://x" } })
+      )
+    ).toBe(true);
+  });
+  it("false for a normal inspiration", () => {
+    expect(
+      isSelfVoice(
+        makeVoice({ label: "Hosseeb", referenceVoiceId: "r1", referenceVoice: { id: "r1", name: "Hosseeb", handle: "hosseeb", avatarUrl: "http://a" } })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("resolveVoiceAvatar", () => {
+  const self = makeVoice({ label: "My voice" });
+  const inspiration = makeVoice({
+    label: "Hosseeb",
+    referenceVoiceId: "r1",
+    referenceVoice: { id: "r1", name: "Hosseeb", handle: "hosseeb", avatarUrl: "https://cdn/hosseeb.png" },
+  });
+
+  it("self + user.avatarUrl present → user avatar", () => {
+    expect(resolveVoiceAvatar(self, { avatarUrl: "https://cdn/me.png", handle: "alex" })).toBe(
+      "https://cdn/me.png"
+    );
+  });
+  it("self + no avatarUrl but user.handle → unavatar by user handle", () => {
+    expect(resolveVoiceAvatar(self, { handle: "@alex" })).toBe("https://unavatar.io/twitter/alex");
+  });
+  it("self + no user info → empty string (caller shows initials)", () => {
+    expect(resolveVoiceAvatar(self, null)).toBe("");
+  });
+  it("self + user + inspiration-like referenceVoice on same slot → STILL returns user avatar", () => {
+    const poisoned = makeVoice({
+      label: "My voice",
+      referenceVoiceId: "r1",
+      referenceVoice: { id: "r1", name: "Hosseeb", handle: "hosseeb", avatarUrl: "https://cdn/hosseeb.png" },
+    });
+    expect(resolveVoiceAvatar(poisoned, { avatarUrl: "https://cdn/me.png", handle: "alex" })).toBe(
+      "https://cdn/me.png"
+    );
+  });
+  it("inspiration → referenceVoice.avatarUrl", () => {
+    expect(resolveVoiceAvatar(inspiration, { avatarUrl: "https://cdn/me.png", handle: "alex" })).toBe(
+      "https://cdn/hosseeb.png"
+    );
+  });
+  it("inspiration with handle only → unavatar by referenceVoice handle", () => {
+    const v = makeVoice({
+      label: "Naval",
+      referenceVoiceId: "r2",
+      referenceVoice: { id: "r2", name: "Naval", handle: "naval" },
+    });
+    expect(resolveVoiceAvatar(v, { handle: "alex" })).toBe("https://unavatar.io/twitter/naval");
+  });
+});
+
+describe("voiceInitials", () => {
+  it("uses displayName for self", () => {
+    expect(voiceInitials(makeVoice({ label: "My voice" }), { displayName: "Alex Peri" })).toBe("A");
+  });
+  it("uses voice.label for inspiration", () => {
+    expect(
+      voiceInitials(
+        makeVoice({ label: "Hosseeb", referenceVoiceId: "r1", referenceVoice: { id: "r1", name: "H", handle: "h", avatarUrl: "x" } }),
+        { displayName: "Alex" }
+      )
+    ).toBe("H");
+  });
+});

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -828,7 +828,7 @@ export default function VoiceProfilesPage() {
                   })()}
                   notableDimensions={notableDimensions}
                   isActive={activeVoiceId === blend.id}
-                  userHandle={user?.handle}
+                  user={user}
                   onCompareVsMine={() =>
                     void handleCompareVsMine(blend.id)
                   }

--- a/src/components/onboarding/BlendRatioSlider.tsx
+++ b/src/components/onboarding/BlendRatioSlider.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import DimensionBar from "@/components/ui/DimensionBar";
+import { resolveVoiceAvatar, type MinimalUser } from "@/lib/voice-avatar";
 
 export interface BlendReference {
   name: string;
@@ -24,6 +25,7 @@ export interface BlendRatioSliderProps {
    * Weights are normalized so they sum to 100 (share of the reference portion).
    */
   onReferenceWeightsChange?: (weights: number[]) => void;
+  user?: MinimalUser | null;
 }
 
 export default function BlendRatioSlider({
@@ -32,6 +34,7 @@ export default function BlendRatioSlider({
   references,
   referenceNames,
   onReferenceWeightsChange,
+  user,
 }: BlendRatioSliderProps) {
   const refs: BlendReference[] =
     references && references.length > 0
@@ -112,11 +115,7 @@ export default function BlendRatioSlider({
 
           {/* My voice row */}
           <div className="flex items-center gap-3">
-            <div className="h-8 w-8 shrink-0 rounded-full bg-atlas-teal/20 border border-atlas-teal/40 flex items-center justify-center">
-              <span className="text-[10px] font-semibold text-atlas-teal">
-                ME
-              </span>
-            </div>
+            <SelfAvatar user={user} />
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between text-sm mb-1">
                 <span className="text-atlas-text truncate">My voice</span>
@@ -185,6 +184,32 @@ export default function BlendRatioSlider({
         </div>
       )}
     </div>
+  );
+}
+
+function SelfAvatar({ user }: { user?: MinimalUser | null }) {
+  const [errored, setErrored] = useState(false);
+  const url = resolveVoiceAvatar({ label: "My voice" }, user);
+  const initial = (user?.displayName || user?.handle || "ME").trim().charAt(0).toUpperCase();
+
+  if (!url || errored) {
+    return (
+      <div className="h-8 w-8 shrink-0 rounded-full bg-atlas-teal/20 border border-atlas-teal/40 flex items-center justify-center">
+        <span className="text-[10px] font-semibold text-atlas-teal">
+          {initial}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt="My voice"
+      onError={() => setErrored(true)}
+      className="h-8 w-8 shrink-0 rounded-full object-cover border border-atlas-teal/40 bg-atlas-surface"
+    />
   );
 }
 

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -17,6 +17,7 @@ import {
   type VoiceDimensions,
   VOICE_DIMENSION_SECTIONS,
 } from "@/lib/voice-profile-dimensions";
+import { resolveVoiceAvatar, voiceInitials, type MinimalUser } from "@/lib/voice-avatar";
 
 interface RecipeCardProps {
   blend: SavedBlend;
@@ -31,32 +32,22 @@ interface RecipeCardProps {
   previewError?: string | null;
   previewLoading?: boolean;
   previewText?: string;
-  userHandle?: string;
-}
-
-function getVoiceAvatarUrl(voice: BlendVoice, userHandle?: string): string {
-  if (voice.referenceVoice?.avatarUrl) return voice.referenceVoice.avatarUrl;
-  if (voice.referenceVoice?.handle) {
-    return `https://unavatar.io/twitter/${voice.referenceVoice.handle.replace("@", "")}`;
-  }
-  // User's own voice (no referenceVoice attached)
-  if (userHandle) return `https://unavatar.io/twitter/${userHandle.replace("@", "")}`;
-  return "";
+  user?: MinimalUser | null;
 }
 
 function VoiceAvatar({
   voice,
-  userHandle,
+  user,
   size = 24,
   className = "",
 }: {
   voice: BlendVoice;
-  userHandle?: string;
+  user?: MinimalUser | null;
   size?: number;
   className?: string;
 }) {
-  const url = getVoiceAvatarUrl(voice, userHandle);
-  const initials = voice.label.charAt(0).toUpperCase();
+  const url = resolveVoiceAvatar(voice, user);
+  const initials = voiceInitials(voice, user);
 
   if (!url) {
     return (
@@ -133,7 +124,7 @@ export default function RecipeCard({
   previewError,
   previewLoading = false,
   previewText,
-  userHandle,
+  user,
 }: RecipeCardProps) {
   const [isExpanded, toggleExpanded] = useCycle(false, true);
   const totalWeight = blend.voices.reduce((sum, voice) => sum + voice.percentage, 0) || 1;
@@ -167,7 +158,7 @@ export default function RecipeCard({
                 <VoiceAvatar
                   key={`${blend.id}-${voice.id ?? voice.label}-cluster`}
                   voice={voice}
-                  userHandle={userHandle}
+                  user={user}
                   size={28}
                   className={`border-2 border-atlas-bg ring-0 ${
                     reverseIndex === blend.voices.length - 1 ? "" : "-ml-2"
@@ -223,7 +214,7 @@ export default function RecipeCard({
               key={`${blend.id}-${voice.label}-pill`}
               className={`inline-flex items-center gap-1.5 rounded-full border py-1 pl-1 pr-3 text-xs font-medium ${SEGMENT_STYLES[index % SEGMENT_STYLES.length].pill}`}
             >
-              <VoiceAvatar voice={voice} userHandle={userHandle} size={20} />
+              <VoiceAvatar voice={voice} user={user} size={20} />
               {Math.round((voice.percentage / totalWeight) * 100)}% {voice.label}
             </span>
           ))}

--- a/src/lib/voice-avatar.ts
+++ b/src/lib/voice-avatar.ts
@@ -1,0 +1,59 @@
+import type { BlendVoice } from "@/lib/api";
+
+export interface MinimalUser {
+  handle?: string | null;
+  avatarUrl?: string | null;
+  displayName?: string | null;
+}
+
+/**
+ * True when this BlendVoice represents the authoring user themselves,
+ * not an inspiration/reference account.
+ *
+ * Rules (in priority order):
+ *   1. Explicit `isSelf` flag on the voice (future-proofing).
+ *   2. No referenceVoiceId AND no referenceVoice object.
+ *   3. Label matches "My voice" / "Me" / "You" (case-insensitive, trimmed) —
+ *      defensive against backend rows that mistakenly attach a referenceVoice
+ *      to the user's own slot.
+ */
+export function isSelfVoice(
+  voice: Pick<BlendVoice, "label" | "referenceVoice" | "referenceVoiceId"> & { isSelf?: boolean }
+): boolean {
+  if (voice.isSelf === true) return true;
+  if (!voice.referenceVoiceId && !voice.referenceVoice) return true;
+  const label = (voice.label ?? "").trim().toLowerCase();
+  if (label === "my voice" || label === "me" || label === "you") return true;
+  return false;
+}
+
+/**
+ * Single source of truth for which avatar URL to render for a BlendVoice.
+ * Returns empty string when no image source is available (caller shows initials).
+ */
+export function resolveVoiceAvatar(
+  voice: Pick<BlendVoice, "label" | "referenceVoice" | "referenceVoiceId"> & { isSelf?: boolean },
+  user?: MinimalUser | null
+): string {
+  if (isSelfVoice(voice)) {
+    if (user?.avatarUrl) return user.avatarUrl;
+    if (user?.handle) return `https://unavatar.io/twitter/${user.handle.replace(/^@/, "")}`;
+    return "";
+  }
+  if (voice.referenceVoice?.avatarUrl) return voice.referenceVoice.avatarUrl;
+  if (voice.referenceVoice?.handle) {
+    return `https://unavatar.io/twitter/${voice.referenceVoice.handle.replace(/^@/, "")}`;
+  }
+  return "";
+}
+
+export function voiceInitials(
+  voice: Pick<BlendVoice, "label">,
+  user?: MinimalUser | null
+): string {
+  if (isSelfVoice(voice as BlendVoice)) {
+    const src = user?.displayName || user?.handle || voice.label || "?";
+    return src.trim().charAt(0).toUpperCase();
+  }
+  return (voice.label || "?").trim().charAt(0).toUpperCase();
+}


### PR DESCRIPTION
Implements /tmp/forge-plan-p1-blend-avatars.md. New src/lib/voice-avatar.ts (isSelfVoice/resolveVoiceAvatar/voiceInitials). Migrates RecipeCard, voice-profiles, BlendRatioSlider, crafting. 8 unit tests incl. poisoned-referenceVoice regression. REQUIRES Forge-Audit.