### PR TITLE
feat(crafting): add tweet scheduling UI

### DIFF
--- a/src/__tests__/app/CraftingPage.test.tsx
+++ b/src/__tests__/app/CraftingPage.test.tsx
@@ -47,6 +47,8 @@ jest.mock("@/lib/api", () => ({
       regenerate: jest.fn(),
       delete: jest.fn(),
       refine: jest.fn(),
+      schedule: jest.fn(),
+      postToX: jest.fn(),
     },
     analytics: {
       summary: jest.fn(),
@@ -80,6 +82,8 @@ const mockedApi = api as unknown as {
     regenerate: jest.Mock;
     delete: jest.Mock;
     refine: jest.Mock;
+    schedule: jest.Mock;
+    postToX: jest.Mock;
   };
   analytics: {
     summary: jest.Mock;
@@ -118,6 +122,8 @@ describe("CraftingPage", () => {
     mockedApi.drafts.regenerate.mockReset();
     mockedApi.drafts.delete.mockReset();
     mockedApi.drafts.refine.mockReset();
+    mockedApi.drafts.schedule.mockReset();
+    mockedApi.drafts.postToX.mockReset();
     mockedApi.auth.x.status.mockReset();
     mockedApi.auth.x.authorize.mockReset();
     mockedApi.analytics.summary.mockReset();
@@ -452,5 +458,56 @@ describe("CraftingPage", () => {
     expect(
       screen.queryByRole("button", { name: "Post to X" })
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the Schedule button for draft and approved statuses", async () => {
+    mockedApi.drafts.list.mockResolvedValue({
+      drafts: [createDraft({ status: "DRAFT" })],
+    });
+
+    render(<CraftingPage />);
+
+    await screen.findByRole("textbox", { name: "Generated draft" });
+
+    expect(screen.getByRole("button", { name: "Schedule" })).toBeInTheDocument();
+  });
+
+  it("opens the schedule popover and schedules the draft", async () => {
+    const draft = createDraft({ status: "APPROVED" });
+    const scheduledDraft = createDraft({ status: "SCHEDULED", scheduledAt: "2026-04-15T12:00:00.000Z" });
+
+    mockedApi.drafts.list.mockResolvedValue({ drafts: [draft] });
+    mockedApi.drafts.schedule.mockResolvedValue({ draft: scheduledDraft });
+
+    render(<CraftingPage />);
+
+    await screen.findByRole("textbox", { name: "Generated draft" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
+
+    const dateInput = await screen.findByLabelText("Schedule date and time");
+    expect(dateInput).toBeInTheDocument();
+
+    fireEvent.change(dateInput, { target: { value: "2026-04-15T12:00" } });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() =>
+      expect(mockedApi.drafts.schedule).toHaveBeenCalledWith(
+        "draft-1",
+        expect.stringMatching(/^2026-04-15T\d{2}:00:00\.000Z$/)
+      )
+    );
+  });
+
+  it("does not show the Schedule button for archived drafts", async () => {
+    mockedApi.drafts.list.mockResolvedValue({
+      drafts: [createDraft({ status: "ARCHIVED" })],
+    });
+
+    render(<CraftingPage />);
+
+    await screen.findByRole("textbox", { name: "Generated draft" });
+
+    expect(screen.queryByRole("button", { name: "Schedule" })).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/SchedulePopover.test.tsx
+++ b/src/__tests__/components/SchedulePopover.test.tsx
@@ -1,0 +1,99 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SchedulePopover } from "@/components/ui/SchedulePopover";
+
+describe("SchedulePopover", () => {
+  const baseTime = "2026-04-15T10:00:00.000Z";
+
+  it("renders the datetime input and buttons", () => {
+    render(
+      <SchedulePopover
+        initialAt={baseTime}
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText("Schedule date and time")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Cancel is clicked", () => {
+    const onCancel = jest.fn();
+    render(
+      <SchedulePopover
+        initialAt={baseTime}
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("calls onConfirm with ISO string when Confirm is clicked", () => {
+    const onConfirm = jest.fn();
+    render(
+      <SchedulePopover
+        initialAt={baseTime}
+        onCancel={jest.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Schedule date and time"), {
+      target: { value: "2026-04-20T14:30" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.stringMatching(/^2026-04-20T\d{2}:30:00\.000Z$/)
+    );
+  });
+
+  it("calls onCancel when Escape is pressed", () => {
+    const onCancel = jest.fn();
+    render(
+      <SchedulePopover
+        initialAt={baseTime}
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("calls onCancel when clicking outside", () => {
+    const onCancel = jest.fn();
+    render(
+      <div data-testid="outside">
+        <SchedulePopover
+          initialAt={baseTime}
+          onCancel={onCancel}
+          onConfirm={jest.fn()}
+        />
+      </div>
+    );
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("shows loading state when busy", () => {
+    render(
+      <SchedulePopover
+        initialAt={baseTime}
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        busy
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+});

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -11,6 +11,7 @@ import {
 import {
   Archive,
   ArrowUp,
+  Calendar,
   Check,
   CheckCircle,
   ChevronRight,
@@ -57,6 +58,8 @@ import OracleWidget from "@/components/oracle/OracleWidget";
 import OracleCraftingHints from "@/components/oracle/OracleCraftingHints";
 import OracleInspector from "@/components/oracle/OracleInspector";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
+import { useToast } from "@/components/ui/Toast";
+import { SchedulePopover } from "@/components/ui/SchedulePopover";
 
 const CRAFTING_MODES = [
   { id: "new_post", label: "New Post" },
@@ -253,6 +256,7 @@ function CraftingPage() {
   const regenerationGuidanceId = useId();
   const draftFeedbackHintId = useId();
   const { user } = useAuth();
+  const { toast } = useToast();
   const [drafts, setDrafts] = useState<TweetDraft[]>([]);
   const [draftHistory, setDraftHistory] = useState<DraftHistoryItem[]>([]);
   const [draftVersions, setDraftVersions] = useState<TweetDraft[]>([]);
@@ -269,6 +273,8 @@ function CraftingPage() {
   const [feedbackText, setFeedbackText] = useState("");
   const [showFeedback, setShowFeedback] = useState(false);
   const [statusUpdating, setStatusUpdating] = useState(false);
+  const [schedulePopoverOpen, setSchedulePopoverOpen] = useState(false);
+  const [scheduleLoading, setScheduleLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [voiceBanner, setVoiceBanner] = useState<string | null>(null);
   const [blendWarning, setBlendWarning] = useState<string | null>(null);
@@ -963,6 +969,41 @@ function CraftingPage() {
       );
     } finally {
       setStatusUpdating(false);
+    }
+  };
+
+  const handleScheduleDraft = async (scheduledAt: string) => {
+    if (!user || !activeDraft) return;
+
+    setScheduleLoading(true);
+    setError(null);
+
+    try {
+      const sourceUrl = extractSourceUrl(activeDraft);
+      const { draft, conflicts } = await api.drafts.schedule(
+        activeDraft.id,
+        scheduledAt
+      );
+      syncDraftReferences(draft, sourceUrl ?? undefined);
+      setSchedulePopoverOpen(false);
+
+      if (conflicts && conflicts.length > 0) {
+        toast(
+          `Scheduled, but it conflicts with ${conflicts.length} other draft${conflicts.length === 1 ? "" : "s"}.`,
+          "warning"
+        );
+      } else {
+        toast("Draft scheduled successfully.", "success");
+      }
+    } catch (scheduleError: unknown) {
+      console.error("Failed to schedule draft:", scheduleError);
+      setError(
+        scheduleError instanceof Error
+          ? scheduleError.message
+          : "Failed to schedule draft"
+      );
+    } finally {
+      setScheduleLoading(false);
     }
   };
 
@@ -2054,6 +2095,27 @@ function CraftingPage() {
                       </svg>
                       Post to X
                     </button>
+                  ) : null}
+                  {activeDraft.status === "APPROVED" || activeDraft.status === "DRAFT" ? (
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={() => setSchedulePopoverOpen(true)}
+                        title="Schedule this draft"
+                        className="flex items-center gap-1.5 rounded-lg border border-glass-border bg-atlas-surface px-3 py-1.5 text-xs font-medium text-atlas-text transition-colors hover:border-atlas-teal/50 hover:text-atlas-teal"
+                      >
+                        <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+                        Schedule
+                      </button>
+                      {schedulePopoverOpen && (
+                        <SchedulePopover
+                          initialAt={activeDraft.scheduledAt || new Date(Date.now() + 3600000).toISOString()}
+                          onCancel={() => setSchedulePopoverOpen(false)}
+                          onConfirm={(iso) => void handleScheduleDraft(iso)}
+                          busy={scheduleLoading}
+                        />
+                      )}
+                    </div>
                   ) : null}
                   {activeDraft.status === "APPROVED" || activeDraft.status === "DRAFT" ? (
                     <button

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -37,6 +37,7 @@ import QueueTimeline from "@/components/queue/QueueTimeline";
 import OracleInspector from "@/components/oracle/OracleInspector";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
 import { api, QueuedDraft } from "@/lib/api";
+import { SchedulePopover } from "@/components/ui/SchedulePopover";
 
 type FilterKey = "all" | "draft" | "scheduled" | "posted" | "archived";
 
@@ -80,62 +81,6 @@ function statusVariant(status: QueuedDraft["status"]): {
         className: "bg-glass-border/30 text-atlas-text-secondary",
       };
   }
-}
-
-function toLocalDateTimeInput(iso: string): string {
-  const d = new Date(iso);
-  // Format as yyyy-MM-ddTHH:mm in local time for <input type="datetime-local">
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
-    d.getDate()
-  )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-/* ---- Schedule picker popover ---- */
-function SchedulePopover({
-  initialAt,
-  onCancel,
-  onConfirm,
-  busy,
-}: {
-  initialAt: string;
-  onCancel: () => void;
-  onConfirm: (iso: string) => void;
-  busy?: boolean;
-}) {
-  const [value, setValue] = useState(() => toLocalDateTimeInput(initialAt));
-
-  return (
-    <div className="absolute right-0 top-full z-30 mt-2 w-64 rounded-xl border border-glass-border bg-atlas-nav p-3 shadow-xl backdrop-blur-xl">
-      <p className="mb-2 text-[11px] font-medium text-atlas-text-secondary">
-        Pick a date and time
-      </p>
-      <input
-        type="datetime-local"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        className="w-full rounded-lg border border-glass-border bg-atlas-surface px-2 py-1.5 text-xs text-atlas-text focus:border-atlas-teal focus:outline-none"
-      />
-      <div className="mt-3 flex items-center justify-end gap-2">
-        <button
-          onClick={onCancel}
-          className="rounded-lg border border-glass-border px-2.5 py-1 text-[11px] text-atlas-text-muted hover:text-atlas-text"
-        >
-          Cancel
-        </button>
-        <button
-          disabled={busy || !value}
-          onClick={() => {
-            const iso = new Date(value).toISOString();
-            onConfirm(iso);
-          }}
-          className="rounded-lg bg-atlas-teal px-2.5 py-1 text-[11px] font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:opacity-50"
-        >
-          {busy ? "Saving..." : "Confirm"}
-        </button>
-      </div>
-    </div>
-  );
 }
 
 /* ---- Sortable queue item ---- */

--- a/src/components/ui/SchedulePopover.tsx
+++ b/src/components/ui/SchedulePopover.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+function toLocalDateTimeInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export interface SchedulePopoverProps {
+  initialAt: string;
+  onCancel: () => void;
+  onConfirm: (iso: string) => void;
+  busy?: boolean;
+}
+
+export function SchedulePopover({ initialAt, onCancel, onConfirm, busy }: SchedulePopoverProps) {
+  const [value, setValue] = useState(() => toLocalDateTimeInput(initialAt));
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onCancel();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [onCancel]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute right-0 top-full z-30 mt-2 w-64 rounded-xl border border-glass-border bg-atlas-nav p-3 shadow-xl backdrop-blur-xl"
+      role="dialog"
+      aria-label="Schedule draft"
+    >
+      <p className="mb-2 text-[11px] font-medium text-atlas-text-secondary">
+        Pick a date and time
+      </p>
+      <input
+        type="datetime-local"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="w-full rounded-lg border border-glass-border bg-atlas-surface px-2 py-1.5 text-xs text-atlas-text focus:border-atlas-teal focus:outline-none"
+        aria-label="Schedule date and time"
+      />
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-glass-border px-2.5 py-1 text-[11px] text-atlas-text-muted hover:text-atlas-text"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={busy || !value}
+          onClick={() => {
+            const iso = new Date(value).toISOString();
+            onConfirm(iso);
+          }}
+          className="rounded-lg bg-atlas-teal px-2.5 py-1 text-[11px] font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? "Saving..." : "Confirm"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add reusable SchedulePopover component in src/components/ui/
- Integrate schedule button into crafting station draft actions
- Wire up api.drafts.schedule() with toast feedback and conflict handling
- Update queue page to use the shared SchedulePopover
- Add tests for SchedulePopover and CraftingPage scheduling flow
