### PR TITLE
improve onboarding flow: back nav, dead code cleanup, tests

### DIFF
--- a/src/__tests__/components/onboarding/OracleChat.test.tsx
+++ b/src/__tests__/components/onboarding/OracleChat.test.tsx
@@ -1,0 +1,269 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+
+function runAllChatTimers() {
+  // The chat schedules nested setTimeouts for each pending message.
+  // We need to flush them iteratively so React effects can schedule
+  // the next timer between each act() batch.
+  for (let i = 0; i < 10; i++) {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+  }
+}
+import OracleChat from "@/components/onboarding/OracleChat";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+
+const mockUseAuth = jest.fn();
+const mockXStatus = jest.fn();
+const mockXAuthorize = jest.fn();
+const mockUpdateProfile = jest.fn();
+const mockVoiceUpdateProfile = jest.fn();
+const mockCalibrate = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+  }),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    auth: {
+      x: {
+        status: () => mockXStatus(),
+        authorize: () => mockXAuthorize(),
+      },
+    },
+    users: {
+      updateProfile: (data: unknown) => mockUpdateProfile(data),
+    },
+    voice: {
+      updateProfile: (data: unknown) => mockVoiceUpdateProfile(data),
+      calibrate: (handle: string) => mockCalibrate(handle),
+    },
+  },
+}));
+
+// Stub heavy child components so tests focus on OracleChat orchestration.
+jest.mock("@/components/onboarding/OracleAvatar", () => {
+  return function MockOracleAvatar({ size }: { size: string }) {
+    return <div data-testid="oracle-avatar" data-size={size} />;
+  };
+});
+
+jest.mock("@/components/onboarding/OracleMessage", () => {
+  return function MockOracleMessage({
+    message,
+    isLast,
+    onAction,
+  }: {
+    message: { role: string; content: string; actions?: unknown[] };
+    isLast?: boolean;
+    onAction?: (value: string) => void;
+  }) {
+    return (
+      <div
+        data-testid="oracle-message"
+        data-role={message.role}
+        data-islast={String(isLast)}
+      >
+        <span data-testid="message-content">{message.content}</span>
+        {isLast &&
+          message.actions?.map((a: any) => (
+            <button
+              key={a.value}
+              data-testid={`action-${a.value}`}
+              onClick={() => onAction?.(a.value)}
+            >
+              {a.label}
+            </button>
+          ))}
+      </div>
+    );
+  };
+});
+
+jest.mock("@/components/onboarding/TypingIndicator", () => {
+  return function MockTypingIndicator() {
+    return <div data-testid="typing-indicator">Typing...</div>;
+  };
+});
+
+jest.mock("@/components/onboarding/TrackBadge", () => {
+  return function MockTrackBadge() {
+    return <div data-testid="track-badge" />;
+  };
+});
+
+jest.mock("@/components/ui/NavBar", () => {
+  return function MockNavBar() {
+    return <nav data-testid="navbar" />;
+  };
+});
+
+describe("OracleChat", () => {
+  let originalURLSearchParams: typeof URLSearchParams;
+
+  beforeEach(() => {
+    // scrollIntoView is not implemented in jsdom
+    Element.prototype.scrollIntoView = jest.fn();
+    jest.useFakeTimers();
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockUseAuth.mockReturnValue({ user: null });
+    mockXStatus.mockResolvedValue({ linked: false });
+    mockXAuthorize.mockResolvedValue({ url: "https://x.com/oauth" });
+    mockUpdateProfile.mockResolvedValue({});
+    mockVoiceUpdateProfile.mockResolvedValue({});
+    mockCalibrate.mockResolvedValue({
+      profile: {},
+      calibration: { analysis: "Great voice!", tweetsAnalyzed: 42 },
+    });
+
+    // Clear sessionStorage
+    try {
+      sessionStorage.clear();
+    } catch {}
+
+    // @ts-expect-error mocking history
+    window.history.replaceState = jest.fn();
+
+    originalURLSearchParams = URLSearchParams;
+  });
+
+  afterEach(() => {
+    global.URLSearchParams = originalURLSearchParams;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the welcome flow on initial mount", async () => {
+    render(<OracleChat />);
+
+    expect(screen.getByText("The Oracle")).toBeInTheDocument();
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+
+    // Welcome messages are pending and should drain via typing effect
+    runAllChatTimers();
+    await waitFor(() => {
+      const messages = screen.getAllByTestId("oracle-message");
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("shows the x-oauth action area at CONNECT_X after starting onboarding", async () => {
+    render(<OracleChat />);
+
+    runAllChatTimers();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("action-start-onboarding")
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("action-start-onboarding"));
+
+    runAllChatTimers();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("action-skip-x")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("drains pending messages through the typing indicator", async () => {
+    render(<OracleChat />);
+
+    // Initially there should be a typing indicator because pending messages exist
+    await waitFor(() => {
+      expect(screen.getByTestId("typing-indicator")).toBeInTheDocument();
+    });
+
+    // Fast-forward through the typing delays to drain all welcome messages
+    runAllChatTimers();
+
+    await waitFor(() => {
+      const messages = screen.getAllByTestId("oracle-message");
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("shows back button after advancing and lets the user go back", async () => {
+    render(<OracleChat />);
+
+    runAllChatTimers();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("action-start-onboarding")
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("action-start-onboarding"));
+
+    runAllChatTimers();
+
+    // Now at CONNECT_X — back button should be visible
+    await waitFor(() => {
+      expect(screen.getByText("← Back")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("← Back"));
+
+    runAllChatTimers();
+
+    // We should be back at WELCOME
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("action-start-onboarding")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("advances to track b when skip-x is clicked", async () => {
+    render(<OracleChat />);
+
+    runAllChatTimers();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("action-start-onboarding")
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("action-start-onboarding"));
+
+    runAllChatTimers();
+
+    // Wait for the skip-x action in CONNECT_X
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("action-skip-x")
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("action-skip-x"));
+
+    runAllChatTimers();
+
+    await waitFor(() => {
+      const userMessages = screen
+        .getAllByTestId("oracle-message")
+        .filter((m) => m.getAttribute("data-role") === "user");
+      const lastUser = userMessages[userMessages.length - 1];
+      expect(lastUser).toHaveTextContent(/set up manually/i);
+    });
+  });
+});

--- a/src/__tests__/lib/oracle.test.ts
+++ b/src/__tests__/lib/oracle.test.ts
@@ -1,6 +1,15 @@
 import "@testing-library/jest-dom";
 
-import { getOnboardingCompletionHref } from "@/lib/oracle";
+import {
+  canAdvance,
+  getContinueLabel,
+  getOnboardingCompletionHref,
+  getTrackMeta,
+  initialOracleState,
+  oracleReducer,
+  TRACK_META,
+} from "@/lib/oracle";
+import { DEFAULT_VOICE_DIMENSIONS } from "@/lib/voice-profile-dimensions";
 
 describe("getOnboardingCompletionHref", () => {
   it("routes Track A completions to the dashboard banner", () => {
@@ -13,5 +22,381 @@ describe("getOnboardingCompletionHref", () => {
     expect(getOnboardingCompletionHref("b")).toBe(
       "/voice-lab?prompt=complete-voice-setup"
     );
+  });
+});
+
+describe("getTrackMeta", () => {
+  it("returns null when track is null", () => {
+    expect(getTrackMeta(null)).toBeNull();
+  });
+
+  it("returns Track A metadata", () => {
+    expect(getTrackMeta("a")).toEqual(TRACK_META.a);
+  });
+
+  it("returns Track B metadata", () => {
+    expect(getTrackMeta("b")).toEqual(TRACK_META.b);
+  });
+});
+
+describe("getContinueLabel", () => {
+  it.each([
+    ["TRACK_A_RESULT", "a", "Looks right — continue"],
+    ["TRACK_A_RESULT", "b", "Looks right — continue"],
+    ["TRACK_B_STYLE", "a", "Use this as my starting point"],
+    ["TRACK_B_STYLE", "b", "Use this as my starting point"],
+    ["TRACK_B_DIMENSIONS", "a", "Lock in these dimensions"],
+    ["TRACK_B_DIMENSIONS", "b", "Lock in these dimensions"],
+    ["REFERENCES", "a", "These are my people"],
+    ["REFERENCES", "b", "These voices feel right"],
+    ["WELCOME", "a", "Continue"],
+    ["WELCOME", "b", "Continue"],
+    ["HANDOFF", "a", "Continue"],
+  ] as const)(
+    "returns the correct label for step %s track %s",
+    (step, track, expected) => {
+      expect(getContinueLabel(step, track)).toBe(expected);
+    }
+  );
+});
+
+describe("canAdvance", () => {
+  const base = initialOracleState();
+
+  it("allows advancing from WELCOME", () => {
+    expect(canAdvance(base)).toBe(true);
+  });
+
+  it("blocks advancing from CONNECT_X when not connected", () => {
+    const state = { ...base, currentStep: "CONNECT_X" as const };
+    expect(canAdvance(state)).toBe(false);
+  });
+
+  it("allows advancing from CONNECT_X when connected with handle", () => {
+    const state = {
+      ...base,
+      currentStep: "CONNECT_X" as const,
+      xConnected: true,
+      xHandle: "alex",
+    };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("blocks advancing from TRACK_A_SCANNING without calibration", () => {
+    const state = { ...base, currentStep: "TRACK_A_SCANNING" as const };
+    expect(canAdvance(state)).toBe(false);
+  });
+
+  it("allows advancing from TRACK_A_SCANNING with calibration result", () => {
+    const state = {
+      ...base,
+      currentStep: "TRACK_A_SCANNING" as const,
+      calibrationResult: { analysis: "test", tweetsAnalyzed: 42 },
+    };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("allows advancing from TRACK_A_RESULT", () => {
+    const state = { ...base, currentStep: "TRACK_A_RESULT" as const };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("blocks advancing from TRACK_B_STYLE without selection", () => {
+    const state = { ...base, currentStep: "TRACK_B_STYLE" as const };
+    expect(canAdvance(state)).toBe(false);
+  });
+
+  it("allows advancing from TRACK_B_STYLE with selection", () => {
+    const state = {
+      ...base,
+      currentStep: "TRACK_B_STYLE" as const,
+      selectedStyle: "Fun",
+    };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("allows advancing from TRACK_B_CONTENT", () => {
+    const state = { ...base, currentStep: "TRACK_B_CONTENT" as const };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("allows advancing from TRACK_B_DIMENSIONS", () => {
+    const state = { ...base, currentStep: "TRACK_B_DIMENSIONS" as const };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("blocks advancing from REFERENCES without selections", () => {
+    const state = { ...base, currentStep: "REFERENCES" as const };
+    expect(canAdvance(state)).toBe(false);
+  });
+
+  it("allows advancing from REFERENCES with at least one selection", () => {
+    const state = {
+      ...base,
+      currentStep: "REFERENCES" as const,
+      selectedRefs: ["ref1"],
+    };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("allows advancing from BLEND", () => {
+    const state = { ...base, currentStep: "BLEND" as const };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("allows advancing from TOPICS", () => {
+    const state = { ...base, currentStep: "TOPICS" as const };
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it("blocks advancing from HANDOFF", () => {
+    const state = { ...base, currentStep: "HANDOFF" as const };
+    expect(canAdvance(state)).toBe(false);
+  });
+});
+
+describe("oracleReducer", () => {
+  const base = initialOracleState();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("SET_TRACK", () => {
+    it("selects track a and advances to CONNECT_X", () => {
+      const state = oracleReducer(base, { type: "SET_TRACK", track: "a" });
+      expect(state.track).toBe("a");
+      expect(state.currentStep).toBe("CONNECT_X");
+      expect(state.selfPercentage).toBe(50);
+      expect(state.messages[state.messages.length - 1].role).toBe("user");
+      expect(state.pendingMessages.length).toBeGreaterThan(0);
+    });
+
+    it("selects track b and advances to TRACK_B_STYLE", () => {
+      const state = oracleReducer(base, { type: "SET_TRACK", track: "b" });
+      expect(state.track).toBe("b");
+      expect(state.currentStep).toBe("TRACK_B_STYLE");
+      expect(state.selfPercentage).toBe(30);
+      expect(state.messages[state.messages.length - 1].role).toBe("user");
+      expect(state.pendingMessages.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("ADVANCE", () => {
+    it("advances from WELCOME to CONNECT_X and records history", () => {
+      const state = oracleReducer(base, {
+        type: "ADVANCE",
+        payload: "Let's go",
+      });
+      expect(state.currentStep).toBe("CONNECT_X");
+      expect(state.stepHistory.length).toBe(1);
+      expect(state.stepHistory[0].step).toBe("WELCOME");
+      expect(state.messages[state.messages.length - 1].content).toBe("Let's go");
+      expect(state.pendingMessages.length).toBeGreaterThan(0);
+    });
+
+    it("does not advance from a terminal step", () => {
+      const terminal = { ...base, currentStep: "HANDOFF" as const };
+      const state = oracleReducer(terminal, { type: "ADVANCE" });
+      expect(state.currentStep).toBe("HANDOFF");
+      expect(state.stepHistory).toEqual([]);
+    });
+
+    it("caps history at 10 entries", () => {
+      // Use a synthetic non-terminal step so we can keep advancing indefinitely.
+      let state = { ...base, currentStep: "WELCOME" as const };
+      const cycle: Array<typeof base.currentStep> = [
+        "WELCOME",
+        "CONNECT_X",
+        "TRACK_B_STYLE",
+        "TRACK_B_CONTENT",
+        "TRACK_B_DIMENSIONS",
+      ];
+      for (let i = 0; i < 14; i++) {
+        const nextStep = cycle[(cycle.indexOf(state.currentStep) + 1) % cycle.length];
+        state = oracleReducer(
+          { ...state, currentStep: state.currentStep },
+          { type: "ADVANCE", payload: `step ${i}` }
+        );
+        // Force the next step so we never hit a terminal step
+        state = { ...state, currentStep: nextStep };
+      }
+      expect(state.stepHistory.length).toBe(10);
+    });
+
+    it("appends user message only when payload is provided", () => {
+      const state = oracleReducer(base, { type: "ADVANCE" });
+      expect(state.currentStep).toBe("CONNECT_X");
+      expect(state.messages.length).toBe(base.messages.length);
+    });
+  });
+
+  describe("GO_BACK", () => {
+    it("restores previous step and truncates messages", () => {
+      const s1 = oracleReducer(base, { type: "SET_TRACK", track: "a" });
+      const s2 = oracleReducer(s1, {
+        type: "ADVANCE",
+        payload: "Connected",
+      });
+      expect(s2.currentStep).toBe("TRACK_A_SCANNING");
+      expect(s2.messages.length).toBeGreaterThan(s1.messages.length);
+
+      const back = oracleReducer(s2, { type: "GO_BACK" });
+      expect(back.currentStep).toBe("CONNECT_X");
+      expect(back.messages.length).toBe(s1.messages.length);
+      expect(back.stepHistory.length).toBe(0);
+      expect(back.isTyping).toBe(false);
+      expect(back.pendingMessages).toEqual([]);
+    });
+
+    it("does nothing when history is empty", () => {
+      const state = oracleReducer(base, { type: "GO_BACK" });
+      expect(state).toEqual(base);
+    });
+
+    it("restores snapshot state including dimensions", () => {
+      const withDims = {
+        ...base,
+        dimensions: { ...DEFAULT_VOICE_DIMENSIONS, humor: 80 },
+      };
+      // ADVANCE to build history, then mutate dimensions, then go back.
+      const s1 = oracleReducer(withDims, { type: "ADVANCE", payload: "go" });
+      const s2 = oracleReducer(s1, {
+        type: "SET_DIMENSIONS",
+        dimensions: { ...DEFAULT_VOICE_DIMENSIONS, humor: 20 },
+      });
+      const back = oracleReducer(s2, { type: "GO_BACK" });
+      expect(back.currentStep).toBe("WELCOME");
+      expect(back.dimensions.humor).toBe(80);
+    });
+  });
+
+  describe("SET_HANDLE", () => {
+    it("updates xHandle", () => {
+      const state = oracleReducer(base, {
+        type: "SET_HANDLE",
+        handle: "alex",
+      });
+      expect(state.xHandle).toBe("alex");
+    });
+  });
+
+  describe("SET_X_CONNECTED", () => {
+    it("updates xConnected", () => {
+      const state = oracleReducer(base, {
+        type: "SET_X_CONNECTED",
+        connected: true,
+      });
+      expect(state.xConnected).toBe(true);
+    });
+  });
+
+  describe("SET_CALIBRATION", () => {
+    it("updates calibrationResult", () => {
+      const result = { analysis: "test", tweetsAnalyzed: 5 };
+      const state = oracleReducer(base, {
+        type: "SET_CALIBRATION",
+        result,
+      });
+      expect(state.calibrationResult).toEqual(result);
+    });
+  });
+
+  describe("SET_DIMENSIONS", () => {
+    it("updates dimensions", () => {
+      const dims = { ...DEFAULT_VOICE_DIMENSIONS, humor: 99 };
+      const state = oracleReducer(base, {
+        type: "SET_DIMENSIONS",
+        dimensions: dims,
+      });
+      expect(state.dimensions).toEqual(dims);
+    });
+  });
+
+  describe("SET_STYLE", () => {
+    it("updates selectedStyle", () => {
+      const state = oracleReducer(base, { type: "SET_STYLE", style: "Serious" });
+      expect(state.selectedStyle).toBe("Serious");
+    });
+  });
+
+  describe("SET_REFS", () => {
+    it("updates selectedRefs", () => {
+      const state = oracleReducer(base, {
+        type: "SET_REFS",
+        ids: ["ref1", "ref2"],
+      });
+      expect(state.selectedRefs).toEqual(["ref1", "ref2"]);
+    });
+  });
+
+  describe("SET_BLEND", () => {
+    it("updates selfPercentage", () => {
+      const state = oracleReducer(base, { type: "SET_BLEND", percentage: 75 });
+      expect(state.selfPercentage).toBe(75);
+    });
+  });
+
+  describe("SET_TOPICS", () => {
+    it("updates selectedTopics", () => {
+      const state = oracleReducer(base, {
+        type: "SET_TOPICS",
+        topics: ["crypto", "ai"],
+      });
+      expect(state.selectedTopics).toEqual(["crypto", "ai"]);
+    });
+  });
+
+  describe("ENQUEUE_MESSAGES", () => {
+    it("appends messages to pendingMessages", () => {
+      const msgs = [
+        { id: "1", role: "oracle" as const, content: "hello", timestamp: 1 },
+      ];
+      const state = oracleReducer(base, {
+        type: "ENQUEUE_MESSAGES",
+        messages: msgs,
+      });
+      expect(state.pendingMessages.length).toBe(base.pendingMessages.length + 1);
+      expect(state.pendingMessages[state.pendingMessages.length - 1]).toEqual(
+        msgs[0]
+      );
+    });
+  });
+
+  describe("DEQUEUE_MESSAGE", () => {
+    it("moves the first pending message to messages", () => {
+      const state = oracleReducer(base, { type: "DEQUEUE_MESSAGE" });
+      expect(state.pendingMessages.length).toBe(base.pendingMessages.length - 1);
+      expect(state.messages.length).toBe(base.messages.length + 1);
+      expect(state.isTyping).toBe(false);
+    });
+
+    it("clears isTyping when no pending messages remain", () => {
+      const emptyPending = { ...base, pendingMessages: [], isTyping: true };
+      const state = oracleReducer(emptyPending, { type: "DEQUEUE_MESSAGE" });
+      expect(state.isTyping).toBe(false);
+      expect(state.pendingMessages).toEqual([]);
+      expect(state.messages).toEqual(base.messages);
+    });
+  });
+
+  describe("SET_TYPING", () => {
+    it("updates isTyping", () => {
+      const state = oracleReducer(base, { type: "SET_TYPING", isTyping: true });
+      expect(state.isTyping).toBe(true);
+    });
+  });
+
+  describe("unknown action", () => {
+    it("returns state unchanged", () => {
+      // @ts-expect-error testing unknown action
+      const state = oracleReducer(base, { type: "UNKNOWN" });
+      expect(state).toEqual(base);
+    });
   });
 });

--- a/src/components/onboarding/ActionZone.tsx
+++ b/src/components/onboarding/ActionZone.tsx
@@ -62,7 +62,7 @@ export default function ActionZone({
             <Send className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
-      ) : actions && actions.length > 0 ? (
+      ) : (
         <div className="flex flex-wrap gap-2 justify-center items-center">
           {canGoBack && (
             <button
@@ -73,7 +73,7 @@ export default function ActionZone({
               ← Back
             </button>
           )}
-          {actions.map((action) => (
+          {actions?.map((action) => (
             <GradientButton
               key={action.value}
               variant={
@@ -87,7 +87,7 @@ export default function ActionZone({
             </GradientButton>
           ))}
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -17,7 +17,6 @@ import { styleToDimensions } from "@/lib/voice-profile-dimensions";
 import {
   getReferenceAccountLookup,
   persistReferenceSelections,
-  buildReferenceBlendVoices,
   REFERENCE_ACCOUNT_FALLBACK,
 } from "@/lib/reference-accounts";
 
@@ -29,7 +28,6 @@ import ActionZone from "./ActionZone";
 import NavBar from "@/components/ui/NavBar";
 
 // Inline components
-import TopicPicker from "./TopicPicker";
 import ReferenceVoiceSelector from "./ReferenceVoiceSelector";
 import ContentSignalsPreview from "./ContentSignalsPreview";
 import VoiceDimensionSections from "@/components/voice-profiles/VoiceDimensionSections";
@@ -56,11 +54,6 @@ export default function OracleChat() {
   const drainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [oauthLoading, setOauthLoading] = useState(false);
   const [resumeTrackAAfterOAuth, setResumeTrackAAfterOAuth] = useState(false);
-  const [blendSaveStatus, setBlendSaveStatus] = useState<
-    "idle" | "saving" | "saved" | "error"
-  >("idle");
-  // Tracks the persisted blend so future PATCH operations can target it.
-  const [, setSavedBlendId] = useState<string | null>(null);
 
   // Pre-fill handle from linked X profile
   useEffect(() => {
@@ -224,35 +217,8 @@ export default function OracleChat() {
             }
           }
         }
-        if (step === "BLEND") {
-          setBlendSaveStatus("saving");
-          try {
-            const result = await api.voice.createBlend(
-              state.track === "a" ? "Onboarding blend" : "My starting blend",
-              buildReferenceBlendVoices(
-                state.selectedRefs,
-                state.selfPercentage,
-                REFERENCE_ACCOUNT_FALLBACK
-              )
-            );
-            setSavedBlendId(result.blend.id);
-            setBlendSaveStatus("saved");
-          } catch (err) {
-            console.error("Blend persist failed:", err);
-            setBlendSaveStatus("error");
-          }
-        }
-        if (step === "TOPICS") {
-          try {
-            await api.briefing.updatePreferences({
-              deliveryTime: "08:00",
-              topics: state.selectedTopics,
-              sources: [],
-              channel: "Portal Only",
-            });
-          } catch {
-            /* optional */
-          }
+        if (step === "HANDOFF") {
+          // Persist onboarding track completion on handoff
           if (state.track === "a" || state.track === "b") {
             try {
               await api.users.updateProfile({
@@ -310,12 +276,8 @@ export default function OracleChat() {
     if (step === "TRACK_B_STYLE") echo = state.selectedStyle || undefined;
     if (step === "REFERENCES")
       echo = `Selected ${state.selectedRefs.length} references`;
-    if (step === "BLEND") echo = `${state.selfPercentage}% my voice`;
-    if (step === "TOPICS") echo = state.selectedTopics.join(", ");
 
-    if (step === "TOPICS") {
-      // Finish the wizard on the final preferences step and land users in the
-      // next surface they should act in, rather than the legacy handoff screen.
+    if (step === "HANDOFF") {
       router.replace(getOnboardingCompletionHref(state.track));
       return;
     }
@@ -492,14 +454,8 @@ export default function OracleChat() {
           return null;
 
         case "topics":
-          return (
-            <TopicPicker
-              selected={state.selectedTopics}
-              onChange={(topics) =>
-                dispatch({ type: "SET_TOPICS", topics })
-              }
-            />
-          );
+          // TOPICS step is skipped in onboarding — topic preferences are managed in Settings.
+          return null;
 
         case "content-signals":
           return (
@@ -536,17 +492,7 @@ export default function OracleChat() {
                 <GradientButton
                   fullWidth
                   onClick={() => {
-                    // Mark onboarding complete so crafting stays gated until HANDOFF.
-                    // Best-effort — navigate regardless of whether the API call succeeds.
-                    if (state.track === "a" || state.track === "b") {
-                      api.users
-                        .updateProfile({
-                          onboardingTrack:
-                            state.track === "a" ? "TRACK_A" : "TRACK_B",
-                        })
-                        .catch(() => {});
-                    }
-                    router.push(getOnboardingCompletionHref(state.track));
+                    handleContinue();
                   }}
                 >
                   Go to Dashboard
@@ -595,7 +541,7 @@ export default function OracleChat() {
           return null;
       }
     },
-    [oauthLoading, router, state, blendSaveStatus]
+    [oauthLoading, state, handleContinue]
   );
 
   // ── Determine ActionZone config per step ─────────────────────────
@@ -607,7 +553,11 @@ export default function OracleChat() {
     if (hasPending) return { disabled: true };
 
     // Terminal step — handoff has its own button inside the component
-    if (step === "HANDOFF") return {};
+    if (step === "HANDOFF") {
+      return {
+        canGoBack: state.stepHistory.length > 0,
+      };
+    }
 
     // Steps that need a Continue button
     const continueSteps = [
@@ -627,10 +577,13 @@ export default function OracleChat() {
           },
         ],
         disabled: !canAdvance(state),
+        canGoBack: state.stepHistory.length > 0,
       };
     }
 
-    return {};
+    return {
+      canGoBack: state.stepHistory.length > 0,
+    };
   };
 
   const actionConfig = getActionZoneConfig();
@@ -679,6 +632,7 @@ export default function OracleChat() {
       <ActionZone
         actions={actionConfig.actions}
         disabled={actionConfig.disabled}
+        canGoBack={actionConfig.canGoBack}
         onAction={(value) => {
           if (value === "continue") {
             handleContinue();
@@ -686,6 +640,7 @@ export default function OracleChat() {
             handleAction(value);
           }
         }}
+        onGoBack={() => dispatch({ type: "GO_BACK" })}
       />
     </div>
   );


### PR DESCRIPTION
- Wire up Back button in OracleChat (reducer already supported it)
- Clean up unreachable BLEND/TOPICS handling in OracleChat
- Fix ActionZone to render back button without action buttons
- Add comprehensive unit tests for oracleReducer, canAdvance, getContinueLabel
- Add OracleChat component tests for typing animation and navigation
