### PR TITLE
[codex] add PR templates and streamline CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,22 @@
+## Summary
+- Briefly describe the bug and the fix.
+
+## Root Cause
+- Explain what was broken.
+- Note why the issue escaped or what condition triggered it.
+
+## Fix
+- Summarize the code path or safeguard that changed.
+- Mention any follow-on cleanups or risk areas.
+
+## Validation
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Reproduced the issue before the fix
+- [ ] Verified the fix manually or with tests
+
+## Checklist
+- [ ] Targets `staging`
+- [ ] Added or updated regression coverage where practical
+- [ ] No unrelated refactors bundled into the fix

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+## Summary
+- Briefly describe the user-facing change.
+- Call out the main implementation details.
+
+## Why
+- Link the problem, request, or ticket this change addresses.
+- Note any product, UX, or operational context reviewers need.
+
+## Validation
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Manual verification completed
+
+## Screenshots / Recording
+- Add before/after visuals for UI changes, or write `N/A`.
+
+## Checklist
+- [ ] Targets `staging`
+- [ ] Added or updated tests when behavior changed
+- [ ] Follows Atlas Portal frontend conventions

--- a/.github/PULL_REQUEST_TEMPLATE/maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/maintenance.md
@@ -1,0 +1,19 @@
+## Summary
+- Briefly describe the maintenance, CI, tooling, or dependency change.
+
+## Why
+- Explain the operational problem, cleanup goal, or maintenance need.
+
+## Impact
+- Note developer workflow impact, runtime impact, or write `Low` / `None`.
+- Call out any rollout or follow-up requirements.
+
+## Validation
+- [ ] Relevant local checks completed
+- [ ] CI-specific behavior reviewed
+- [ ] Docs or configs updated if needed
+
+## Checklist
+- [ ] Targets `staging`
+- [ ] Change stays scoped to maintenance or tooling
+- [ ] Any risky follow-up work is captured in the PR body

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   push:
     branches: [staging, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,6 +32,7 @@ jobs:
   resolve-preview:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 10
     outputs:
       preview_url: ${{ steps.resolve.outputs.url }}
     permissions:
@@ -165,6 +174,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check, resolve-preview]
     if: github.event_name == 'pull_request'
+    timeout-minutes: 30
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ needs.resolve-preview.outputs.preview_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -173,30 +185,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install chromium --with-deps
-      - name: Get Vercel preview URL (delphi-atlas project)
-        run: |
-          SHA="${{ github.event.pull_request.head.sha }}"
-          REPO="${{ github.repository }}"
-          for attempt in $(seq 1 24); do
-            DEPLOY_ID=$(gh api "repos/${REPO}/deployments?sha=${SHA}&per_page=50" \
-              --jq '[.[] | select(.environment | test("delphi-atlas"))] | first | .id' 2>/dev/null)
-            if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
-              ENV_URL=$(gh api "repos/${REPO}/deployments/${DEPLOY_ID}/statuses?per_page=10" \
-                --jq '[.[] | select(.state == "success")] | first | .environment_url' 2>/dev/null)
-              if [ -n "$ENV_URL" ] && [ "$ENV_URL" != "null" ] && [ "$ENV_URL" != "" ]; then
-                echo "PLAYWRIGHT_BASE_URL=${ENV_URL}" >> $GITHUB_ENV
-                echo "Using delphi-atlas preview: ${ENV_URL}"
-                exit 0
-              fi
-            fi
-            echo "Waiting for delphi-atlas deployment... (${attempt}/24)"
-            sleep 5
-          done
-          SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-')
-          echo "PLAYWRIGHT_BASE_URL=https://delphi-atlas-git-${SLUG}-alex-peris-projects.vercel.app" >> $GITHUB_ENV
-          echo "Fallback: constructed delphi-atlas URL"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run test:e2e
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET || secrets.VERCEL_PROTECTION_BYPASS }}
@@ -210,8 +198,11 @@ jobs:
 
   e2e-extended:
     runs-on: ubuntu-latest
-    needs: check
+    needs: [check, resolve-preview]
     if: github.event_name == 'pull_request'
+    timeout-minutes: 30
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ needs.resolve-preview.outputs.preview_url }}
     strategy:
       fail-fast: false
       matrix:
@@ -232,30 +223,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install chromium --with-deps
-      - name: Get Vercel preview URL
-        run: |
-          SHA="${{ github.event.pull_request.head.sha }}"
-          REPO="${{ github.repository }}"
-          for attempt in $(seq 1 24); do
-            DEPLOY_ID=$(gh api "repos/${REPO}/deployments?sha=${SHA}&per_page=50" \
-              --jq '[.[] | select(.environment | test("delphi-atlas"))] | first | .id' 2>/dev/null)
-            if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
-              ENV_URL=$(gh api "repos/${REPO}/deployments/${DEPLOY_ID}/statuses?per_page=10" \
-                --jq '[.[] | select(.state == "success")] | first | .environment_url' 2>/dev/null)
-              if [ -n "$ENV_URL" ] && [ "$ENV_URL" != "null" ] && [ "$ENV_URL" != "" ]; then
-                echo "PLAYWRIGHT_BASE_URL=${ENV_URL}" >> $GITHUB_ENV
-                echo "Using Vercel preview: ${ENV_URL}"
-                exit 0
-              fi
-            fi
-            echo "Waiting for Vercel deployment... (${attempt}/24)"
-            sleep 5
-          done
-          SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-')
-          echo "PLAYWRIGHT_BASE_URL=https://delphi-atlas-git-${SLUG}-alex-peris-projects.vercel.app" >> $GITHUB_ENV
-          echo "Fallback: constructed URL (may not resolve for long branch names)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npx playwright test --config=playwright-e2e.config.ts --project=${{ matrix.project }}
         continue-on-error: ${{ matrix.continue_on_error == true }}
         env:


### PR DESCRIPTION
## Summary
- add dedicated pull request templates for feature, bugfix, and maintenance work
- add workflow concurrency and timeouts to CI so superseded runs cancel cleanly
- reuse the existing `resolve-preview` job output in Playwright jobs instead of resolving the same Vercel URL twice

## Why
PR descriptions in this repo were free-form, and the CI workflow duplicated preview URL lookup logic across both Playwright jobs even though `resolve-preview` was already a required dependency. This change standardizes PR authoring and trims redundant CI logic without expanding the workflow surface.

## Impact
- contributors get a scoped PR template depending on the kind of change they are shipping
- CI cancels stale in-progress runs for the same branch/PR
- Playwright jobs now consume a single preview URL source of truth from `resolve-preview`

## Validation
- `npm ci`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings in `src/app/arena/page.tsx`, `src/components/onboarding/OracleChat.tsx`, and `src/components/voice-profiles/VoiceEditorModal.tsx`)
- `npm run build`
- `npm test -- --runInBand` fails on existing `staging` test mismatches unrelated to this change:
  - `src/__tests__/app/CraftingPage.test.tsx`
  - `src/__tests__/app/AlertsPage.test.tsx`
  - `src/__tests__/app/VoiceProfilesPage.test.tsx`
  - `src/__tests__/app/AnalyticsPage.test.tsx`
  - `src/__tests__/components/ContentInput.test.tsx`
