### PR TITLE
feat(dashboard): add keyboard shortcuts

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,17 @@
 process.env.NEXT_PUBLIC_API_URL = "http://localhost:3001";
+
+// Polyfill HTMLDialogElement methods for jsdom
+if (typeof HTMLDialogElement !== "undefined") {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.setAttribute("open", "");
+      this.setAttribute("data-modal", "true");
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.removeAttribute("open");
+      this.removeAttribute("data-modal");
+    };
+  }
+}

--- a/src/__tests__/app/DashboardPage.test.tsx
+++ b/src/__tests__/app/DashboardPage.test.tsx
@@ -253,4 +253,68 @@ describe("DashboardPage", () => {
       screen.queryByText("Some dashboard data is temporarily unavailable.")
     ).not.toBeInTheDocument();
   });
+
+  it("opens the keyboard shortcuts modal when the ? key is pressed", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "?" });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+  });
+
+  it("opens the keyboard shortcuts modal when the shortcuts button is clicked", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open keyboard shortcuts" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+  });
+
+  it("closes the keyboard shortcuts modal with Escape", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "?" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("navigates to the first nav card when 1 is pressed", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "1" });
+
+    expect(mockPush).toHaveBeenCalledWith("/crafting");
+  });
+
+  it("focuses the quick draft input when q is pressed", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    const quickDraftInput = screen.getByRole("textbox", { name: "Quick Draft" });
+    expect(document.activeElement).not.toBe(quickDraftInput);
+
+    fireEvent.keyDown(document, { key: "q" });
+
+    expect(document.activeElement).toBe(quickDraftInput);
+  });
+
+  it("does not trigger shortcuts when typing in an input", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("Drafts this week")).toBeInTheDocument();
+
+    const quickDraftInput = screen.getByRole("textbox", { name: "Quick Draft" });
+    fireEvent.focus(quickDraftInput);
+    fireEvent.keyDown(quickDraftInput, { key: "1" });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { api, TweetDraft, QueuedDraft, TrendingTopic } from "@/lib/api";
 import { PenTool, Bell, BarChart3, Mic2, BookOpen, Users, TrendingUp, X, Clock, Zap, Calendar, Sparkles, ArrowRight, Trophy, Megaphone } from "lucide-react";
 import DashboardSkeleton from "@/components/skeletons/DashboardSkeleton";
 import OracleWidget from "@/components/oracle/OracleWidget";
+import KeyboardShortcutsModal from "@/components/ui/KeyboardShortcutsModal";
 import { useRouteEnabled, useFeatureFlags } from "@/lib/feature-flags";
 
 const navCards = [
@@ -54,7 +55,9 @@ const searchParams = useSearchParams();
     useState(false);
   const [briefingText, setBriefingText] = useState<string | null>(null);
   const [briefingLoading, setBriefingLoading] = useState(false);
+  const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const briefingFiredRef = useRef(false);
+  const quickDraftInputRef = useRef<HTMLInputElement>(null);
   const completionBanner = searchParams.get("banner");
   const showVoiceCalibratedBanner =
     completionBanner === "voice-calibrated" && !dismissedCompletionBanner;
@@ -222,6 +225,67 @@ const searchParams = useSearchParams();
     router.push(`/crafting?draft=${encodeURIComponent(trimmedDraft)}`);
   };
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+      const isTyping =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable;
+
+      // Escape: close expanded drafts, engagement form, or shortcuts modal
+      if (event.key === "Escape") {
+        if (isShortcutsOpen) {
+          event.preventDefault();
+          setIsShortcutsOpen(false);
+          return;
+        }
+        if (engagementDraftId) {
+          event.preventDefault();
+          setEngagementDraftId(null);
+          return;
+        }
+        if (expandedDraftId) {
+          event.preventDefault();
+          setExpandedDraftId(null);
+          return;
+        }
+        return;
+      }
+
+      // Don't intercept when typing in inputs (except Enter which is handled locally)
+      if (isTyping) return;
+
+      // ?: Show keyboard shortcuts
+      if (event.key === "?") {
+        event.preventDefault();
+        setIsShortcutsOpen(true);
+        return;
+      }
+
+      // Q: Focus quick draft
+      if (event.key === "q" || event.key === "Q") {
+        event.preventDefault();
+        quickDraftInputRef.current?.focus();
+        return;
+      }
+
+      // 1-8: Navigate to visible nav cards
+      const num = parseInt(event.key, 10);
+      if (!Number.isNaN(num) && num >= 1 && num <= 8) {
+        const card = visibleNavCards[num - 1];
+        if (card) {
+          event.preventDefault();
+          router.push(card.href);
+        }
+        return;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [visibleNavCards, router, isShortcutsOpen, engagementDraftId, expandedDraftId]);
+
   if (loading) {
     return (
       <AppShell>
@@ -307,6 +371,7 @@ const searchParams = useSearchParams();
           <input
             id="quick-draft-input"
             name="quickDraft"
+            ref={quickDraftInputRef}
             type="text"
             value={quickDraft}
             onChange={(event) => setQuickDraft(event.target.value)}
@@ -483,8 +548,18 @@ const searchParams = useSearchParams();
         </div>
       )}
 
-      <div className="mt-8">
+      <div className="mt-8 flex items-center justify-between">
         <p className="text-atlas-text-secondary text-sm mb-4">Recent activity</p>
+        <button
+          type="button"
+          onClick={() => setIsShortcutsOpen(true)}
+          aria-label="Open keyboard shortcuts"
+          className="mb-4 rounded-lg border border-glass-border bg-atlas-surface px-2.5 py-1.5 text-xs font-medium text-atlas-text-secondary transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+        >
+          Shortcuts <kbd className="ml-1 rounded border border-glass-border bg-atlas-bg px-1 text-[10px]">?</kbd>
+        </button>
+      </div>
+      <div>
         {drafts.length > 0 ? (
           <div className="bg-atlas-surface border border-glass-border rounded-2xl divide-y divide-glass-border">
             {drafts.map((draft) => (
@@ -572,6 +647,15 @@ const searchParams = useSearchParams();
           </div>
         )}
       </div>
+
+      <KeyboardShortcutsModal
+        isOpen={isShortcutsOpen}
+        onClose={() => setIsShortcutsOpen(false)}
+        navShortcuts={visibleNavCards.slice(0, 8).map((card, i) => ({
+          key: String(i + 1),
+          label: card.label,
+        }))}
+      />
     </AppShell>
   );
 }

--- a/src/components/ui/KeyboardShortcutsModal.tsx
+++ b/src/components/ui/KeyboardShortcutsModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Modal from "./Modal";
+import { Command, CornerDownLeft, ArrowUp, ArrowDown } from "lucide-react";
+
+interface ShortcutItem {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  items: ShortcutItem[];
+}
+
+interface KeyboardShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  navShortcuts?: { key: string; label: string }[];
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex min-w-[1.5rem] items-center justify-center rounded border border-glass-border bg-atlas-bg px-1.5 py-0.5 text-[11px] font-medium text-atlas-text-secondary">
+      {children}
+    </kbd>
+  );
+}
+
+export default function KeyboardShortcutsModal({
+  isOpen,
+  onClose,
+  navShortcuts = [],
+}: KeyboardShortcutsModalProps) {
+  const groups: ShortcutGroup[] = [
+    {
+      title: "Navigation",
+      items: [
+        { keys: ["?"], description: "Show keyboard shortcuts" },
+        { keys: ["Esc"], description: "Close modals / cancel actions" },
+        ...(navShortcuts.length > 0
+          ? navShortcuts.map((s) => ({
+              keys: [s.key],
+              description: `Go to ${s.label}`,
+            }))
+          : []),
+      ],
+    },
+    {
+      title: "Dashboard",
+      items: [
+        { keys: ["Q"], description: "Focus Quick Draft input" },
+        { keys: ["Enter"], description: "Submit Quick Draft" },
+      ],
+    },
+    {
+      title: "Global",
+      items: [
+        { keys: ["⌘", "K"], description: "Open Command Palette" },
+        { keys: ["/"], description: "Search from anywhere" },
+      ],
+    },
+  ];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Keyboard Shortcuts"
+      description="Speed up your workflow with these shortcuts"
+    >
+      <div className="space-y-6">
+        {groups.map((group) => (
+          <div key={group.title}>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-atlas-text-muted">
+              {group.title}
+            </h3>
+            <ul className="space-y-2">
+              {group.items.map((item, idx) => (
+                <li
+                  key={`${group.title}-${idx}`}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="text-atlas-text-secondary">
+                    {item.description}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    {item.keys.map((key, kidx) => (
+                      <Kbd key={kidx}>
+                        {key === "Enter" ? (
+                          <CornerDownLeft className="h-3 w-3" />
+                        ) : key === "Esc" ? (
+                          "Esc"
+                        ) : key === "ArrowUp" ? (
+                          <ArrowUp className="h-3 w-3" />
+                        ) : key === "ArrowDown" ? (
+                          <ArrowDown className="h-3 w-3" />
+                        ) : key === "⌘" ? (
+                          <Command className="h-3 w-3" />
+                        ) : (
+                          key
+                        )}
+                      </Kbd>
+                    ))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
- Add KeyboardShortcutsModal component for displaying shortcuts
- Bind ? key to open shortcuts help modal
- Bind 1-8 keys to navigate to dashboard nav cards
- Bind q key to focus Quick Draft input
- Bind Escape to close modal, expanded drafts, and engagement form
- Add shortcuts button in Recent activity section
- Add tests for all keyboard shortcut behaviors
- Add HTMLDialogElement polyfill for jest/jsdom
