### PR TITLE
fix(analytics): guard empty data arrays with fallback

### DIFF
--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -96,4 +96,36 @@ test.describe("Analytics page", () => {
     await expect(page.getByText("Predicted")).toBeVisible();
     await expect(page.getByText("Actual")).toBeVisible();
   });
+
+  test("renders without crash when all analytics arrays are undefined/empty", async ({ authedPage: page, context }) => {
+    // Override analytics endpoints to return missing array fields (empty data)
+    await context.route("**/api/analytics/summary", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ summary: null }) }),
+    );
+    await context.route("**/api/analytics/learning-log", (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({}) });
+      }
+      return route.fallback();
+    });
+    await context.route("**/api/analytics/engagement-daily", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({}) }),
+    );
+    await context.route("**/api/analytics/activity-daily", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({}) }),
+    );
+    await context.route("**/api/drafts*", (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ drafts: [] }) });
+      }
+      return route.fallback();
+    });
+
+    await page.goto("/analytics");
+    await page.waitForLoadState("networkidle");
+
+    // Should show empty state instead of crashing
+    await expect(page.getByText("Nothing here yet")).toBeVisible();
+    await expect(page.getByText("Craft your first draft and the numbers will start rolling in.")).toBeVisible();
+  });
 });

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -100,7 +100,7 @@ function AnalyticsPage() {
   // When the analytics API reports zero drafts but we can confirm posted drafts exist from
   // the drafts endpoint, use the known count as a floor. The analytics_events table can
   // lag behind the drafts table, causing the summary to show 0 while the detail table has data.
-  const knownPostedCount = topDrafts.length;
+  const knownPostedCount = (topDrafts ?? []).length;
   const usageStats = summary
     ? [
         { label: "Drafts", value: String(summary.draftsCreated > 0 ? summary.draftsCreated : knownPostedCount), href: "/crafting" },
@@ -119,18 +119,18 @@ function AnalyticsPage() {
   const hasNoAnalyticsData = !loading
     && !error
     && !summary
-    && engagementDays.length === 0
-    && activityDays.length === 0
-    && logEntries.length === 0
-    && topDrafts.length === 0;
+    && (engagementDays ?? []).length === 0
+    && (activityDays ?? []).length === 0
+    && (logEntries ?? []).length === 0
+    && (topDrafts ?? []).length === 0;
   const latestActivityCount =
-    activityDays.length > 0 ? activityDays[activityDays.length - 1]?.count ?? 0 : 0;
+    (activityDays ?? []).length > 0 ? (activityDays ?? [])[(activityDays ?? []).length - 1]?.count ?? 0 : 0;
   const activitySparklineSummary =
-    activityDays.length > 0
-      ? `Activity over ${activityDays.length} days. Peak day had ${activityMax} actions and the latest day had ${latestActivityCount}.`
+    (activityDays ?? []).length > 0
+      ? `Activity over ${(activityDays ?? []).length} days. Peak day had ${activityMax} actions and the latest day had ${latestActivityCount}.`
       : "No activity data yet. Activity data will appear as you create drafts.";
-  const recentLogEntries = logEntries.slice(-20);
-  const positiveSignalCount = logEntries.filter((entry) => entry.positive).length;
+  const recentLogEntries = (logEntries ?? []).slice(-20);
+  const positiveSignalCount = (logEntries ?? []).filter((entry) => entry.positive).length;
   const confidenceTrendSummary =
     recentLogEntries.length > 0
       ? `Confidence trend across ${recentLogEntries.length} recent learning events. ${positiveSignalCount} positive signals detected so far.`
@@ -196,7 +196,7 @@ function AnalyticsPage() {
                 ))}
           </div>
           {/* Sparkline */}
-          {activityDays.length > 0 ? (() => {
+          {(activityDays ?? []).length > 0 ? (() => {
             const sparkData = activityDays ?? [];
             return (
               <div
@@ -284,9 +284,9 @@ function AnalyticsPage() {
 
         <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface p-4">
           <h3 className="mb-3 text-sm font-medium text-atlas-text">Top Performing Drafts</h3>
-          {topDrafts.length > 0 ? (
+          {(topDrafts ?? []).length > 0 ? (
             <div className="space-y-3">
-              {topDrafts.map((draft, i) => (
+              {(topDrafts ?? []).map((draft, i) => (
                 <Link
                   key={draft.id}
                   href="/crafting"

--- a/src/components/analytics/EngagementVelocityChart.tsx
+++ b/src/components/analytics/EngagementVelocityChart.tsx
@@ -12,25 +12,25 @@ export default function EngagementVelocityChart({
 }: EngagementVelocityChartProps) {
   const chartDescriptionId = useId();
   const chartMax =
-    engagementDays.length > 0
-      ? Math.max(...engagementDays.flatMap((day) => [day.predicted ?? 0, day.actual ?? 0]), 1)
+    (engagementDays ?? []).length > 0
+      ? Math.max(...(engagementDays ?? []).flatMap((day) => [day.predicted ?? 0, day.actual ?? 0]), 1)
       : 100;
 
   const accuracyPct =
-    engagementDays.length > 0
+    (engagementDays ?? []).length > 0
       ? Math.round(
           (1 -
-            engagementDays.reduce((sum, day) => {
+            (engagementDays ?? []).reduce((sum, day) => {
               const maxVal = Math.max(day.predicted ?? 0, day.actual ?? 0, 1);
               return sum + Math.abs((day.predicted ?? 0) - (day.actual ?? 0)) / maxVal;
             }, 0) /
-              engagementDays.length) *
+              (engagementDays ?? []).length) *
             100
         )
       : null;
   const chartSummary =
-    engagementDays.length > 0
-      ? `Engagement velocity over ${engagementDays.length} days. Highest value shown is ${chartMax}. Prediction accuracy is ${accuracyPct ?? 0} percent.`
+    (engagementDays ?? []).length > 0
+      ? `Engagement velocity over ${(engagementDays ?? []).length} days. Highest value shown is ${chartMax}. Prediction accuracy is ${accuracyPct ?? 0} percent.`
       : "No engagement data yet. Create and post drafts to compare predictions with actual engagement.";
 
   return (
@@ -63,8 +63,8 @@ export default function EngagementVelocityChart({
               <span>Low</span>
             </div>
             <div className="ml-10 h-full flex items-end gap-0">
-              {engagementDays.length > 0 ? (
-                engagementDays.map((day) => (
+              {(engagementDays ?? []).length > 0 ? (
+                (engagementDays ?? []).map((day) => (
                   <div key={day.date} className="flex-1 flex flex-col items-center gap-1">
                     <div className="w-full flex h-40 items-end justify-center gap-1">
                       <div

--- a/src/components/analytics/ModelReliabilitySection.tsx
+++ b/src/components/analytics/ModelReliabilitySection.tsx
@@ -9,8 +9,8 @@ interface ModelReliabilitySectionProps {
 export default function ModelReliabilitySection({
   logEntries,
 }: ModelReliabilitySectionProps) {
-  const recentEntries = logEntries.slice(-20);
-  const positiveSignals = logEntries.filter((entry) => entry.positive).length;
+  const recentEntries = (logEntries ?? []).slice(-20);
+  const positiveSignals = (logEntries ?? []).filter((entry) => entry.positive).length;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
@@ -22,8 +22,8 @@ export default function ModelReliabilitySection({
           Model Reliability
         </h3>
         <div className="mt-4 h-20 flex items-end gap-0.5">
-          {recentEntries.length > 0 ? (
-            recentEntries.map((entry, index) => {
+          {(recentEntries ?? []).length > 0 ? (
+            (recentEntries ?? []).map((entry, index) => {
               const score = entry.positive ? 70 + index * 1.5 : 30 + index * 1.5;
               return (
                 <div
@@ -43,7 +43,7 @@ export default function ModelReliabilitySection({
         </div>
       </div>
       <div className="bg-atlas-surface border border-glass-border rounded-xl p-6 flex items-center">
-        {logEntries.length > 0 ? (
+        {(logEntries ?? []).length > 0 ? (
           <p className="font-heading font-medium text-base text-atlas-text italic leading-relaxed">
             {positiveSignals} positive signals detected across your recent activity.
           </p>


### PR DESCRIPTION
Analytics page crashed on empty data; added fallbacks.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>