### PR TITLE
fix(voice): display-normalize blend percentages to 100%

### DIFF
--- a/src/__tests__/components/voice-profiles/RecipeCard.test.tsx
+++ b/src/__tests__/components/voice-profiles/RecipeCard.test.tsx
@@ -1,0 +1,98 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import RecipeCard from "@/components/voice-profiles/RecipeCard";
+import type { SavedBlend } from "@/lib/api";
+import type { VoiceDimensions } from "@/lib/voice-profile-dimensions";
+import type { VoiceDimensionSnapshot } from "@/lib/voice-recipes";
+
+const mockDimensions: VoiceDimensions = {
+  humor: 50,
+  formality: 50,
+  brevity: 50,
+  contrarianTone: 50,
+  directness: 50,
+  warmth: 50,
+  technicalDepth: 50,
+  confidence: 50,
+  evidenceOrientation: 50,
+  solutionOrientation: 50,
+  socialPosture: 50,
+  selfPromotionalIntensity: 50,
+};
+
+const mockNotableDimensions: VoiceDimensionSnapshot[] = [];
+
+function makeBlend(percentages: number[]): SavedBlend {
+  return {
+    id: "blend-1",
+    name: "Test Blend",
+    voices: percentages.map((percentage, index) => ({
+      id: `voice-${index}`,
+      label: `Voice ${index + 1}`,
+      percentage,
+    })),
+  };
+}
+
+describe("RecipeCard", () => {
+  it("display-normalizes blend percentages so they sum to 100%", () => {
+    const blend = makeBlend([100, 75, 40]);
+    // raw total = 215; normalized ≈ 46.51%, 34.88%, 18.60%
+
+    render(
+      <RecipeCard
+        blend={blend}
+        dimensions={mockDimensions}
+        fingerprintDescription="Test description"
+        notableDimensions={mockNotableDimensions}
+        isActive={false}
+        onPreviewSample={jest.fn()}
+        onUse={jest.fn()}
+      />
+    );
+
+    // Total blend badge shows 100%
+    expect(screen.getByText("100%")).toBeInTheDocument();
+
+    // Composition text shows rounded normalized percentages
+    expect(screen.getByText("47% Voice 1 + 35% Voice 2 + 19% Voice 3")).toBeInTheDocument();
+
+    // Pills show rounded normalized percentages
+    expect(screen.getByText("47% Voice 1")).toBeInTheDocument();
+    expect(screen.getByText("35% Voice 2")).toBeInTheDocument();
+    expect(screen.getByText("19% Voice 3")).toBeInTheDocument();
+
+    // Bar segments use exact normalized widths
+    const barContainer = screen.getByText("Composition").parentElement?.nextElementSibling;
+    expect(barContainer).not.toBeNull();
+    const widthBars = barContainer?.querySelectorAll('div[aria-hidden="true"]');
+    expect(widthBars).toHaveLength(3);
+    expect((widthBars![0] as HTMLElement).style.width).toBe(`${(100 / 215) * 100}%`);
+    expect((widthBars![1] as HTMLElement).style.width).toBe(`${(75 / 215) * 100}%`);
+    expect((widthBars![2] as HTMLElement).style.width).toBe(`${(40 / 215) * 100}%`);
+  });
+
+  it("handles a single voice as 100%", () => {
+    const blend = makeBlend([50]);
+
+    render(
+      <RecipeCard
+        blend={blend}
+        dimensions={mockDimensions}
+        fingerprintDescription="Test description"
+        notableDimensions={mockNotableDimensions}
+        isActive={false}
+        onPreviewSample={jest.fn()}
+        onUse={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByText("100% Voice 1").length).toBeGreaterThanOrEqual(1);
+
+    const barContainer = screen.getByText("Composition").parentElement?.nextElementSibling;
+    expect(barContainer).not.toBeNull();
+    const widthBars = barContainer?.querySelectorAll('div[aria-hidden="true"]');
+    expect(widthBars).toHaveLength(1);
+    expect((widthBars![0] as HTMLElement).style.width).toBe("100%");
+  });
+});

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -133,6 +133,7 @@ export default function RecipeCard({
   userHandle,
 }: RecipeCardProps) {
   const [isExpanded, toggleExpanded] = useCycle(false, true);
+  const totalWeight = blend.voices.reduce((sum, voice) => sum + voice.percentage, 0) || 1;
 
   return (
     <article
@@ -187,7 +188,7 @@ export default function RecipeCard({
             Blend
           </p>
           <p className="mt-1 text-lg font-semibold text-atlas-text">
-            {blend.voices.reduce((sum, voice) => sum + voice.percentage, 0)}%
+            {blend.voices.length > 0 ? 100 : 0}%
           </p>
         </div>
       </div>
@@ -198,7 +199,7 @@ export default function RecipeCard({
             Composition
           </p>
           <p className="text-xs text-atlas-text-secondary">
-            {blend.voices.map((voice) => `${voice.percentage}% ${voice.label}`).join(" + ")}
+            {blend.voices.map((voice) => `${Math.round((voice.percentage / totalWeight) * 100)}% ${voice.label}`).join(" + ")}
           </p>
         </div>
         <div className="mt-3 overflow-hidden rounded-full border border-glass-border bg-atlas-bg/70">
@@ -208,7 +209,7 @@ export default function RecipeCard({
                 key={`${blend.id}-${voice.label}`}
                 aria-hidden="true"
                 className={SEGMENT_STYLES[index % SEGMENT_STYLES.length].bar}
-                style={{ width: `${voice.percentage}%` }}
+                style={{ width: `${(voice.percentage / totalWeight) * 100}%` }}
               />
             ))}
           </div>
@@ -220,7 +221,7 @@ export default function RecipeCard({
               className={`inline-flex items-center gap-1.5 rounded-full border py-1 pl-1 pr-3 text-xs font-medium ${SEGMENT_STYLES[index % SEGMENT_STYLES.length].pill}`}
             >
               <VoiceAvatar voice={voice} userHandle={userHandle} size={20} />
-              {voice.percentage}% {voice.label}
+              {Math.round((voice.percentage / totalWeight) * 100)}% {voice.label}
             </span>
           ))}
         </div>


### PR DESCRIPTION
BUG-1. RecipeCard.tsx display-normalizes voice.percentage so row sums to 100%; backend weights unchanged. Unit test included.