### PR TITLE
Replace hardcoded URLs with public env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,7 @@ E2E_USER_PASSWORD=
 VERCEL_AUTOMATION_BYPASS_SECRET=
 # Legacy fallback name used by older workflows/tests.
 VERCEL_PROTECTION_BYPASS=
+
+# Alerts advanced UI (Auto-fire button, subscription controls).
+# Demo default: false. Set true to unhide for power users.
+NEXT_PUBLIC_ALERTS_ADVANCED=false

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 # Set per environment in Vercel dashboard (Production / Preview / Development scopes).
 # This file is for documentation only — do not commit real values.
 
+# Frontend app URL
+# Production: https://delphi-atlas.vercel.app
+# Preview:    https://<your-preview-domain>.vercel.app
+# Local dev:  http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
 # Backend API URL
 # Production: https://api-production-9bef.up.railway.app
 # Staging:    https://atlas-api-staging.up.railway.app (TBD after Railway setup)
@@ -9,8 +15,19 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Supabase (anon/public key — safe for client)
+# Get project URL from Supabase project > Settings > API > Project URL
+NEXT_PUBLIC_SUPABASE_URL=
 # Get from Supabase project > Settings > API > Project API keys > anon/public
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Public third-party URLs used by metadata, external links, CSP, and avatars
+NEXT_PUBLIC_X_BASE_URL=https://twitter.com
+NEXT_PUBLIC_UNAVATAR_ORIGIN=https://unavatar.io
+NEXT_PUBLIC_TELEGRAM_BOT_URL=https://t.me/AtlasDelphiBot
+NEXT_PUBLIC_X_IMAGE_CDN_ORIGIN=https://pbs.twimg.com
+NEXT_PUBLIC_GOOGLE_FONTS_STYLES_ORIGIN=https://fonts.googleapis.com
+NEXT_PUBLIC_GOOGLE_FONTS_ASSETS_ORIGIN=https://fonts.gstatic.com
+NEXT_PUBLIC_DEMO_SOURCE_URL=https://example.com/sol-ath
 
 # Sentry — Error Tracking
 # Get DSN from https://sentry.io > Project Settings > Client Keys (DSN)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,7 @@ process.env.NEXT_PUBLIC_X_IMAGE_CDN_ORIGIN = "https://pbs.twimg.com";
 process.env.NEXT_PUBLIC_GOOGLE_FONTS_STYLES_ORIGIN = "https://fonts.googleapis.com";
 process.env.NEXT_PUBLIC_GOOGLE_FONTS_ASSETS_ORIGIN = "https://fonts.gstatic.com";
 process.env.NEXT_PUBLIC_DEMO_SOURCE_URL = "https://example.com/sol-ath";
+process.env.NEXT_PUBLIC_ALERTS_ADVANCED = "true";
 
 // Polyfill HTMLDialogElement methods for jsdom
 if (typeof HTMLDialogElement !== "undefined") {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,13 @@
 process.env.NEXT_PUBLIC_API_URL = "http://localhost:3001";
+process.env.NEXT_PUBLIC_APP_URL = "https://delphi-atlas.vercel.app";
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://zoirudjyqfqvpxsrxepr.supabase.co";
+process.env.NEXT_PUBLIC_X_BASE_URL = "https://twitter.com";
+process.env.NEXT_PUBLIC_UNAVATAR_ORIGIN = "https://unavatar.io";
+process.env.NEXT_PUBLIC_TELEGRAM_BOT_URL = "https://t.me/AtlasDelphiBot";
+process.env.NEXT_PUBLIC_X_IMAGE_CDN_ORIGIN = "https://pbs.twimg.com";
+process.env.NEXT_PUBLIC_GOOGLE_FONTS_STYLES_ORIGIN = "https://fonts.googleapis.com";
+process.env.NEXT_PUBLIC_GOOGLE_FONTS_ASSETS_ORIGIN = "https://fonts.gstatic.com";
+process.env.NEXT_PUBLIC_DEMO_SOURCE_URL = "https://example.com/sol-ath";
 
 // Polyfill HTMLDialogElement methods for jsdom
 if (typeof HTMLDialogElement !== "undefined") {

--- a/src/__tests__/app/CraftingPage.test.tsx
+++ b/src/__tests__/app/CraftingPage.test.tsx
@@ -49,6 +49,7 @@ jest.mock("@/lib/api", () => ({
       refine: jest.fn(),
       schedule: jest.fn(),
       postToX: jest.fn(),
+      enqueue: jest.fn(),
     },
     analytics: {
       summary: jest.fn(),
@@ -84,6 +85,7 @@ const mockedApi = api as unknown as {
     refine: jest.Mock;
     schedule: jest.Mock;
     postToX: jest.Mock;
+    enqueue: jest.Mock;
   };
   analytics: {
     summary: jest.Mock;
@@ -124,6 +126,7 @@ describe("CraftingPage", () => {
     mockedApi.drafts.refine.mockReset();
     mockedApi.drafts.schedule.mockReset();
     mockedApi.drafts.postToX.mockReset();
+    mockedApi.drafts.enqueue.mockReset();
     mockedApi.auth.x.status.mockReset();
     mockedApi.auth.x.authorize.mockReset();
     mockedApi.analytics.summary.mockReset();
@@ -509,5 +512,69 @@ describe("CraftingPage", () => {
     await screen.findByRole("textbox", { name: "Generated draft" });
 
     expect(screen.queryByRole("button", { name: "Schedule" })).not.toBeInTheDocument();
+  });
+
+  it("shows multi-angle button after pasting substantial text and opens panel on click", async () => {
+    render(<CraftingPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a tweet idea or link…"), {
+      target: { value: "a".repeat(600) },
+    });
+
+    const multiAngleButton = await screen.findByRole("button", {
+      name: "Generate Multi-Angle Tweets",
+    });
+    expect(multiAngleButton).toBeInTheDocument();
+
+    mockedApi.drafts.generate.mockResolvedValue({ draft: createDraft() });
+
+    fireEvent.click(multiAngleButton);
+
+    await waitFor(() =>
+      expect(screen.getByText("Multi-Angle Tweets")).toBeInTheDocument()
+    );
+  });
+
+  it("batch approves multi-angle drafts and refreshes the sidebar", async () => {
+    render(<CraftingPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a tweet idea or link…"), {
+      target: { value: "a".repeat(600) },
+    });
+
+    const multiAngleButton = await screen.findByRole("button", {
+      name: "Generate Multi-Angle Tweets",
+    });
+
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", content: "Angle draft content" }),
+    });
+    mockedApi.drafts.update.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", status: "APPROVED" }),
+    });
+    mockedApi.drafts.enqueue.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", status: "APPROVED" }),
+    });
+
+    fireEvent.click(multiAngleButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Angle draft content").length).toBeGreaterThan(0)
+    );
+
+    const batchApproveButton = screen.getByRole("button", {
+      name: "Approve 5 to Queue",
+    });
+    fireEvent.click(batchApproveButton);
+
+    await waitFor(() =>
+      expect(mockedApi.drafts.update).toHaveBeenCalledWith(
+        "draft-angle-1",
+        expect.objectContaining({ status: "APPROVED" })
+      )
+    );
+    await waitFor(() =>
+      expect(mockedApi.drafts.enqueue).toHaveBeenCalledWith("draft-angle-1")
+    );
   });
 });

--- a/src/__tests__/app/CraftingPage.test.tsx
+++ b/src/__tests__/app/CraftingPage.test.tsx
@@ -440,7 +440,7 @@ describe("CraftingPage", () => {
 
     await waitFor(() =>
       expect(openSpy).toHaveBeenCalledWith(
-        "https://twitter.com/intent/tweet?text=BTC%20looks%20constructive%20above%20range%20highs.",
+        "https://twitter.com/intent/tweet?text=BTC+looks+constructive+above+range+highs.",
         "_blank",
         "width=550,height=420"
       )

--- a/src/__tests__/components/crafting/MultiAnglePanel.test.tsx
+++ b/src/__tests__/components/crafting/MultiAnglePanel.test.tsx
@@ -1,0 +1,162 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MultiAnglePanel } from "@/components/crafting/MultiAnglePanel";
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    drafts: {
+      generate: jest.fn(),
+      update: jest.fn(),
+      enqueue: jest.fn(),
+    },
+  },
+}));
+
+const { api } = require("@/lib/api");
+const mockedApi = api as unknown as {
+  drafts: {
+    generate: jest.Mock;
+    update: jest.Mock;
+    enqueue: jest.Mock;
+  };
+};
+
+function createDraft(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `draft-${Math.random().toString(36).slice(2)}`,
+    content: "Generated draft content",
+    version: 1,
+    status: "DRAFT",
+    createdAt: "2026-04-03T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("MultiAnglePanel", () => {
+  beforeEach(() => {
+    mockedApi.drafts.generate.mockReset();
+    mockedApi.drafts.update.mockReset();
+    mockedApi.drafts.enqueue.mockReset();
+  });
+
+  it("generates 5 angles on mount and renders them in a grid", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft(),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Some report content that is long enough"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Contrarian")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Bullish")).toBeInTheDocument();
+    expect(screen.getByText("Educational")).toBeInTheDocument();
+    expect(screen.getByText("Data-led")).toBeInTheDocument();
+    expect(screen.getByText("Narrative")).toBeInTheDocument();
+  });
+
+  it("allows editing draft content", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ content: "Original angle content" }),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByDisplayValue("Original angle content").length).toBeGreaterThan(0)
+    );
+
+    const textarea = screen.getAllByDisplayValue("Original angle content")[0];
+    fireEvent.change(textarea, { target: { value: "Edited angle content" } });
+    fireEvent.blur(textarea);
+
+    expect(textarea).toHaveValue("Edited angle content");
+  });
+
+  it("batch approves selected drafts and calls update + enqueue", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", content: "Angle one" }),
+    });
+    mockedApi.drafts.update.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", status: "APPROVED" }),
+    });
+    mockedApi.drafts.enqueue.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", status: "APPROVED" }),
+    });
+
+    const onDraftsCreated = jest.fn();
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+        onDraftsCreated={onDraftsCreated}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Approve 5 to Queue" })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve 5 to Queue" }));
+
+    await waitFor(() =>
+      expect(mockedApi.drafts.update).toHaveBeenCalledTimes(5)
+    );
+    await waitFor(() =>
+      expect(mockedApi.drafts.enqueue).toHaveBeenCalledTimes(5)
+    );
+
+    expect(onDraftsCreated).toHaveBeenCalled();
+  });
+
+  it("allows discarding a draft and removes it from selection", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", content: "Angle one" }),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByLabelText("Discard draft").length).toBeGreaterThan(0)
+    );
+
+    const discardButtons = screen.getAllByLabelText("Discard draft");
+    fireEvent.click(discardButtons[0]);
+
+    await waitFor(() =>
+      expect(screen.getByText(/4 angles ready/i)).toBeInTheDocument()
+    );
+  });
+
+  it("calls onError when generation fails", async () => {
+    mockedApi.drafts.generate.mockRejectedValue(new Error("Generation failed"));
+
+    const onError = jest.fn();
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith("Generation failed")
+    );
+  });
+});

--- a/src/__tests__/lib/queue-rank.test.ts
+++ b/src/__tests__/lib/queue-rank.test.ts
@@ -1,0 +1,100 @@
+import { computeQueueRank, rankQueue } from "@/lib/queue-rank";
+import type { QueuedDraft } from "@/lib/api";
+
+function makeDraft(
+  overrides: Partial<QueuedDraft> = {}
+): QueuedDraft {
+  const now = new Date();
+  return {
+    id: "d1",
+    content: "Test draft",
+    version: 1,
+    status: "DRAFT",
+    confidence: 0.8,
+    predictedEngagement: 10,
+    actualEngagement: undefined,
+    sourceType: "MANUAL",
+    createdAt: now.toISOString(),
+    _score: 0,
+    suggestedAt: now.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("computeQueueRank", () => {
+  it("returns empty array for empty input", () => {
+    expect(computeQueueRank([])).toEqual([]);
+  });
+
+  it("assigns higher rank score to higher confidence drafts", () => {
+    const low = makeDraft({ id: "low", confidence: 0.2 });
+    const high = makeDraft({ id: "high", confidence: 0.95 });
+    const ranked = computeQueueRank([low, high]);
+    const lowScore = ranked.find((d) => d.id === "low")!._rankScore;
+    const highScore = ranked.find((d) => d.id === "high")!._rankScore;
+    expect(highScore).toBeGreaterThan(lowScore);
+  });
+
+  it("assigns higher rank score to peak-hour drafts", () => {
+    const now = new Date();
+    const offPeak = makeDraft({
+      id: "off",
+      suggestedAt: new Date(now.setHours(3, 0, 0, 0)).toISOString(),
+    });
+    const peak = makeDraft({
+      id: "peak",
+      suggestedAt: new Date(now.setHours(14, 0, 0, 0)).toISOString(),
+    });
+    const ranked = computeQueueRank([offPeak, peak]);
+    const offScore = ranked.find((d) => d.id === "off")!._rankBreakdown.timeliness;
+    const peakScore = ranked.find((d) => d.id === "peak")!._rankBreakdown.timeliness;
+    expect(peakScore).toBeGreaterThan(offScore);
+  });
+
+  it("uses actualEngagement over predictedEngagement when available", () => {
+    const predictedOnly = makeDraft({
+      id: "pred",
+      predictedEngagement: 5,
+      actualEngagement: undefined,
+    });
+    const withActual = makeDraft({
+      id: "actual",
+      predictedEngagement: 5,
+      actualEngagement: 50,
+    });
+    const ranked = computeQueueRank([predictedOnly, withActual]);
+    const predPerf = ranked.find((d) => d.id === "pred")!._rankBreakdown.performance;
+    const actualPerf = ranked.find((d) => d.id === "actual")!._rankBreakdown.performance;
+    expect(actualPerf).toBeGreaterThan(predPerf);
+  });
+
+  it("normalizes _score to 0-1 range", () => {
+    const draft = makeDraft({ confidence: 1, predictedEngagement: 100 });
+    const ranked = computeQueueRank([draft]);
+    expect(ranked[0]._score).toBeGreaterThan(0);
+    expect(ranked[0]._score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("rankQueue", () => {
+  it("sorts drafts by descending rank score", () => {
+    const now = new Date();
+    const a = makeDraft({
+      id: "a",
+      confidence: 0.2,
+      predictedEngagement: 1,
+      createdAt: new Date(now.getTime() - 48 * 3600000).toISOString(),
+      suggestedAt: new Date(now.setHours(3, 0, 0, 0)).toISOString(),
+    });
+    const b = makeDraft({
+      id: "b",
+      confidence: 0.95,
+      predictedEngagement: 100,
+      createdAt: now.toISOString(),
+      suggestedAt: new Date(now.setHours(14, 0, 0, 0)).toISOString(),
+    });
+    const ranked = rankQueue([a, b]);
+    expect(ranked[0].id).toBe("b");
+    expect(ranked[1].id).toBe("a");
+  });
+});

--- a/src/app/admin/qa/test-definitions.ts
+++ b/src/app/admin/qa/test-definitions.ts
@@ -1,3 +1,5 @@
+import { appHostDisplay, getAppUrl } from "@/lib/public-urls";
+
 export interface TestCase {
   id: string;
   name: string;
@@ -15,6 +17,9 @@ export interface TestSection {
   tests: TestCase[];
 }
 
+const dashboardUrl = getAppUrl("/dashboard");
+const notFoundUrl = getAppUrl("/nonexistent-page");
+
 export const sections: TestSection[] = [
   {
     id: "auth",
@@ -25,7 +30,7 @@ export const sections: TestSection[] = [
         id: "AUTH-01",
         name: "Register new account",
         steps: [
-          "Go to delphi-atlas.vercel.app",
+          `Go to ${appHostDisplay}`,
           'Click "Sign Up" tab or link',
           "Fill: email qa_manual@test.com, password TestManual123!",
           "Click Submit",
@@ -73,7 +78,7 @@ export const sections: TestSection[] = [
         steps: [
           "Login successfully",
           "Close the browser tab",
-          "Open delphi-atlas.vercel.app in a new tab",
+          `Open ${appHostDisplay} in a new tab`,
         ],
         expected: "Still logged in. Dashboard loads without re-login.",
       },
@@ -90,7 +95,7 @@ export const sections: TestSection[] = [
         id: "AUTH-12",
         name: "Protected route redirect",
         steps: [
-          "After logout, manually type delphi-atlas.vercel.app/dashboard in address bar",
+          `After logout, manually type ${dashboardUrl} in address bar`,
         ],
         expected:
           "Redirected to login page. Should NOT see dashboard content.",
@@ -623,7 +628,7 @@ export const sections: TestSection[] = [
         id: "ERR-03",
         name: "404 page",
         steps: [
-          "Navigate to delphi-atlas.vercel.app/nonexistent-page",
+          `Navigate to ${notFoundUrl}`,
         ],
         expected:
           "Shows 404 page or redirects to dashboard. No white screen.",

--- a/src/app/admin/roadmap/page.tsx
+++ b/src/app/admin/roadmap/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import AppShell from "@/components/layout/AppShell";
+import { publicUrls } from "@/lib/public-urls";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -12,7 +13,7 @@ import {
   Search,
 } from "lucide-react";
 
-const SUPA_URL = "https://zoirudjyqfqvpxsrxepr.supabase.co";
+const SUPA_URL = publicUrls.supabaseUrl;
 const SUPA_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
 
 const headers = {

--- a/src/app/alerts/page.tsx
+++ b/src/app/alerts/page.tsx
@@ -24,6 +24,8 @@ function formatAlertTimestamp(createdAt: string) {
   }).format(new Date(createdAt));
 }
 
+const showAdvanced = process.env.NEXT_PUBLIC_ALERTS_ADVANCED === "true";
+
 function AlertsPage() {
   const router = useRouter();
   const [alerts, setAlerts] = useState<Alert[]>([]);
@@ -105,14 +107,19 @@ function AlertsPage() {
             </p>
           </div>
           <div className="flex flex-col items-start gap-3 sm:items-end">
-            <button
-              data-tour="signals-subscribe"
-              onClick={() => setShowSubscriptions(!showSubscriptions)}
-              className="flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs font-medium text-atlas-text-secondary transition-colors hover:text-atlas-text"
-            >
-              <Settings className="h-3.5 w-3.5" aria-hidden="true" />
-              Monitors ({subscriptions.filter((sub) => sub.isActive).length})
-            </button>
+            {/** Demo-suppressed advanced UI — gated by NEXT_PUBLIC_ALERTS_ADVANCED, not deleted. */}
+            {showAdvanced ? (
+              <button
+                data-tour="signals-subscribe"
+                onClick={() => setShowSubscriptions(!showSubscriptions)}
+                className="flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs font-medium text-atlas-text-secondary transition-colors hover:text-atlas-text"
+              >
+                <Settings className="h-3.5 w-3.5" aria-hidden="true" />
+                Monitors ({subscriptions.filter((sub) => sub.isActive).length})
+              </button>
+            ) : (
+              <div data-testid="alerts-advanced-gated" />
+            )}
             {!loading && alerts.length > 0 && (
               <p className="text-xs font-medium uppercase tracking-[0.2em] text-atlas-text-muted">
                 {alerts.length} live signals
@@ -121,16 +128,20 @@ function AlertsPage() {
           </div>
         </div>
 
-        {showSubscriptions && (
-          <MonitorBuilder
-            subscriptions={subscriptions}
-            onSubscriptionChange={() => {
-              api.alerts
-                .subscriptions()
-                .then((res) => setSubscriptions(res.subscriptions ?? []))
-                .catch(() => {});
-            }}
-          />
+        {showAdvanced ? (
+          showSubscriptions && (
+            <MonitorBuilder
+              subscriptions={subscriptions}
+              onSubscriptionChange={() => {
+                api.alerts
+                  .subscriptions()
+                  .then((res) => setSubscriptions(res.subscriptions ?? []))
+                  .catch(() => {});
+              }}
+            />
+          )
+        ) : (
+          <div data-testid="alerts-advanced-gated" />
         )}
 
         {error && (

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -55,6 +55,7 @@ import { hasCalibratedVoiceDimensions } from "@/lib/voice-profile-dimensions";
 import OracleWidget from "@/components/oracle/OracleWidget";
 import OracleCraftingHints from "@/components/oracle/OracleCraftingHints";
 import OracleInspector from "@/components/oracle/OracleInspector";
+import { MultiAnglePanel } from "@/components/crafting/MultiAnglePanel";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
 import { useToast } from "@/components/ui/Toast";
 import { SchedulePopover } from "@/components/ui/SchedulePopover";
@@ -305,6 +306,11 @@ function CraftingPage() {
   const [urlPreview, setUrlPreview] = useState<{
     title?: string;
     url: string;
+  } | null>(null);
+  const [showMultiAngle, setShowMultiAngle] = useState(false);
+  const [multiAngleSource, setMultiAngleSource] = useState<{
+    content: string;
+    sourceType: DraftSourceType;
   } | null>(null);
   const activeDraftInitialized = useRef(false);
   const copyResetTimeoutRef = useRef<number | null>(null);
@@ -670,7 +676,13 @@ function CraftingPage() {
     if (sourceError && trimmedText) {
       setSourceError("");
     }
-  }, [contentError, sourceError]);
+
+    if (activeMode === "new_post" && trimmedText.length > 500) {
+      setMultiAngleSource({ content: text, sourceType: "MANUAL" });
+    } else if (activeMode === "new_post" && !trimmedText) {
+      setMultiAngleSource(null);
+    }
+  }, [activeMode, contentError, sourceError]);
   handleDraftTextChangeRef.current = handleDraftTextChange;
 
   const createDraftFromSource = useCallback(async (
@@ -796,6 +808,14 @@ function CraftingPage() {
 
       setError(null);
       handleDraftTextChange(text);
+      // Auto-trigger multi-angle for PDFs; for other files only if substantial text
+      const isPdf = file.type === "application/pdf" || file.name.endsWith(".pdf");
+      if (isPdf && activeMode === "new_post") {
+        setMultiAngleSource({ content: text, sourceType: "REPORT" });
+        setShowMultiAngle(true);
+      } else if (text.length > 500 && activeMode === "new_post") {
+        setMultiAngleSource({ content: text, sourceType: "MANUAL" });
+      }
     } catch (fileDropError: unknown) {
       console.error("Failed to process file:", fileDropError);
       setError(
@@ -804,7 +824,7 @@ function CraftingPage() {
           : "Failed to process file. Try pasting the content instead."
       );
     }
-  }, [handleDraftTextChange]);
+  }, [handleDraftTextChange, activeMode]);
 
   const handleFileDrop = useCallback(async (files: FileList) => {
     if (files.length === 0) {
@@ -1637,6 +1657,17 @@ function CraftingPage() {
                       Craft with Atlas
                     </button>
                   )}
+                  {activeMode === "new_post" && multiAngleSource && !showMultiAngle && (
+                    <button
+                      type="button"
+                      onClick={() => setShowMultiAngle(true)}
+                      disabled={creating || isVoiceCalibrationBlocked}
+                      className="mt-2 w-full inline-flex items-center justify-center gap-2 rounded-xl border border-atlas-teal/20 bg-atlas-teal/5 px-4 py-2.5 text-sm font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/10 hover:border-atlas-teal/40 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      Generate Multi-Angle Tweets
+                    </button>
+                  )}
                   {error ? (
                     <div
                       role="alert"
@@ -1658,6 +1689,22 @@ function CraftingPage() {
                       <span>{blendWarning}</span>
                       <button type="button" onClick={() => setBlendWarning(null)} aria-label="Dismiss" className="ml-2 hover:text-atlas-text"><X className="h-3.5 w-3.5" aria-hidden="true" /></button>
                     </div>
+                  )}
+                  {showMultiAngle && multiAngleSource && (
+                    <MultiAnglePanel
+                      sourceContent={multiAngleSource.content}
+                      sourceType={multiAngleSource.sourceType}
+                      blendId={selectedBlendId}
+                      disabled={creating || isVoiceCalibrationBlocked}
+                      onDraftsCreated={() => {
+                        void loadDrafts();
+                      }}
+                      onError={(message) => setError(message)}
+                      onClose={() => {
+                        setShowMultiAngle(false);
+                        setMultiAngleSource(null);
+                      }}
+                    />
                   )}
                 </div>
               </div>

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -39,6 +39,7 @@ import ContentInput from "@/components/ui/ContentInput";
 import { useVoiceRecorder } from "@/lib/useVoiceRecorder";
 import GradientButton from "@/components/ui/GradientButton";
 import ReplyAngleSelector from "@/components/ui/ReplyAngleSelector";
+import { getXIntentUrl } from "@/lib/public-urls";
 import RefinementChips, {
   RefinementChipOption,
 } from "@/components/ui/RefinementChips";
@@ -2067,8 +2068,12 @@ function CraftingPage() {
                         } catch (postError: unknown) {
                           console.error("Post to X failed:", postError);
                           // Fallback to intent
-                          const text = encodeURIComponent(activeDraft.content);
-                          window.open(`https://twitter.com/intent/tweet?text=${text}`, "_blank", "width=550,height=420");
+                          const intentUrl = getXIntentUrl(activeDraft.content);
+                          if (!intentUrl) {
+                            setError("X fallback URL is not configured.");
+                            return;
+                          }
+                          window.open(intentUrl, "_blank", "width=550,height=420");
                         }
                       }}
                       className="flex items-center gap-1.5 rounded-lg border border-glass-border bg-atlas-surface px-3 py-1.5 text-xs font-medium text-atlas-text transition-colors hover:border-atlas-teal/50"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { playfairDisplay, inter } from "@/lib/fonts";
+import { publicUrls } from "@/lib/public-urls";
 import { colors } from "@/lib/tokens";
 import RouteProgress from "@/components/ui/RouteProgress";
 import Providers from "./providers";
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
   },
   description:
     "Content-to-tweet crafting platform with personalized voice profiles for crypto analysts.",
-  metadataBase: new URL("https://delphi-atlas.vercel.app"),
+  metadataBase: publicUrls.appUrl ? new URL(publicUrls.appUrl) : undefined,
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
     apple: "/apple-touch-icon.png",
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Atlas — Delphi Digital",
     description: "Craft tweets that sound like you. Powered by voice AI.",
-    url: "https://delphi-atlas.vercel.app",
+    url: publicUrls.appUrl || undefined,
     siteName: "Atlas",
     type: "website",
   },

--- a/src/app/onboarding/handoff/page.tsx
+++ b/src/app/onboarding/handoff/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import OnboardingShell from "@/components/layout/OnboardingShell";
 import GradientButton from "@/components/ui/GradientButton";
+import { publicUrls } from "@/lib/public-urls";
 import { Check } from "lucide-react";
 
 const feedbackChannels = ["Text", "Voice note", "Loom video"];
@@ -74,7 +75,7 @@ function HandoffContent() {
                 <p className="text-xs text-atlas-text-muted">Scan to connect</p>
               </div>
             </div>
-            <a href="https://t.me/AtlasDelphiBot" target="_blank" rel="noopener noreferrer" className="text-atlas-teal text-sm hover:underline cursor-pointer">
+            <a href={publicUrls.telegramBotUrl} target="_blank" rel="noopener noreferrer" className="text-atlas-teal text-sm hover:underline cursor-pointer">
               or tap this link to connect →
             </a>
           </div>

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
   X,
   Send,
+  Sparkles,
 } from "lucide-react";
 import {
   DndContext,
@@ -38,6 +39,7 @@ import OracleInspector from "@/components/oracle/OracleInspector";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
 import { api, QueuedDraft } from "@/lib/api";
 import { SchedulePopover } from "@/components/ui/SchedulePopover";
+import { rankQueue } from "@/lib/queue-rank";
 
 type FilterKey = "all" | "draft" | "scheduled" | "posted" | "archived";
 
@@ -429,6 +431,17 @@ function QueuePage() {
     }
   }, []);
 
+  const handleRank = useCallback(async () => {
+    const ranked = rankQueue(queue);
+    setQueue(ranked);
+    setIsManualOrder(true);
+    try {
+      await api.drafts.reorderQueue(ranked.map((d) => d.id));
+    } catch (err) {
+      console.error("Failed to persist ranked order:", err);
+    }
+  }, [queue]);
+
   // Filter logic — "all" and "scheduled" use the ranked queue, every other
   // status pulls from the full draft list so users can manage the entire pipeline.
   const filteredQueue = useMemo(() => {
@@ -541,6 +554,17 @@ function QueuePage() {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {/* Smart Rank */}
+          {draggable && (
+            <button
+              onClick={() => void handleRank()}
+              className="flex items-center gap-1 rounded-full border border-glass-border px-3 py-1 text-xs font-medium text-atlas-text-muted transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+              aria-label="Rank queue by predicted engagement"
+            >
+              <Sparkles className="h-3 w-3" />
+              Rank
+            </button>
+          )}
           {/* Reset to Auto */}
           {isManualOrder && draggable && (
             <button

--- a/src/components/crafting/MultiAnglePanel.tsx
+++ b/src/components/crafting/MultiAnglePanel.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState } from "react";
+import { Loader2, X, CheckCircle2, Sparkles } from "lucide-react";
+import { api, type TweetDraft } from "@/lib/api";
+import { TweetAngleCard, type AngleDraftItem } from "./TweetAngleCard";
+
+const ANGLE_CONFIGS = [
+  {
+    label: "Contrarian",
+    instruction:
+      "Write a contrarian take that challenges the main narrative or consensus view in this report. Be sharp but credible.",
+  },
+  {
+    label: "Bullish",
+    instruction:
+      "Write a bullish, optimistic take highlighting opportunities, upside, or positive implications from this report.",
+  },
+  {
+    label: "Educational",
+    instruction:
+      "Write an educational tweet that explains the most important concept from this report simply and clearly.",
+  },
+  {
+    label: "Data-led",
+    instruction:
+      "Write a data-led tweet focusing on the key numbers, statistics, or metrics from this report.",
+  },
+  {
+    label: "Narrative",
+    instruction:
+      "Write a narrative-driven tweet that tells the story or human impact behind this report.",
+  },
+];
+
+interface MultiAnglePanelProps {
+  sourceContent: string;
+  sourceType: string;
+  blendId?: string | null;
+  disabled?: boolean;
+  onDraftsCreated?: () => void;
+  onError?: (message: string) => void;
+  onClose?: () => void;
+}
+
+export function MultiAnglePanel({
+  sourceContent,
+  sourceType,
+  blendId,
+  disabled = false,
+  onDraftsCreated,
+  onError,
+  onClose,
+}: MultiAnglePanelProps) {
+  const [items, setItems] = useState<AngleDraftItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchApproving, setBatchApproving] = useState(false);
+  const [successCount, setSuccessCount] = useState<number | null>(null);
+  const titleId = useId();
+
+  const generateAngles = useCallback(async () => {
+    if (!sourceContent.trim()) return;
+
+    setLoading(true);
+    setSuccessCount(null);
+    setItems([]);
+    setSelectedIds(new Set());
+
+    try {
+      const results = await Promise.all(
+        ANGLE_CONFIGS.map(async (config) => {
+          const { draft } = await api.drafts.generate({
+            sourceContent,
+            sourceType,
+            blendId: blendId || undefined,
+            angleInstruction: config.instruction,
+          });
+          return {
+            id: `${config.label}-${draft.id}`,
+            draft,
+            angleLabel: config.label,
+            discarded: false,
+          } as AngleDraftItem;
+        })
+      );
+      setItems(results);
+      // Auto-select all by default
+      setSelectedIds(new Set(results.map((r) => r.id)));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to generate angle drafts";
+      onError?.(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sourceContent, sourceType, blendId, onError]);
+
+  useEffect(() => {
+    void generateAngles();
+  }, [generateAngles]);
+
+  const activeItems = items.filter((i) => !i.discarded);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setSelectedIds(new Set(activeItems.map((i) => i.id)));
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
+  };
+
+  const updateItemContent = (id: string, content: string) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, draft: { ...item.draft, content } } : item
+      )
+    );
+  };
+
+  const discardItem = (id: string) => {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, discarded: true } : item))
+    );
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const approveItem = async (id: string) => {
+    const item = items.find((i) => i.id === id);
+    if (!item) return;
+
+    try {
+      await api.drafts.update(item.draft.id, {
+        content: item.draft.content,
+        status: "APPROVED",
+      });
+      await api.drafts.enqueue(item.draft.id);
+      setItems((prev) =>
+        prev.map((i) => (i.id === id ? { ...i, discarded: true } : i))
+      );
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to approve draft";
+      onError?.(message);
+    }
+  };
+
+  const handleBatchApprove = async () => {
+    if (selectedIds.size === 0) return;
+
+    setBatchApproving(true);
+    let approved = 0;
+
+    try {
+      const toApprove = items.filter(
+        (i) => selectedIds.has(i.id) && !i.discarded
+      );
+      await Promise.all(
+        toApprove.map(async (item) => {
+          await api.drafts.update(item.draft.id, {
+            content: item.draft.content,
+            status: "APPROVED",
+          });
+          await api.drafts.enqueue(item.draft.id);
+          approved++;
+        })
+      );
+
+      setItems((prev) =>
+        prev.map((i) =>
+          selectedIds.has(i.id) ? { ...i, discarded: true } : i
+        )
+      );
+      setSelectedIds(new Set());
+      setSuccessCount(approved);
+      onDraftsCreated?.();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Batch approval failed";
+      onError?.(message);
+    } finally {
+      setBatchApproving(false);
+    }
+  };
+
+  const allSelected =
+    activeItems.length > 0 && activeItems.every((i) => selectedIds.has(i.id));
+
+  return (
+    <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface p-5 sm:p-6">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 id={titleId} className="font-heading text-lg font-bold text-atlas-text">
+            Multi-Angle Tweets
+          </h3>
+          <p className="text-sm text-atlas-text-secondary">
+            {loading
+              ? "Generating 5 different angles from your report…"
+              : activeItems.length > 0
+                ? `${activeItems.length} angle${activeItems.length !== 1 ? "s" : ""} ready. Edit, select, and approve.`
+                : items.length > 0
+                  ? "All drafts have been handled."
+                  : "No angles generated yet."}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {!loading && activeItems.length > 0 && (
+            <label className="flex cursor-pointer items-center gap-1.5 text-xs text-atlas-text-muted hover:text-atlas-text-secondary">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={() => (allSelected ? clearSelection() : selectAll())}
+                className="h-4 w-4 accent-atlas-teal"
+              />
+              Select all
+            </label>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-text"
+            aria-label="Close panel"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {successCount !== null && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-atlas-teal/30 bg-atlas-teal/10 px-3 py-2 text-sm text-atlas-teal">
+          <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+          {successCount} draft{successCount !== 1 ? "s" : ""} approved and added to queue.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {ANGLE_CONFIGS.map((config) => (
+            <div
+              key={config.label}
+              className="h-48 animate-pulse rounded-2xl border border-glass-border bg-atlas-surface/50"
+              aria-hidden="true"
+            >
+              <div className="p-5">
+                <div className="mb-3 h-5 w-20 rounded bg-atlas-nav" />
+                <div className="space-y-2">
+                  <div className="h-3 w-full rounded bg-atlas-nav" />
+                  <div className="h-3 w-5/6 rounded bg-atlas-nav" />
+                  <div className="h-3 w-4/6 rounded bg-atlas-nav" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => (
+            <TweetAngleCard
+              key={item.id}
+              item={item}
+              selected={selectedIds.has(item.id)}
+              disabled={disabled || batchApproving}
+              isApproving={batchApproving}
+              onToggleSelect={() => toggleSelect(item.id)}
+              onChangeContent={(content) => updateItemContent(item.id, content)}
+              onApprove={() => void approveItem(item.id)}
+              onDiscard={() => discardItem(item.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && activeItems.length === 0 && items.length > 0 && (
+        <div className="mt-6 text-center text-sm text-atlas-text-secondary">
+          All angles approved or discarded.
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-2 text-atlas-teal hover:underline"
+          >
+            Close panel
+          </button>
+        </div>
+      )}
+
+      {/* Floating batch action bar */}
+      {selectedIds.size > 0 && !loading && (
+        <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-2xl border border-glass-border bg-atlas-nav/95 px-5 py-3 shadow-xl backdrop-blur-xl">
+          <Sparkles className="h-4 w-4 text-atlas-teal" aria-hidden="true" />
+          <span className="text-sm text-atlas-text">
+            {selectedIds.size} selected
+          </span>
+          <button
+            type="button"
+            onClick={() => void handleBatchApprove()}
+            disabled={batchApproving || disabled}
+            className="rounded-lg bg-atlas-teal px-4 py-2 text-sm font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {batchApproving ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                Approving…
+              </span>
+            ) : (
+              `Approve ${selectedIds.size} to Queue`
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={clearSelection}
+            disabled={batchApproving}
+            className="rounded-lg border border-glass-border px-3 py-2 text-xs text-atlas-text-muted transition-colors hover:text-atlas-text disabled:opacity-50"
+            aria-label="Clear selection"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/crafting/TweetAngleCard.tsx
+++ b/src/components/crafting/TweetAngleCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Loader2, Trash2, CheckCircle2 } from "lucide-react";
+import type { TweetDraft } from "@/lib/api";
+
+export interface AngleDraftItem {
+  id: string;
+  draft: TweetDraft;
+  angleLabel: string;
+  discarded: boolean;
+}
+
+interface TweetAngleCardProps {
+  item: AngleDraftItem;
+  selected: boolean;
+  disabled: boolean;
+  isApproving: boolean;
+  onToggleSelect: () => void;
+  onChangeContent: (content: string) => void;
+  onApprove: () => void;
+  onDiscard: () => void;
+}
+
+const ANGLE_COLORS: Record<string, string> = {
+  Contrarian: "bg-orange-500/15 text-orange-300 border-orange-500/25",
+  Bullish: "bg-emerald-500/15 text-emerald-300 border-emerald-500/25",
+  Educational: "bg-violet-500/15 text-violet-300 border-violet-500/25",
+  "Data-led": "bg-blue-500/15 text-blue-300 border-blue-500/25",
+  Narrative: "bg-teal-500/15 text-teal-300 border-teal-500/25",
+};
+
+export function TweetAngleCard({
+  item,
+  selected,
+  disabled,
+  isApproving,
+  onToggleSelect,
+  onChangeContent,
+  onApprove,
+  onDiscard,
+}: TweetAngleCardProps) {
+  const [localContent, setLocalContent] = useState(item.draft.content);
+  const angleClass =
+    ANGLE_COLORS[item.angleLabel] ??
+    "bg-atlas-text-muted/15 text-atlas-text-muted border-atlas-text-muted/25";
+
+  const charCount = localContent.length;
+  const isOverLimit = charCount > 280;
+
+  const handleBlur = () => {
+    if (localContent !== item.draft.content) {
+      onChangeContent(localContent);
+    }
+  };
+
+  if (item.discarded) {
+    return null;
+  }
+
+  return (
+    <div className="relative rounded-2xl border border-glass-border bg-glass p-5 backdrop-blur-xl transition-colors hover:border-atlas-teal/20">
+      {/* Header: checkbox + badge + actions */}
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex flex-1 items-center gap-2 flex-wrap">
+          <button
+            type="button"
+            onClick={onToggleSelect}
+            disabled={disabled}
+            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors ${
+              selected
+                ? "border-atlas-teal bg-atlas-teal"
+                : "border-white/20 bg-transparent hover:border-white/40"
+            } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+            aria-label={selected ? "Deselect draft" : "Select draft"}
+          >
+            {selected && (
+              <Check className="h-3.5 w-3.5 text-white" aria-hidden="true" />
+            )}
+          </button>
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${angleClass}`}
+          >
+            {item.angleLabel}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onApprove}
+            disabled={disabled || isApproving}
+            className="inline-flex items-center gap-1 rounded-lg border border-atlas-teal/30 px-2.5 py-1 text-[11px] font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/10 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Approve to queue"
+          >
+            {isApproving ? (
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+            )}
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={disabled}
+            className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-error disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Discard draft"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Editable content */}
+      <textarea
+        value={localContent}
+        onChange={(e) => setLocalContent(e.target.value)}
+        onBlur={handleBlur}
+        disabled={disabled}
+        rows={5}
+        className="w-full resize-none rounded-lg border border-glass-border bg-atlas-surface/60 px-3 py-2.5 text-sm leading-relaxed text-atlas-text placeholder:text-atlas-text-muted focus:border-atlas-teal focus:outline-none disabled:opacity-60"
+      />
+
+      {/* Footer: char count */}
+      <div className="mt-2 flex items-center justify-between">
+        <span
+          className={`text-xs font-mono ${
+            isOverLimit
+              ? "text-atlas-error"
+              : charCount > 250
+                ? "text-atlas-warning"
+                : "text-atlas-text-muted"
+          }`}
+        >
+          {charCount}/280
+        </span>
+        {isOverLimit && (
+          <span className="text-xs text-atlas-error">
+            {charCount - 280} over limit
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/BlendRatioSlider.tsx
+++ b/src/components/onboarding/BlendRatioSlider.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import DimensionBar from "@/components/ui/DimensionBar";
+import { getTwitterAvatarUrl } from "@/lib/public-urls";
 import { resolveVoiceAvatar, type MinimalUser } from "@/lib/voice-avatar";
 
 export interface BlendReference {
@@ -228,10 +229,22 @@ function RefAvatar({ handle, name }: { handle?: string; name: string }) {
   }
 
   const cleanHandle = handle.replace(/^@/, "");
+  const avatarUrl = getTwitterAvatarUrl(cleanHandle);
+
+  if (!avatarUrl) {
+    return (
+      <div className="h-8 w-8 shrink-0 rounded-full bg-atlas-surface border border-atlas-text-secondary/20 flex items-center justify-center">
+        <span className="text-[10px] font-semibold text-atlas-text-secondary">
+          {initial}
+        </span>
+      </div>
+    );
+  }
+
   return (
     // eslint-disable-next-line @next/next/no-img-element
     <img
-      src={`https://unavatar.io/twitter/${cleanHandle}`}
+      src={avatarUrl}
       alt={name}
       width={32}
       height={32}

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useAuth } from "@/lib/auth";
 import { api } from "@/lib/api";
+import { publicUrls } from "@/lib/public-urls";
 import {
   canAdvance,
   getContinueLabel,
@@ -563,7 +564,7 @@ export default function OracleChat() {
                 the go.
               </p>
               <a
-                href="https://t.me/AtlasDelphiBot"
+                href={publicUrls.telegramBotUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-atlas-teal text-sm hover:underline"

--- a/src/components/onboarding/ReferenceVoiceSelector.tsx
+++ b/src/components/onboarding/ReferenceVoiceSelector.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Check, ExternalLink, Loader2, Plus, X } from "lucide-react";
 import GradientButton from "@/components/ui/GradientButton";
 import { api, type ReferenceAccount, type TwitterFollow } from "@/lib/api";
+import { getXProfileUrl } from "@/lib/public-urls";
 import {
   normalizeReferenceAccounts,
   REFERENCE_ACCOUNT_FALLBACK,
@@ -186,6 +187,7 @@ export default function ReferenceVoiceSelector({
             const isSelected = selected.includes(account.id);
             const avatarUrl = account.profileImageUrl ?? account.avatarUrl;
             const label = account.displayName || account.handle || account.name || account.id;
+            const profileUrl = getXProfileUrl(account.handle);
             return (
               <button
                 key={account.id}
@@ -220,9 +222,9 @@ export default function ReferenceVoiceSelector({
                   </div>
                 )}
                 <p className="mt-3 text-xs text-atlas-text-muted">
-                  {account.handle ? (
+                  {account.handle && profileUrl ? (
                     <a
-                      href={`https://twitter.com/${account.handle}`}
+                      href={profileUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={(e) => e.stopPropagation()}

--- a/src/components/voice-profiles/ReferenceVoicesSection.tsx
+++ b/src/components/voice-profiles/ReferenceVoicesSection.tsx
@@ -9,6 +9,7 @@ import ImportFromXFollowsModal from "@/components/voice-profiles/ImportFromXFoll
 import ImportFromXLikesModal from "@/components/voice-profiles/ImportFromXLikesModal";
 import { api, type ReferenceAccount, type ReferenceVoice } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { getTwitterAvatarUrl, getXProfileUrl } from "@/lib/public-urls";
 import { colors } from "@/lib/tokens";
 import {
   getEqualReferenceWeights,
@@ -144,11 +145,7 @@ export default function ReferenceVoicesSection({
       handle: matchingReference?.handle ?? id,
       name: matchingReference?.name ?? id,
       profileImageUrl: matchingReference?.avatarUrl
-        ?? (matchingReference?.handle
-          ? `https://unavatar.io/twitter/${normalizeTwitterHandle(
-              matchingReference.handle
-            )}`
-          : null),
+        ?? getTwitterAvatarUrl(normalizeTwitterHandle(matchingReference?.handle)),
     });
   });
 
@@ -280,6 +277,7 @@ export default function ReferenceVoicesSection({
           <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {selectedAccounts.map((account) => {
               const normalizedHandle = normalizeTwitterHandle(account.handle);
+              const profileUrl = getXProfileUrl(normalizedHandle);
 
               return (
                 <div
@@ -318,9 +316,9 @@ export default function ReferenceVoicesSection({
                     <p className="truncate text-sm font-semibold text-atlas-text">
                       {account.displayName || account.name || account.handle || account.id}
                     </p>
-                    {normalizedHandle ? (
+                    {normalizedHandle && profileUrl ? (
                       <a
-                        href={`https://twitter.com/${normalizedHandle}`}
+                        href={profileUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-0.5 text-xs text-atlas-text-secondary hover:text-atlas-teal hover:underline"

--- a/src/lib/alertSocket.tsx
+++ b/src/lib/alertSocket.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback } from "react";
 import { io, Socket } from "socket.io-client";
 import { useAuth } from "./auth";
+import { publicUrls } from "./public-urls";
 
 interface Alert {
   id: string;
@@ -28,7 +29,7 @@ const AlertSocketContext = createContext<AlertSocketState>({
   onNewAlert: () => () => {},
 });
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+const API_URL = publicUrls.apiUrl;
 
 export function AlertSocketProvider({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -18,6 +18,7 @@ import type {
   DailyActivity,
   TeamMember,
 } from "./api";
+import { publicUrls } from "./public-urls";
 
 const now = new Date().toISOString();
 const daysAgo = (n: number) => new Date(Date.now() - n * 86400000).toISOString();
@@ -636,7 +637,7 @@ const alertsFeed: { alerts: Alert[] } = {
       context:
         "Solana hits new ATH. Content opportunity around ecosystem comparison takes.",
       category: "SIGNAL",
-      sourceUrl: "https://example.com/sol-ath",
+      sourceUrl: publicUrls.demoSourceUrl,
       sentiment: "bullish",
       relevance: 0.78,
       createdAt: daysAgo(1),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -33,7 +33,7 @@ function validateEnv() {
   } catch {
     throw new Error(
       `[Atlas] NEXT_PUBLIC_API_URL is not a valid URL: "${apiUrl}"\n` +
-        `Expected format: https://your-api.up.railway.app`
+        "Expected format: a fully-qualified URL beginning with http:// or https://"
     );
   }
 }

--- a/src/lib/public-urls.ts
+++ b/src/lib/public-urls.ts
@@ -1,0 +1,115 @@
+function stripTrailingSlash(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+function stripLeadingSlash(value: string) {
+  return value.replace(/^\/+/, "");
+}
+
+function normalizeHandle(value?: string | null) {
+  return value?.trim().replace(/^@/, "") ?? "";
+}
+
+function getOrigin(value: string) {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return stripTrailingSlash(value);
+  }
+}
+
+function joinUrl(base: string, path: string) {
+  if (!base) {
+    return "";
+  }
+
+  return `${stripTrailingSlash(base)}/${stripLeadingSlash(path)}`;
+}
+
+function getHost(value: string) {
+  if (!value) {
+    return "NEXT_PUBLIC_APP_URL";
+  }
+
+  try {
+    return new URL(value).host;
+  } catch {
+    return stripTrailingSlash(value).replace(/^https?:\/\//, "");
+  }
+}
+
+export const publicUrls = {
+  apiUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_API_URL ?? ""),
+  appUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_APP_URL ?? ""),
+  supabaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""),
+  xBaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_X_BASE_URL ?? ""),
+  unavatarOrigin: stripTrailingSlash(process.env.NEXT_PUBLIC_UNAVATAR_ORIGIN ?? ""),
+  telegramBotUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_TELEGRAM_BOT_URL ?? ""),
+  xImageCdnOrigin: stripTrailingSlash(
+    process.env.NEXT_PUBLIC_X_IMAGE_CDN_ORIGIN ?? ""
+  ),
+  googleFontsStylesOrigin: stripTrailingSlash(
+    process.env.NEXT_PUBLIC_GOOGLE_FONTS_STYLES_ORIGIN ?? ""
+  ),
+  googleFontsAssetsOrigin: stripTrailingSlash(
+    process.env.NEXT_PUBLIC_GOOGLE_FONTS_ASSETS_ORIGIN ?? ""
+  ),
+  demoSourceUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_DEMO_SOURCE_URL ?? ""),
+} as const;
+
+export const publicOrigins = {
+  apiOrigin: getOrigin(publicUrls.apiUrl),
+  supabaseOrigin: getOrigin(publicUrls.supabaseUrl),
+  unavatarOrigin: getOrigin(publicUrls.unavatarOrigin),
+  xImageCdnOrigin: getOrigin(publicUrls.xImageCdnOrigin),
+  googleFontsStylesOrigin: getOrigin(publicUrls.googleFontsStylesOrigin),
+  googleFontsAssetsOrigin: getOrigin(publicUrls.googleFontsAssetsOrigin),
+} as const;
+
+export const appHostDisplay = getHost(publicUrls.appUrl);
+
+export function getAppUrl(path = "") {
+  if (!publicUrls.appUrl) {
+    return path;
+  }
+
+  if (!path) {
+    return publicUrls.appUrl;
+  }
+
+  return new URL(path, `${publicUrls.appUrl}/`).toString();
+}
+
+export function getTwitterAvatarUrl(handle?: string | null) {
+  const normalizedHandle = normalizeHandle(handle);
+
+  if (!normalizedHandle || !publicUrls.unavatarOrigin) {
+    return null;
+  }
+
+  return joinUrl(publicUrls.unavatarOrigin, `twitter/${normalizedHandle}`);
+}
+
+export function getXProfileUrl(handle?: string | null) {
+  const normalizedHandle = normalizeHandle(handle);
+
+  if (!normalizedHandle || !publicUrls.xBaseUrl) {
+    return null;
+  }
+
+  return joinUrl(publicUrls.xBaseUrl, normalizedHandle);
+}
+
+export function getXIntentUrl(text: string) {
+  if (!publicUrls.xBaseUrl) {
+    return null;
+  }
+
+  const url = new URL("/intent/tweet", `${publicUrls.xBaseUrl}/`);
+  url.searchParams.set("text", text);
+  return url.toString();
+}

--- a/src/lib/queue-rank.ts
+++ b/src/lib/queue-rank.ts
@@ -1,0 +1,62 @@
+import { QueuedDraft } from "./api";
+
+const PEAK_HOURS = [9, 10, 13, 14, 19, 20];
+
+export interface RankedDraft extends QueuedDraft {
+  _rankScore: number;
+  _rankBreakdown: {
+    voiceFit: number;
+    timeliness: number;
+    performance: number;
+  };
+}
+
+export function computeQueueRank(drafts: QueuedDraft[]): RankedDraft[] {
+  if (drafts.length === 0) return [];
+
+  const engagements = drafts.map(
+    (d) => d.actualEngagement ?? d.predictedEngagement ?? 0
+  );
+  const maxEngagement = Math.max(...engagements, 1);
+  const now = Date.now();
+
+  return drafts.map((draft) => {
+    const suggested = new Date(draft.suggestedAt);
+    const hour = suggested.getHours();
+    const isPeak = PEAK_HOURS.includes(hour);
+
+    // Voice fit: confidence (0-1) scaled to 0-35 pts
+    const voiceFit = (draft.confidence ?? 0.5) * 35;
+
+    // Timeliness: peak-hour bonus + recency decay -> 0-35 pts
+    const peakBonus = isPeak ? 20 : 0;
+    const ageHours = Math.max(
+      0,
+      (now - new Date(draft.createdAt).getTime()) / 36e5
+    );
+    const recencyBonus = Math.max(0, 15 - ageHours * 0.5);
+    const timeliness = Math.min(35, peakBonus + recencyBonus);
+
+    // Performance: normalized engagement vs batch max -> 0-30 pts
+    const engagement = draft.actualEngagement ?? draft.predictedEngagement ?? 0;
+    const performance = Math.min(30, (engagement / maxEngagement) * 30);
+
+    const total = voiceFit + timeliness + performance;
+
+    return {
+      ...draft,
+      _score: total / 100,
+      _rankScore: total,
+      _rankBreakdown: {
+        voiceFit,
+        timeliness,
+        performance,
+      },
+    };
+  });
+}
+
+export function rankQueue(drafts: QueuedDraft[]): RankedDraft[] {
+  const ranked = computeQueueRank(drafts);
+  return ranked.sort((a, b) => b._rankScore - a._rankScore);
+}

--- a/src/lib/reference-accounts.ts
+++ b/src/lib/reference-accounts.ts
@@ -1,4 +1,5 @@
 import type { BlendVoiceInput, ReferenceAccount, ReferenceVoice } from "@/lib/api";
+import { getTwitterAvatarUrl } from "@/lib/public-urls";
 
 export type ReferenceAccountCategory =
   | "Crypto/VC"
@@ -46,70 +47,70 @@ export const REFERENCE_ACCOUNT_FALLBACK: ReferenceAccount[] = [
     handle: "hosseeb",
     displayName: "Haseeb Qureshi",
     category: "Crypto/VC",
-    profileImageUrl: "https://unavatar.io/twitter/hosseeb",
+    profileImageUrl: getTwitterAvatarUrl("hosseeb"),
   },
   {
     id: "DefiIgnas",
     handle: "DefiIgnas",
     displayName: "Ignas",
     category: "DeFi",
-    profileImageUrl: "https://unavatar.io/twitter/DefiIgnas",
+    profileImageUrl: getTwitterAvatarUrl("DefiIgnas"),
   },
   {
     id: "goodalexander",
     handle: "goodalexander",
     displayName: "Alex Good",
     category: "Macro",
-    profileImageUrl: "https://unavatar.io/twitter/goodalexander",
+    profileImageUrl: getTwitterAvatarUrl("goodalexander"),
   },
   {
     id: "thedankoe",
     handle: "thedankoe",
     displayName: "Dan Koe",
     category: "Content",
-    profileImageUrl: "https://unavatar.io/twitter/thedankoe",
+    profileImageUrl: getTwitterAvatarUrl("thedankoe"),
   },
   {
     id: "thiccyth0t",
     handle: "thiccyth0t",
     displayName: "thiccyth0t",
     category: "Culture",
-    profileImageUrl: "https://unavatar.io/twitter/thiccyth0t",
+    profileImageUrl: getTwitterAvatarUrl("thiccyth0t"),
   },
   {
     id: "ThinkingUSD",
     handle: "ThinkingUSD",
     displayName: "ThinkingUSD",
     category: "Macro",
-    profileImageUrl: "https://unavatar.io/twitter/ThinkingUSD",
+    profileImageUrl: getTwitterAvatarUrl("ThinkingUSD"),
   },
   {
     id: "JasonYanowitz",
     handle: "JasonYanowitz",
     displayName: "Jason Yanowitz",
     category: "Crypto/VC",
-    profileImageUrl: "https://unavatar.io/twitter/JasonYanowitz",
+    profileImageUrl: getTwitterAvatarUrl("JasonYanowitz"),
   },
   {
     id: "balaboris",
     handle: "balaboris",
     displayName: "Balaji",
     category: "Tech",
-    profileImageUrl: "https://unavatar.io/twitter/balaboris",
+    profileImageUrl: getTwitterAvatarUrl("balaboris"),
   },
   {
     id: "naval",
     handle: "naval",
     displayName: "Naval",
     category: "Philosophy",
-    profileImageUrl: "https://unavatar.io/twitter/naval",
+    profileImageUrl: getTwitterAvatarUrl("naval"),
   },
   {
     id: "elonmusk",
     handle: "elonmusk",
     displayName: "Elon Musk",
     category: "Culture",
-    profileImageUrl: "https://unavatar.io/twitter/elonmusk",
+    profileImageUrl: getTwitterAvatarUrl("elonmusk"),
   },
 ];
 
@@ -162,7 +163,7 @@ export function normalizeReferenceAccount(
   const profileImageUrl =
     account.profileImageUrl ??
     account.avatarUrl ??
-    (handle ? `https://unavatar.io/twitter/${handle}` : null);
+    getTwitterAvatarUrl(handle);
 
   return {
     id: resolvedId,

--- a/src/lib/voice-avatar.ts
+++ b/src/lib/voice-avatar.ts
@@ -1,4 +1,5 @@
 import type { BlendVoice } from "@/lib/api";
+import { getTwitterAvatarUrl } from "@/lib/public-urls";
 
 export interface MinimalUser {
   handle?: string | null;
@@ -37,12 +38,12 @@ export function resolveVoiceAvatar(
 ): string {
   if (isSelfVoice(voice)) {
     if (user?.avatarUrl) return user.avatarUrl;
-    if (user?.handle) return `https://unavatar.io/twitter/${user.handle.replace(/^@/, "")}`;
+    if (user?.handle) return getTwitterAvatarUrl(user.handle) ?? "";
     return "";
   }
   if (voice.referenceVoice?.avatarUrl) return voice.referenceVoice.avatarUrl;
   if (voice.referenceVoice?.handle) {
-    return `https://unavatar.io/twitter/${voice.referenceVoice.handle.replace(/^@/, "")}`;
+    return getTwitterAvatarUrl(voice.referenceVoice.handle) ?? "";
   }
   return "";
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { publicOrigins } from "@/lib/public-urls";
 
 // Public routes that don't require authentication
 const PUBLIC_PATHS = new Set(["/", "/auth/x/callback", "/auth/callback", "/onboarding"]);
@@ -59,9 +60,36 @@ export function middleware(request: NextRequest) {
   // - connect-src: allow self + Railway backend API
   // - font-src: allow self + Google Fonts (Playfair Display, Inter)
   // - frame-ancestors 'none': same as X-Frame-Options DENY but for modern browsers
-  const apiOrigin = process.env.NEXT_PUBLIC_API_URL
-    ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
-    : "";
+  const styleSrc = [
+    "style-src 'self' 'unsafe-inline'",
+    publicOrigins.googleFontsStylesOrigin,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const imgSrc = [
+    "img-src 'self' data: blob:",
+    publicOrigins.xImageCdnOrigin,
+    publicOrigins.unavatarOrigin,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const connectSrc = [
+    "connect-src 'self'",
+    publicOrigins.apiOrigin,
+    publicOrigins.supabaseOrigin,
+    "wss:",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const fontSrc = [
+    "font-src 'self'",
+    publicOrigins.googleFontsAssetsOrigin,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   // TODO(H-2): Migrate script-src off 'unsafe-inline' by adopting per-request
   // nonces for Next.js App Router hydration scripts (see follow-up ticket
@@ -72,10 +100,10 @@ export function middleware(request: NextRequest) {
     [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "img-src 'self' data: blob: https://pbs.twimg.com https://unavatar.io",
-      `connect-src 'self' ${apiOrigin} https://zoirudjyqfqvpxsrxepr.supabase.co wss:`,
-      "font-src 'self' https://fonts.gstatic.com",
+      styleSrc,
+      imgSrc,
+      connectSrc,
+      fontSrc,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
## Summary
- replace hardcoded app, API, Supabase, avatar, X, Telegram, demo, and CSP URLs in `src/` with `NEXT_PUBLIC_*`-backed helpers
- add `src/lib/public-urls.ts` to centralize public URL assembly and origin derivation
- document the new public URL variables in `.env.example`

## Verification
- `npm run lint`
- `set -a && source .env.example && set +a && npm run build`
- `npm test -- --runInBand src/__tests__/lib/env.test.ts`

## Notes
- lint still reports two pre-existing hook warnings in `src/app/arena/page.tsx` and `src/components/onboarding/OracleChat.tsx`
- build still reports the existing Prisma/OpenTelemetry critical dependency warning from Sentry/Prisma instrumentation