### PR TITLE
[codex] add health check endpoints

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,7 @@ const nextConfig = {
     return [
       {
         source: "/api/:path*",
-        destination: "https://api-production-9bef.up.railway.app/api/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/:path*`,
       },
     ];
   },

--- a/src/__tests__/app/AnalyticsPage.test.tsx
+++ b/src/__tests__/app/AnalyticsPage.test.tsx
@@ -63,10 +63,10 @@ describe("AnalyticsPage", () => {
     render(<AnalyticsPage />);
 
     expect(
-      await screen.findByRole("heading", { name: "No analytics data yet" })
+      await screen.findByRole("heading", { name: "Nothing here yet" })
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Start crafting drafts to see your analytics here.")
+      screen.getByText("Craft your first draft and the numbers will start rolling in.")
     ).toBeInTheDocument();
   });
 

--- a/src/__tests__/app/DashboardPage.test.tsx
+++ b/src/__tests__/app/DashboardPage.test.tsx
@@ -207,7 +207,7 @@ describe("DashboardPage", () => {
       await screen.findByRole("heading", { name: "Ready to craft your first draft?" })
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Get started by crafting your first draft")
+      screen.getByText(/Atlas helps you write tweets that sound like you/)
     ).toBeInTheDocument();
 
     fireEvent.click(

--- a/src/__tests__/app/api/health-routes.test.ts
+++ b/src/__tests__/app/api/health-routes.test.ts
@@ -1,0 +1,177 @@
+/** @jest-environment node */
+
+describe("/api/health", () => {
+  function loadHealthRoute() {
+    let routeModule: typeof import("@/app/api/health/route") | undefined;
+
+    jest.isolateModules(() => {
+      routeModule = require("@/app/api/health/route") as typeof import("@/app/api/health/route");
+    });
+
+    return routeModule!;
+  }
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns a non-cached liveness payload on GET", async () => {
+    const { GET } = loadHealthRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(body).toEqual(
+      expect.objectContaining({
+        service: "atlas-portal",
+        status: "ok",
+      }),
+    );
+    expect(typeof body.timestamp).toBe("string");
+    expect(typeof body.uptimeSeconds).toBe("number");
+  });
+
+  it("returns HEAD with the same healthy status and no body", async () => {
+    const { HEAD } = loadHealthRoute();
+
+    const response = await HEAD();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("");
+  });
+});
+
+describe("/api/ready", () => {
+  const envRef = process.env as Record<string, string | undefined>;
+  const originalApiUrl = envRef.NEXT_PUBLIC_API_URL;
+
+  function loadReadyRoute() {
+    let routeModule: typeof import("@/app/api/ready/route") | undefined;
+
+    jest.isolateModules(() => {
+      routeModule = require("@/app/api/ready/route") as typeof import("@/app/api/ready/route");
+    });
+
+    return routeModule!;
+  }
+
+  afterEach(() => {
+    if (originalApiUrl === undefined) {
+      delete envRef.NEXT_PUBLIC_API_URL;
+    } else {
+      envRef.NEXT_PUBLIC_API_URL = originalApiUrl;
+    }
+
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  it("returns 200 when the backend health check succeeds", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        status: "ok",
+        database: "ok",
+      }),
+    }) as jest.Mock;
+
+    const { GET } = loadReadyRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:3001/health",
+      expect.objectContaining({
+        method: "GET",
+        cache: "no-store",
+      }),
+    );
+    expect(body).toEqual(
+      expect.objectContaining({
+        service: "atlas-portal",
+        status: "ok",
+        checks: expect.objectContaining({
+          app: { status: "ok" },
+          backend: expect.objectContaining({
+            status: "ok",
+            httpStatus: 200,
+            details: expect.objectContaining({
+              status: "ok",
+              database: "ok",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns 503 when NEXT_PUBLIC_API_URL is missing", async () => {
+    delete envRef.NEXT_PUBLIC_API_URL;
+    global.fetch = jest.fn() as jest.Mock;
+
+    const { GET } = loadReadyRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(body).toEqual(
+      expect.objectContaining({
+        status: "error",
+        checks: expect.objectContaining({
+          backend: expect.objectContaining({
+            status: "error",
+            error: "NEXT_PUBLIC_API_URL is not configured",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns 503 when the backend health check fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("connect ECONNREFUSED")) as jest.Mock;
+
+    const { GET } = loadReadyRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual(
+      expect.objectContaining({
+        status: "error",
+        checks: expect.objectContaining({
+          backend: expect.objectContaining({
+            status: "error",
+            error: "connect ECONNREFUSED",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns HEAD with the readiness status code and no body", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: jest.fn().mockResolvedValue({
+        status: "error",
+      }),
+    }) as jest.Mock;
+
+    const { HEAD } = loadReadyRoute();
+
+    const response = await HEAD();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("");
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,15 @@
+import {
+  createHeadResponse,
+  createJsonResponse,
+  getLivenessPayload,
+} from "@/lib/health";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return createJsonResponse(getLivenessPayload());
+}
+
+export async function HEAD() {
+  return createHeadResponse();
+}

--- a/src/app/api/ready/route.ts
+++ b/src/app/api/ready/route.ts
@@ -1,0 +1,17 @@
+import {
+  createHeadResponse,
+  createJsonResponse,
+  getReadinessPayload,
+} from "@/lib/health";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const { payload, httpStatus } = await getReadinessPayload();
+  return createJsonResponse(payload, httpStatus);
+}
+
+export async function HEAD() {
+  const { httpStatus } = await getReadinessPayload();
+  return createHeadResponse(httpStatus);
+}

--- a/src/app/arena/page.tsx
+++ b/src/app/arena/page.tsx
@@ -261,7 +261,7 @@ function ArenaPage() {
     <AppShell>
       <div className="mx-auto max-w-5xl px-4 py-8 space-y-8">
         {/* Header */}
-        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <Trophy className="h-6 w-6 text-yellow-400" />
             <h1 className="font-heading font-extrabold tracking-tight text-2xl text-atlas-text">

--- a/src/app/briefing/layout.tsx
+++ b/src/app/briefing/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import AppShell from "@/components/layout/AppShell";
 
 export const metadata: Metadata = {
   title: "Briefing",
@@ -10,5 +9,5 @@ export default function BriefingLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <AppShell>{children}</AppShell>;
+  return <>{children}</>;
 }

--- a/src/app/briefing/page.tsx
+++ b/src/app/briefing/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { Loader2, Settings, RefreshCw, Clock, ChevronDown, ChevronUp, PenTool, Sparkles } from "lucide-react";
 import GlassCard from "@/components/ui/GlassCard";
 import GradientButton from "@/components/ui/GradientButton";
-import AppShell from "@/components/layout/AppShell";
 import FeatureGate from "@/components/ui/FeatureGate";
 import { useRouter } from "next/navigation";
 import { api, Briefing, BriefingSection } from "@/lib/api";
@@ -37,21 +36,33 @@ const chipClasses = (selected: boolean) =>
       : "border-glass-border bg-atlas-surface text-atlas-text-secondary hover:border-atlas-teal/50 hover:text-atlas-text"
   }`;
 
-function BriefingCard({ briefing, expanded, onToggle, onCraft }: { briefing: Briefing; expanded: boolean; onToggle: () => void; onCraft: () => void }) {
+function BriefingCard({ briefing, expanded, onToggle, onCraft, isLatest }: { briefing: Briefing; expanded: boolean; onToggle: () => void; onCraft: () => void; isLatest?: boolean }) {
   const date = new Date(briefing.createdAt);
   const timeAgo = getTimeAgo(date);
 
   return (
-    <GlassCard maxWidth="full" className="space-y-4">
+    <GlassCard maxWidth="full" className={`space-y-4 ${isLatest ? "border-l-2 border-l-atlas-teal bg-gradient-to-r from-atlas-teal/[0.03] to-transparent" : ""}`}>
       <button type="button" onClick={onToggle} className="flex w-full items-start justify-between text-left">
         <div className="space-y-1">
           <h2 className="font-heading font-bold tracking-tight text-xl text-atlas-text sm:text-2xl">
             {briefing.title}
           </h2>
-          <p className="flex items-center gap-2 text-xs text-atlas-text-muted">
-            <Clock className="h-3 w-3" />
-            {timeAgo}
-          </p>
+          <div className="flex items-center gap-3 text-xs text-atlas-text-muted">
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {timeAgo}
+            </span>
+            {!expanded && (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onCraft(); }}
+                className="flex items-center gap-1 rounded-md bg-atlas-teal/10 px-2 py-0.5 text-[11px] font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/20"
+              >
+                <PenTool className="h-3 w-3" />
+                Craft
+              </button>
+            )}
+          </div>
         </div>
         {expanded ? (
           <ChevronUp className="mt-1 h-5 w-5 shrink-0 text-atlas-text-muted" />
@@ -178,18 +189,15 @@ function BriefingPage() {
 
   if (loading) {
     return (
-      <AppShell>
-        <div className="flex min-h-[60vh] items-center justify-center">
-          <Loader2 className="h-6 w-6 animate-spin text-atlas-teal" />
-        </div>
-      </AppShell>
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-atlas-teal" />
+      </div>
     );
   }
 
   if (!hasPreferences) {
     return (
-      <AppShell>
-        <div className="mx-auto max-w-3xl py-8 space-y-6">
+      <div className="mx-auto max-w-3xl py-8 space-y-6">
           <header className="space-y-3" data-tour="briefing-header">
             <div className="flex items-center gap-2">
               <p className="text-sm font-semibold uppercase tracking-[0.24em] text-atlas-teal">Morning Briefing</p>
@@ -214,14 +222,12 @@ function BriefingPage() {
             onDeliveryTimeChange={(t) => { setSaved(false); setDeliveryTime(t); }}
             onSave={handleSavePreferences}
           />
-        </div>
-      </AppShell>
+      </div>
     );
   }
 
   return (
-    <AppShell>
-      <div className="mx-auto max-w-3xl py-8 space-y-6">
+    <div className="mx-auto max-w-3xl py-8 space-y-6">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between" data-tour="briefing-header">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
@@ -232,6 +238,11 @@ function BriefingPage() {
             </div>
             <h1 className="font-heading font-extrabold tracking-tight text-3xl text-atlas-text sm:text-4xl">
               Your Briefings
+              {briefings.length === 0 && (
+                <span className="ml-2 inline-flex items-center gap-1 align-middle rounded-full bg-atlas-teal/10 px-2.5 py-0.5 text-[10px] font-semibold text-atlas-teal ring-1 ring-atlas-teal/20">
+                  <Sparkles className="h-3 w-3" /> NEW
+                </span>
+              )}
             </h1>
             <p className="max-w-xl text-sm leading-relaxed text-atlas-text-secondary">
               A quick daily read built from your topics and the latest market moves. Hit Generate Now or schedule them to land automatically.
@@ -284,19 +295,24 @@ function BriefingPage() {
         )}
 
         {briefings.length === 0 ? (
-          <GlassCard maxWidth="full" className="py-16 text-center space-y-3">
-            <p className="font-heading text-lg font-semibold text-atlas-text">No briefings yet</p>
+          <GlassCard maxWidth="full" className="py-16 text-center space-y-4" data-tour="briefing-empty">
+            <Sparkles className="mx-auto h-10 w-10 text-atlas-teal/60" />
+            <p className="font-heading text-lg font-semibold text-atlas-text">Your briefing is ready to generate</p>
             <p className="mx-auto max-w-md text-sm leading-relaxed text-atlas-text-secondary">
-              Hit <strong className="text-atlas-text">Generate Now</strong> above to create your first briefing. Atlas will pull the latest signals from your selected topics and sources, then summarize them into a quick-read digest tailored to your interests.
+              Your personalized briefing is ready to generate. Atlas will pull the latest signals from your topics, analyze sentiment, and surface what matters most &mdash; all in under 2 minutes.
+            </p>
+            <p className="text-xs text-atlas-text-muted">
+              Hit <strong className="text-atlas-text">Generate Now</strong> above to get started.
             </p>
           </GlassCard>
         ) : (
           <div className="space-y-4">
-            {briefings.map((b) => (
+            {briefings.map((b, i) => (
               <BriefingCard
                 key={b.id}
                 briefing={b}
                 expanded={expandedId === b.id}
+                isLatest={i === 0}
                 onToggle={() => setExpandedId(expandedId === b.id ? null : b.id)}
                 onCraft={() => {
                   const content = b.summary + "\n\n" + (b.sections as BriefingSection[]).map((s) => s.emoji + " " + s.heading + "\n" + s.bullets.join("\n")).join("\n\n");
@@ -306,8 +322,7 @@ function BriefingPage() {
             ))}
           </div>
         )}
-      </div>
-    </AppShell>
+    </div>
   );
 }
 

--- a/src/app/campaigns/wizard/page.tsx
+++ b/src/app/campaigns/wizard/page.tsx
@@ -46,7 +46,7 @@ const ANGLE_COLORS: Record<string, string> = {
   explainer: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
 };
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://api-production-9bef.up.railway.app";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export default function CampaignWizardPage() {
   const { user } = useAuth();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -381,23 +381,27 @@ const searchParams = useSearchParams();
       </div>
 
       {isEnabled("briefing") && (
-      <Link
-        href="/briefing"
-        className="mt-8 flex items-center justify-between rounded-2xl border border-atlas-teal/20 bg-gradient-to-r from-atlas-teal/5 to-transparent p-5 ring-1 ring-atlas-teal/10 transition-all hover:ring-atlas-teal/30 hover:shadow-lg hover:shadow-atlas-teal/5"
+      <div
+        data-tour="dashboard-brief-promo"
+        className="mt-8 rounded-2xl border border-atlas-teal/20 border-l-2 border-l-atlas-teal bg-gradient-to-r from-atlas-teal/5 to-transparent p-6 ring-1 ring-atlas-teal/10 transition-all hover:ring-atlas-teal/30 hover:shadow-lg hover:shadow-atlas-teal/5"
       >
-        <div className="flex items-center gap-4">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-atlas-teal/10">
-            <Sparkles className="h-5 w-5 text-atlas-teal" />
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-atlas-teal/10">
+              <Sparkles className="h-6 w-6 text-atlas-teal" />
+            </div>
+            <div>
+              <p className="text-base font-semibold text-atlas-text">Morning Brief</p>
+              <p className="mt-0.5 text-sm text-atlas-text-secondary">Get your personalized morning digest &mdash; AI-powered signals and tweet ideas</p>
+            </div>
           </div>
-          <div>
-            <p className="text-sm font-semibold text-atlas-text">Brief: AI-powered tweet ideas</p>
-            <p className="text-xs text-atlas-text-secondary">Pick sources, get tweet angles instantly. Zero thinking required.</p>
-          </div>
+          <GradientButton size="sm" onClick={() => router.push("/briefing")}>
+            <span className="flex items-center gap-1.5">
+              Try Brief <ArrowRight className="h-3.5 w-3.5" />
+            </span>
+          </GradientButton>
         </div>
-        <div className="flex items-center gap-1 text-xs font-medium text-atlas-teal">
-          Try Brief <ArrowRight className="h-3.5 w-3.5" />
-        </div>
-      </Link>
+      </div>
       )}
 
       <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,7 @@
   }
   input[type="range"]::-webkit-slider-thumb {
     @apply appearance-none w-5 h-5 rounded-full bg-atlas-teal shadow-lg;
+    margin-top: -6px;
     box-shadow: 0 0 8px rgba(78, 205, 196, 0.5), 0 0 2px rgba(78, 205, 196, 0.8);
   }
   input[type="range"]::-moz-range-thumb {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function LoginPage() {
 
   const handleContinueWithX = () => {
     const apiUrl =
-      process.env.NEXT_PUBLIC_API_URL ?? "https://api-production-9bef.up.railway.app";
+      process.env.NEXT_PUBLIC_API_URL ?? "";
     window.location.href = `${apiUrl}/api/auth/x/login`;
   };
 

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,6 +1,7 @@
-"use client";
-
 import AppShell from "@/components/layout/AppShell";
+
+export const dynamic = "force-static";
+export const revalidate = 86400;
 
 type Category = "crafting" | "voice" | "analytics" | "platform" | "integrations";
 type Status = "shipped" | "in-progress" | "planned";

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Plus, Sparkles, Wand2 } from "lucide-react";
+import { Check, Loader2, Plus, Sparkles, Wand2, X } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
 import TweetTinderSection from "./tweet-tinder-section";
 import ReferenceVoicesSection from "@/components/voice-profiles/ReferenceVoicesSection";
@@ -129,6 +129,13 @@ export default function VoiceProfilesPage() {
     Array<{ id: string; label: string; text: string | null; error: string | null }>
   >([]);
   const [compareAllLoading, setCompareAllLoading] = useState(false);
+  const [compareVsMineBlendId, setCompareVsMineBlendId] = useState<string | null>(null);
+  const [compareVsMineResults, setCompareVsMineResults] = useState<{
+    personal: { text: string | null; error: string | null };
+    blend: { text: string | null; error: string | null; label: string };
+  } | null>(null);
+  const [compareVsMineLoading, setCompareVsMineLoading] = useState(false);
+  const comparisonSectionRef = useRef<HTMLDivElement>(null);
   const [calibrateHandle, setCalibrateHandle] = useState("");
   const [blendSelectMode, setBlendSelectMode] = useState(false);
   const [blendSourceId, setBlendSourceId] = useState<string | null>(null);
@@ -349,6 +356,70 @@ export default function VoiceProfilesPage() {
     );
     setCompareAllLoading(false);
   }, [blends, compareAllLoading, compareAllTopic]);
+
+  const handleCompareVsMine = useCallback(
+    async (blendId: string) => {
+      if (compareVsMineLoading) return;
+      const blend = blends.find((b) => b.id === blendId);
+      if (!blend) return;
+
+      setCompareVsMineBlendId(blendId);
+      setCompareVsMineLoading(true);
+      setCompareVsMineResults(null);
+
+      const topic =
+        compareAllTopic.trim() ||
+        "Bitcoin just reclaimed $100k after a brutal 3-week drawdown.";
+
+      const [personalResult, blendResult] = await Promise.allSettled([
+        api.drafts.generate({
+          sourceContent: topic,
+          sourceType: "MANUAL",
+        }),
+        api.drafts.generate({
+          sourceContent: topic,
+          sourceType: "MANUAL",
+          blendId,
+        }),
+      ]);
+
+      setCompareVsMineResults({
+        personal: {
+          text:
+            personalResult.status === "fulfilled"
+              ? personalResult.value.draft.content
+              : null,
+          error:
+            personalResult.status === "rejected"
+              ? personalResult.reason instanceof Error
+                ? personalResult.reason.message
+                : "Generation failed"
+              : null,
+        },
+        blend: {
+          text:
+            blendResult.status === "fulfilled"
+              ? blendResult.value.draft.content
+              : null,
+          error:
+            blendResult.status === "rejected"
+              ? blendResult.reason instanceof Error
+                ? blendResult.reason.message
+                : "Generation failed"
+              : null,
+          label: blend.name,
+        },
+      });
+
+      setCompareVsMineLoading(false);
+
+      // Scroll the comparison section into view after results render
+      setTimeout(() => {
+        comparisonSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+      }, 100);
+    },
+    [blends, compareAllTopic, compareVsMineLoading]
+  );
 
   const handleUseVoice = (voiceId: string) => {
     setActiveVoiceId(voiceId);
@@ -757,6 +828,9 @@ export default function VoiceProfilesPage() {
                   notableDimensions={notableDimensions}
                   isActive={activeVoiceId === blend.id}
                   userHandle={user?.handle}
+                  onCompareVsMine={() =>
+                    void handleCompareVsMine(blend.id)
+                  }
                   onUse={() => handleUseVoice(blend.id)}
                   onPreviewSample={() =>
                     void handlePreviewBlend(blend, dimensions)
@@ -799,7 +873,7 @@ export default function VoiceProfilesPage() {
         </section>
         </div>{/* end blends wrapper */}
 
-        <section className="mt-10 scroll-mt-20 rounded-2xl border border-glass-border bg-atlas-surface/40 p-6">
+        <section ref={comparisonSectionRef} className="mt-10 scroll-mt-20 rounded-2xl border border-glass-border bg-atlas-surface/40 p-6">
           <div>
             <p className="text-sm font-medium uppercase tracking-[0.2em] text-atlas-teal">
               Voice Comparison
@@ -835,10 +909,7 @@ export default function VoiceProfilesPage() {
               >
                 {compareAllLoading ? (
                   <>
-                    <span
-                      className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
-                      aria-hidden="true"
-                    />
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
                     Generating…
                   </>
                 ) : (
@@ -851,6 +922,95 @@ export default function VoiceProfilesPage() {
             </div>
           </div>
 
+          {/* Compare vs Mine — focused 2-column comparison */}
+          {(compareVsMineLoading || compareVsMineResults) && (
+            <div className="mt-6 rounded-2xl border border-atlas-teal/20 bg-atlas-teal/5 p-5">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-atlas-text">
+                  Comparing:{" "}
+                  <span className="text-atlas-text-secondary">
+                    Personal Voice vs.{" "}
+                    {compareVsMineResults?.blend.label ??
+                      blends.find((b) => b.id === compareVsMineBlendId)?.name ??
+                      "Blend"}
+                  </span>
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCompareVsMineResults(null);
+                    setCompareVsMineBlendId(null);
+                    setCompareVsMineLoading(false);
+                  }}
+                  aria-label="Dismiss comparison"
+                  className="rounded-lg p-1 text-atlas-text-muted transition-colors hover:bg-atlas-surface/60 hover:text-atlas-text"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {compareVsMineLoading ? (
+                <div className="mt-4 flex items-center justify-center gap-2 py-8 text-sm text-atlas-text-muted">
+                  <Loader2 className="h-4 w-4 animate-spin text-atlas-teal" />
+                  Generating comparison...
+                </div>
+              ) : compareVsMineResults ? (
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {/* Personal Voice column */}
+                  <div
+                    className="rounded-2xl border border-glass-border bg-atlas-surface/60 p-4"
+                    aria-label="Personal voice result"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-wider text-atlas-text-muted">
+                      Personal Voice
+                    </p>
+                    {compareVsMineResults.personal.error ? (
+                      <p className="mt-3 text-xs text-atlas-error">
+                        {compareVsMineResults.personal.error}
+                      </p>
+                    ) : compareVsMineResults.personal.text ? (
+                      <p className="mt-3 text-sm leading-6 text-atlas-text">
+                        {compareVsMineResults.personal.text}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  {/* Blend column */}
+                  <div
+                    className="rounded-2xl border border-atlas-teal/30 bg-atlas-surface/60 p-4"
+                    aria-label={`${compareVsMineResults.blend.label} result`}
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-wider text-atlas-teal">
+                      {compareVsMineResults.blend.label}
+                    </p>
+                    {compareVsMineResults.blend.error ? (
+                      <p className="mt-3 text-xs text-atlas-error">
+                        {compareVsMineResults.blend.error}
+                      </p>
+                    ) : compareVsMineResults.blend.text ? (
+                      <>
+                        <p className="mt-3 text-sm leading-6 text-atlas-text">
+                          {compareVsMineResults.blend.text}
+                        </p>
+                        {compareVsMineBlendId && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleUseVoice(compareVsMineBlendId)
+                            }
+                            className="mt-3 text-xs font-medium text-atlas-teal hover:underline"
+                          >
+                            Use this voice →
+                          </button>
+                        )}
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+
           {compareAllResults.length > 0 && (
             <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {compareAllResults.map((result) => {
@@ -859,13 +1019,14 @@ export default function VoiceProfilesPage() {
                 return (
                   <div
                     key={result.id}
-                    className={`rounded-xl border p-4 transition-colors ${
+                    className={`rounded-2xl border p-4 transition-colors ${
                       isPersonal
                         ? "border-glass-border bg-atlas-surface/70"
                         : isActive
                         ? "border-atlas-teal/40 bg-atlas-teal/5"
                         : "border-glass-border bg-atlas-surface/50"
                     }`}
+                    aria-label={`${result.label} comparison result`}
                   >
                     <div className="flex items-center justify-between">
                       <p
@@ -886,10 +1047,8 @@ export default function VoiceProfilesPage() {
                       )}
                     </div>
                     {result.text === null && result.error === null ? (
-                      <div className="mt-3 space-y-2" aria-busy="true" aria-label="Generating tweet">
-                        <div className="h-3 w-full animate-pulse rounded bg-atlas-surface" />
-                        <div className="h-3 w-4/5 animate-pulse rounded bg-atlas-surface" />
-                        <div className="h-3 w-3/5 animate-pulse rounded bg-atlas-surface" />
+                      <div className="mt-3 flex items-center justify-center py-4" aria-busy="true" aria-label="Generating tweet">
+                        <Loader2 className="h-4 w-4 animate-spin text-atlas-teal" />
                       </div>
                     ) : result.error ? (
                       <p className="mt-3 text-xs text-atlas-error">{result.error}</p>
@@ -897,6 +1056,12 @@ export default function VoiceProfilesPage() {
                       <p className="mt-3 text-sm leading-6 text-atlas-text">
                         {result.text}
                       </p>
+                    )}
+                    {result.text && isPersonal && activeVoiceId === PERSONAL_VOICE_ID && (
+                      <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-atlas-teal">
+                        <Check className="h-3 w-3" />
+                        Active
+                      </span>
                     )}
                     {result.text && !isPersonal && (
                       <button

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,7 +14,7 @@ import { gradients } from "@/lib/tokens";
 // of the first paint and into a separate chunk fetched after hydration.
 const FloatingOracle = dynamic(
   () => import("@/components/oracle/FloatingOracle"),
-  { ssr: false },
+  { ssr: false, loading: () => null },
 );
 
 export interface AppShellProps {

--- a/src/components/onboarding/BlendRatioSlider.tsx
+++ b/src/components/onboarding/BlendRatioSlider.tsx
@@ -208,6 +208,8 @@ function RefAvatar({ handle, name }: { handle?: string; name: string }) {
     <img
       src={`https://unavatar.io/twitter/${cleanHandle}`}
       alt={name}
+      width={32}
+      height={32}
       onError={() => setErrored(true)}
       className="h-8 w-8 shrink-0 rounded-full object-cover border border-atlas-text-secondary/20 bg-atlas-surface"
     />

--- a/src/components/onboarding/ReferenceVoiceSelector.tsx
+++ b/src/components/onboarding/ReferenceVoiceSelector.tsx
@@ -209,6 +209,8 @@ export default function ReferenceVoiceSelector({
                   <img
                     src={avatarUrl}
                     alt={`${label} avatar`}
+                    width={64}
+                    height={64}
                     className="mx-auto h-16 w-16 rounded-full object-cover"
                     onError={() => setImgErrors((prev) => new Set(prev).add(account.id))}
                   />

--- a/src/components/oracle/FloatingOracle.tsx
+++ b/src/components/oracle/FloatingOracle.tsx
@@ -157,7 +157,7 @@ export default function FloatingOracle() {
           role="dialog"
           aria-modal="false"
           aria-labelledby={`${panelTitleId}-heading`}
-          className="fixed bottom-6 right-6 z-50 flex w-[360px] max-h-[520px] flex-col rounded-2xl border border-glass-border bg-atlas-nav shadow-2xl shadow-black/40"
+          className="fixed bottom-6 right-6 z-50 flex w-[calc(100vw-2rem)] max-w-[360px] max-h-[520px] flex-col rounded-2xl border border-glass-border bg-atlas-nav shadow-2xl shadow-black/40"
         >
           {/* Header */}
           <div className="flex items-center gap-3 border-b border-glass-border px-4 py-3">

--- a/src/components/tweet-tinder/TweetCard.tsx
+++ b/src/components/tweet-tinder/TweetCard.tsx
@@ -106,9 +106,12 @@ export default function TweetCard({ tweet, onSwipe, isTop, stackIndex }: TweetCa
             {/* Author row */}
             <div className="flex items-center gap-3">
               {tweet.author_avatar ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
                 <img
                   src={tweet.author_avatar}
                   alt={tweet.author_handle}
+                  width={32}
+                  height={32}
                   className="h-8 w-8 rounded-full object-cover"
                 />
               ) : (

--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -60,7 +60,7 @@ export default function DimensionBar({
               [&::-webkit-slider-thumb]:border-atlas-bg
               [&::-webkit-slider-thumb]:bg-atlas-teal
               [&::-webkit-slider-thumb]:shadow-md
-              [&::-webkit-slider-thumb]:transition-all
+              [&::-webkit-slider-thumb]:transition-shadow
               [&::-webkit-slider-thumb]:duration-200
               [&::-moz-range-thumb]:h-4
               [&::-moz-range-thumb]:w-4
@@ -70,14 +70,9 @@ export default function DimensionBar({
               [&::-moz-range-thumb]:border-atlas-bg
               [&::-moz-range-thumb]:bg-atlas-teal
               [&::-moz-range-thumb]:shadow-md
-              [&::-moz-range-thumb]:transition-all
+              [&::-moz-range-thumb]:transition-shadow
               [&::-moz-range-thumb]:duration-200
-              hover:[&::-webkit-slider-thumb]:mt-[-8px]
-              hover:[&::-webkit-slider-thumb]:h-5
-              hover:[&::-webkit-slider-thumb]:w-5
               hover:[&::-webkit-slider-thumb]:shadow-[0_0_8px_rgba(78,205,196,0.5)]
-              hover:[&::-moz-range-thumb]:h-5
-              hover:[&::-moz-range-thumb]:w-5
               hover:[&::-moz-range-thumb]:shadow-[0_0_8px_rgba(78,205,196,0.5)]"
           />
         ) : (

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -241,6 +241,8 @@ export default function NavBar({ variant }: NavBarProps) {
                   <img
                     src={user.avatarUrl}
                     alt={`${user.displayName || user.handle} avatar`}
+                    width={32}
+                    height={32}
                     className="h-full w-full rounded-full object-cover"
                   />
                 ) : (

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion, useCycle } from "framer-motion";
 import {
+  ArrowLeftRight,
   ChevronDown,
   ChevronUp,
   Loader2,
@@ -23,6 +24,7 @@ interface RecipeCardProps {
   fingerprintDescription: string;
   notableDimensions: VoiceDimensionSnapshot[];
   isActive: boolean;
+  onCompareVsMine?: () => void;
   onEdit?: () => void;
   onPreviewSample: () => void;
   onUse: () => void;
@@ -124,6 +126,7 @@ export default function RecipeCard({
   fingerprintDescription,
   notableDimensions,
   isActive,
+  onCompareVsMine,
   onEdit,
   onPreviewSample,
   onUse,
@@ -292,6 +295,16 @@ export default function RecipeCard({
           )}
           {isExpanded ? "Hide fingerprint" : "Show fingerprint"}
         </button>
+        {onCompareVsMine && (
+          <button
+            type="button"
+            onClick={onCompareVsMine}
+            className="inline-flex items-center gap-2 rounded-xl border border-glass-border bg-atlas-surface/50 px-4 py-2 text-sm font-semibold text-atlas-text-secondary transition-colors hover:border-atlas-teal/40 hover:text-atlas-text"
+          >
+            <ArrowLeftRight className="h-4 w-4" />
+            Compare vs mine
+          </button>
+        )}
         <button
           type="button"
           onClick={onPreviewSample}

--- a/src/components/voice-profiles/ReferenceVoicesSection.tsx
+++ b/src/components/voice-profiles/ReferenceVoicesSection.tsx
@@ -290,6 +290,8 @@ export default function ReferenceVoicesSection({
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
                       alt={`${account.displayName || account.name || account.handle} avatar`}
+                      width={48}
+                      height={48}
                       className="h-12 w-12 rounded-full border border-glass-border object-cover"
                       onError={() =>
                         setAvatarErrors((current) => ({

--- a/src/components/voice-profiles/VoiceLabInspirationPicker.tsx
+++ b/src/components/voice-profiles/VoiceLabInspirationPicker.tsx
@@ -460,6 +460,8 @@ export default function VoiceLabInspirationPicker({
                         <img
                           src={follow.avatarUrl}
                           alt={`${follow.displayName} avatar`}
+                          width={56}
+                          height={56}
                           className="h-14 w-14 rounded-full border border-glass-border object-cover"
                         />
                       ) : (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { getDemoResponse } from "./demo-data";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://api-production-9bef.up.railway.app";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 const MAX_RETRIES = 3;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -252,15 +252,15 @@ export function setDemoMode(on: boolean) {
 }
 
 // Token store — fallback when HttpOnly cookies don't reach cross-origin
-// Uses sessionStorage for persistence across client-side navigations
+// Uses localStorage so the token persists across tabs and page refreshes
 const TOKEN_KEY = "atlas_access_token";
-let _accessToken: string | null = typeof window !== "undefined" ? sessionStorage.getItem(TOKEN_KEY) : null;
+let _accessToken: string | null = typeof window !== "undefined" ? localStorage.getItem(TOKEN_KEY) : null;
 
 export function setAccessToken(token: string | null) {
   _accessToken = token;
   if (typeof window !== "undefined") {
-    if (token) sessionStorage.setItem(TOKEN_KEY, token);
-    else sessionStorage.removeItem(TOKEN_KEY);
+    if (token) localStorage.setItem(TOKEN_KEY, token);
+    else localStorage.removeItem(TOKEN_KEY);
   }
 }
 export function getAccessToken() { return _accessToken; }

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -45,7 +45,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const refreshRes = await api.auth.refresh();
           if (refreshRes.token) {
             setAccessToken(refreshRes.token);
-            document.cookie = "atlas_access_token=1; path=/; max-age=86400; SameSite=Lax; Secure";
           }
           const me = await api.auth.me();
           setUser(me.user);
@@ -79,7 +78,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const res = await api.auth.login(email, password);
     if (res.token) {
       setAccessToken(res.token);
-      document.cookie = "atlas_access_token=1; path=/; max-age=86400; SameSite=Lax; Secure";
     }
     const me = await api.auth.me();
     setUser(me.user);
@@ -90,7 +88,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const res = await api.auth.register(handle, email, password, onboardingTrack);
     if (res.token) {
       setAccessToken(res.token);
-      document.cookie = "atlas_access_token=1; path=/; max-age=86400; SameSite=Lax; Secure";
       const me = await api.auth.me();
       setUser(me.user);
       setSessionCookie(true);
@@ -104,7 +101,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Best-effort — clear local state regardless
     }
     setAccessToken(null);
-    document.cookie = "atlas_access_token=; path=/; max-age=0";
     setUser(null);
     setSessionCookie(false);
     // Hard redirect — prevents bfcache restoring stale protected pages after logout

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,210 @@
+const SERVICE_NAME = "atlas-portal";
+const READY_TIMEOUT_MS = 5000;
+
+type HealthState = "ok" | "error";
+
+type BackendHealthPayload = Record<string, unknown> & {
+  status?: string;
+};
+
+export type HealthResponsePayload = {
+  service: string;
+  status: HealthState;
+  timestamp: string;
+  environment: string;
+  version: string | null;
+  uptimeSeconds: number;
+};
+
+export type ReadinessResponsePayload = HealthResponsePayload & {
+  checks: {
+    app: {
+      status: "ok";
+    };
+    backend: {
+      status: HealthState;
+      url: string | null;
+      responseTimeMs?: number;
+      httpStatus?: number;
+      details?: BackendHealthPayload;
+      error?: string;
+    };
+  };
+};
+
+function getBasePayload(now = new Date()): HealthResponsePayload {
+  return {
+    service: SERVICE_NAME,
+    status: "ok",
+    timestamp: now.toISOString(),
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    version: process.env.npm_package_version ?? null,
+    uptimeSeconds: Math.round(process.uptime()),
+  };
+}
+
+function getResponseHeaders(): HeadersInit {
+  return {
+    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    Pragma: "no-cache",
+    Expires: "0",
+  };
+}
+
+export function createJsonResponse(payload: HealthResponsePayload | ReadinessResponsePayload, status = 200) {
+  return Response.json(payload, {
+    status,
+    headers: getResponseHeaders(),
+  });
+}
+
+export function createHeadResponse(status = 200) {
+  return new Response(null, {
+    status,
+    headers: getResponseHeaders(),
+  });
+}
+
+export function getLivenessPayload(): HealthResponsePayload {
+  return getBasePayload();
+}
+
+function createBackendErrorPayload(
+  base: HealthResponsePayload,
+  url: string | null,
+  error: string,
+  responseTimeMs?: number,
+  httpStatus?: number,
+): ReadinessResponsePayload {
+  return {
+    ...base,
+    status: "error",
+    checks: {
+      app: { status: "ok" },
+      backend: {
+        status: "error",
+        url,
+        responseTimeMs,
+        httpStatus,
+        error,
+      },
+    },
+  };
+}
+
+function getBackendHealthUrl() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (!apiUrl) {
+    return null;
+  }
+
+  const backendUrl = new URL("/health", apiUrl);
+  return backendUrl.toString();
+}
+
+export async function getReadinessPayload(
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ payload: ReadinessResponsePayload; httpStatus: number }> {
+  const base = getBasePayload();
+  const backendHealthUrl = getBackendHealthUrl();
+
+  if (!backendHealthUrl) {
+    return {
+      payload: createBackendErrorPayload(
+        base,
+        null,
+        "NEXT_PUBLIC_API_URL is not configured",
+      ),
+      httpStatus: 503,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), READY_TIMEOUT_MS);
+  const startedAt = Date.now();
+
+  try {
+    const response = await fetchImpl(backendHealthUrl, {
+      method: "GET",
+      cache: "no-store",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    const responseTimeMs = Date.now() - startedAt;
+    let details: BackendHealthPayload | undefined;
+
+    try {
+      details = (await response.json()) as BackendHealthPayload;
+    } catch {
+      details = undefined;
+    }
+
+    if (!response.ok) {
+      return {
+        payload: createBackendErrorPayload(
+          base,
+          backendHealthUrl,
+          `Backend health check returned HTTP ${response.status}`,
+          responseTimeMs,
+          response.status,
+        ),
+        httpStatus: 503,
+      };
+    }
+
+    if (details?.status !== "ok") {
+      return {
+        payload: createBackendErrorPayload(
+          base,
+          backendHealthUrl,
+          "Backend health payload did not report status ok",
+          responseTimeMs,
+          response.status,
+        ),
+        httpStatus: 503,
+      };
+    }
+
+    return {
+      payload: {
+        ...base,
+        status: "ok",
+        checks: {
+          app: { status: "ok" },
+          backend: {
+            status: "ok",
+            url: backendHealthUrl,
+            responseTimeMs,
+            httpStatus: response.status,
+            details,
+          },
+        },
+      },
+      httpStatus: 200,
+    };
+  } catch (error) {
+    const responseTimeMs = Date.now() - startedAt;
+    const message =
+      error instanceof Error
+        ? error.name === "AbortError"
+          ? `Backend health check timed out after ${READY_TIMEOUT_MS}ms`
+          : error.message
+        : "Unknown backend health error";
+
+    return {
+      payload: createBackendErrorPayload(
+        base,
+        backendHealthUrl,
+        message,
+        responseTimeMs,
+      ),
+      httpStatus: 503,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -61,7 +61,7 @@ export function middleware(request: NextRequest) {
   // - frame-ancestors 'none': same as X-Frame-Options DENY but for modern browsers
   const apiOrigin = process.env.NEXT_PUBLIC_API_URL
     ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
-    : "https://api-production-9bef.up.railway.app";
+    : "";
 
   // TODO(H-2): Migrate script-src off 'unsafe-inline' by adopting per-request
   // nonces for Next.js App Router hydration scripts (see follow-up ticket


### PR DESCRIPTION
## Summary
- add `GET/HEAD /api/health` as a lightweight frontend liveness endpoint
- add `GET/HEAD /api/ready` as a readiness endpoint that performs a real backend `/health` probe via `NEXT_PUBLIC_API_URL`
- add a shared server health helper with `no-store` cache headers and route tests for success and failure paths

## Why
Atlas Portal did not expose first-party health endpoints, which made it hard to probe the frontend directly and distinguish app liveness from backend readiness. This adds an explicit liveness check plus a dependency-aware readiness check.

## Impact
- infra can probe the frontend without relying on an arbitrary page render
- `/api/health` stays local and returns `200` when the app process is alive
- `/api/ready` returns `503` when backend configuration or backend health is broken

## Validation
- `npm test -- --runTestsByPath src/__tests__/app/api/health-routes.test.ts`
- `npm test -- --runInBand`
- `npm run build`