### PR TITLE
feat: add campaign clone feature

### DIFF
--- a/src/__tests__/app/CampaignDetailPage.test.tsx
+++ b/src/__tests__/app/CampaignDetailPage.test.tsx
@@ -1,0 +1,152 @@
+import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockPush = jest.fn();
+const mockUseAuth = jest.fn(() => ({
+  user: { handle: "TestUser" },
+}));
+
+const mockApi = {
+  campaigns: {
+    get: jest.fn().mockResolvedValue({
+      campaign: {
+        id: "camp-1",
+        name: "Test Campaign",
+        description: "A test campaign",
+        status: "DRAFT",
+        draftCount: 1,
+        drafts: [
+          { id: "draft-1", content: "Draft content", status: "DRAFT", createdAt: new Date().toISOString() },
+        ],
+        createdAt: new Date().toISOString(),
+      },
+    }),
+    update: jest.fn().mockResolvedValue({ campaign: {} }),
+    delete: jest.fn().mockResolvedValue({ success: true }),
+    clone: jest.fn().mockResolvedValue({
+      campaign: { id: "camp-clone", name: "Test Campaign (Copy)", status: "DRAFT", draftCount: 1, createdAt: new Date().toISOString() },
+    }),
+  },
+};
+
+jest.mock("@/lib/auth", () => ({
+  useAuth: mockUseAuth,
+}));
+
+jest.mock("@/components/layout/AppShell", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/FeatureGate", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ id: "camp-1" }),
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: mockApi,
+}));
+
+const { api } = require("@/lib/api");
+const CampaignDetailPageGated = require("@/app/campaigns/[id]/page").default;
+
+const mockedApi = api as typeof mockApi;
+
+describe("CampaignDetailPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: { handle: "TestUser" },
+    });
+  });
+
+  it("renders campaign details", async () => {
+    render(<CampaignDetailPageGated />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+    expect(screen.getByText("A test campaign")).toBeInTheDocument();
+    expect(screen.getByText("Draft content")).toBeInTheDocument();
+  });
+
+  it("allows cloning the campaign and routes to the clone", async () => {
+    render(<CampaignDetailPageGated />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+
+    const cloneBtn = screen.getByTitle("Clone campaign");
+    fireEvent.click(cloneBtn);
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.clone).toHaveBeenCalledWith("camp-1")
+    );
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/campaigns/camp-clone")
+    );
+  });
+
+  it("allows deleting the campaign and routes back to list", async () => {
+    render(<CampaignDetailPageGated />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+
+    const deleteBtn = screen.getByTitle("Delete campaign");
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.delete).toHaveBeenCalledWith("camp-1")
+    );
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/campaigns")
+    );
+  });
+
+  it("allows editing the campaign name", async () => {
+    mockedApi.campaigns.update.mockResolvedValueOnce({
+      campaign: {
+        id: "camp-1",
+        name: "Updated Campaign",
+        description: "A test campaign",
+        status: "DRAFT",
+        draftCount: 1,
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    render(<CampaignDetailPageGated />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+
+    const nameInput = screen.getByDisplayValue("Test Campaign");
+    fireEvent.change(nameInput, { target: { value: "Updated Campaign" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.update).toHaveBeenCalledWith("camp-1", {
+        name: "Updated Campaign",
+        description: "A test campaign",
+      })
+    );
+
+    expect(await screen.findByText("Updated Campaign")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/app/CampaignsPage.test.tsx
+++ b/src/__tests__/app/CampaignsPage.test.tsx
@@ -1,0 +1,147 @@
+import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+const mockUseAuth = jest.fn(() => ({
+  user: { handle: "TestUser" },
+}));
+
+const mockApi = {
+  campaigns: {
+    list: jest.fn().mockResolvedValue({ campaigns: [] }),
+    create: jest.fn().mockResolvedValue({ campaign: { id: "camp-new", name: "New Campaign", status: "DRAFT", draftCount: 0, createdAt: new Date().toISOString() } }),
+    delete: jest.fn().mockResolvedValue({ success: true }),
+    clone: jest.fn().mockResolvedValue({ campaign: { id: "camp-clone", name: "Test Campaign (Copy)", status: "DRAFT", draftCount: 0, createdAt: new Date().toISOString() } }),
+  },
+  drafts: {
+    get: jest.fn().mockResolvedValue({ draft: { id: "draft-1", content: "Draft content" } }),
+  },
+};
+
+jest.mock("@/lib/auth", () => ({
+  useAuth: mockUseAuth,
+}));
+
+jest.mock("@/components/layout/AppShell", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/FeatureGate", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: mockApi,
+}));
+
+const { api } = require("@/lib/api");
+const CampaignsPage = require("@/app/campaigns/page").default;
+
+const mockedApi = api as typeof mockApi;
+
+describe("CampaignsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockUseAuth.mockReturnValue({
+      user: { handle: "TestUser" },
+    });
+  });
+
+  it("renders the campaigns heading", async () => {
+    render(<CampaignsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Campaigns" })
+    ).toBeInTheDocument();
+
+    await waitFor(() => expect(mockedApi.campaigns.list).toHaveBeenCalled());
+  });
+
+  it("shows empty state when no campaigns exist", async () => {
+    render(<CampaignsPage />);
+
+    expect(
+      await screen.findByText(/No campaigns yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders campaign list and allows cloning", async () => {
+    mockedApi.campaigns.list.mockResolvedValueOnce({
+      campaigns: [
+        { id: "camp-1", name: "Test Campaign", status: "DRAFT", draftCount: 2, createdAt: new Date().toISOString() },
+      ],
+    });
+
+    render(<CampaignsPage />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+
+    const cloneBtn = screen.getByTitle("Clone campaign");
+    fireEvent.click(cloneBtn);
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.clone).toHaveBeenCalledWith("camp-1")
+    );
+
+    expect(await screen.findByText("Test Campaign (Copy)")).toBeInTheDocument();
+  });
+
+  it("allows deleting a campaign", async () => {
+    mockedApi.campaigns.list.mockResolvedValueOnce({
+      campaigns: [
+        { id: "camp-1", name: "Test Campaign", status: "DRAFT", draftCount: 2, createdAt: new Date().toISOString() },
+      ],
+    });
+
+    render(<CampaignsPage />);
+
+    expect(await screen.findByText("Test Campaign")).toBeInTheDocument();
+
+    const deleteBtn = screen.getByTitle("Delete campaign");
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.delete).toHaveBeenCalledWith("camp-1")
+    );
+
+    expect(screen.queryByText("Test Campaign")).not.toBeInTheDocument();
+  });
+
+  it("allows creating a new campaign", async () => {
+    render(<CampaignsPage />);
+
+    const newBtn = await screen.findByRole("button", { name: /New Campaign/i });
+    fireEvent.click(newBtn);
+
+    const input = screen.getByPlaceholderText(/Campaign name/i);
+    fireEvent.change(input, { target: { value: "My New Campaign" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Campaign$/i }));
+
+    await waitFor(() =>
+      expect(mockedApi.campaigns.create).toHaveBeenCalledWith(
+        "My New Campaign",
+        undefined
+      )
+    );
+  });
+});

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import {
   ArrowLeft,
   Calendar,
+  Copy,
   FileText,
   Loader2,
   Megaphone,
@@ -106,6 +107,12 @@ function CampaignDetailPage() {
     router.push("/campaigns");
   };
 
+  const handleClone = async () => {
+    if (!campaign) return;
+    const { campaign: cloned } = await api.campaigns.clone(campaign.id);
+    router.push(`/campaigns/${cloned.id}`);
+  };
+
   return (
     <AppShell>
       <div className="mx-auto max-w-4xl px-4 py-8 font-body sm:px-6">
@@ -187,8 +194,16 @@ function CampaignDetailPage() {
                       Edit
                     </button>
                     <button
+                      onClick={handleClone}
+                      className="rounded-lg p-2 text-atlas-text-muted transition-colors hover:text-atlas-teal"
+                      title="Clone campaign"
+                    >
+                      <Copy className="h-4 w-4" />
+                    </button>
+                    <button
                       onClick={handleDelete}
                       className="rounded-lg p-2 text-atlas-text-muted transition-colors hover:text-atlas-error"
+                      title="Delete campaign"
                     >
                       <Trash2 className="h-4 w-4" />
                     </button>

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Calendar,
+  Copy,
   ListOrdered,
   Loader2,
   Megaphone,
@@ -135,6 +136,11 @@ function CampaignsTab() {
     setCampaigns((prev) => prev.filter((c) => c.id !== id));
   };
 
+  const handleClone = async (id: string) => {
+    const { campaign: cloned } = await api.campaigns.clone(id);
+    setCampaigns((prev) => [cloned, ...prev]);
+  };
+
   return (
     <div className="mt-6">
       <div className="mb-6 flex items-center justify-between">
@@ -238,13 +244,24 @@ function CampaignsTab() {
                         <span>{campaign.draftCount} post{campaign.draftCount !== 1 ? "s" : ""}</span>
                       </div>
                     </div>
-                    <button
-                      type="button"
-                      onClick={(e) => { e.preventDefault(); handleDelete(campaign.id); }}
-                      className="shrink-0 rounded-lg p-2 text-atlas-text-muted transition-colors hover:text-atlas-error"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={(e) => { e.preventDefault(); handleClone(campaign.id); }}
+                        className="rounded-lg p-2 text-atlas-text-muted transition-colors hover:text-atlas-teal"
+                        title="Clone campaign"
+                      >
+                        <Copy className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.preventDefault(); handleDelete(campaign.id); }}
+                        className="rounded-lg p-2 text-atlas-text-muted transition-colors hover:text-atlas-error"
+                        title="Delete campaign"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </div>
                 </GlassCard>
               </Link>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -807,6 +807,8 @@ export const api = {
       request<{ campaign: Campaign }>(`/api/campaigns/${id}`, { method: "PATCH", body: data }),
     delete: (id: string) =>
       request<{ success: boolean }>(`/api/campaigns/${id}`, { method: "DELETE" }),
+    clone: (id: string) =>
+      request<{ campaign: Campaign }>(`/api/campaigns/${id}/clone`, { method: "POST" }),
     addDraft: (campaignId: string, draftId: string, sortOrder?: number) =>
       request<{ success: boolean }>(`/api/campaigns/${campaignId}/drafts`, { method: "POST", body: { draftId, sortOrder } }),
     removeDraft: (campaignId: string, draftId: string) =>

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -936,6 +936,23 @@ export function getDemoResponse(path: string, method: string = "GET", body?: unk
     };
   }
 
+  // Campaign clone
+  if (method === "POST" && /^\/api\/campaigns\/[^/]+\/clone$/.test(cleanPath)) {
+    const id = cleanPath.split("/")[3] as string;
+    const existing = demoCampaigns.find((c) => c.id === id);
+    return {
+      campaign: {
+        id: `camp-clone-${Date.now()}`,
+        name: `${existing?.name ?? "Campaign"} (Copy)`,
+        description: existing?.description ?? null,
+        status: "DRAFT" as const,
+        draftCount: existing?.draftCount ?? 0,
+        drafts: existing?.drafts ?? [],
+        createdAt: now,
+      },
+    };
+  }
+
   // Campaign update
   if (method === "PATCH" && /^\/api\/campaigns\/[^/]+$/.test(cleanPath)) {
     const id = cleanPath.split("/").pop() as string;


### PR DESCRIPTION
- Add api.campaigns.clone() method calling POST /api/campaigns/:id/clone
- Add clone button to campaigns list page with optimistic list update
- Add clone button to campaign detail page with redirect to cloned campaign
- Add demo data mock for campaign clone endpoint
- Add tests for CampaignsPage and CampaignDetailPage clone functionality
