### PR TITLE
feat(crafting): multi-angle tweet generation from PDF reports

### DIFF
--- a/src/__tests__/app/CraftingPage.test.tsx
+++ b/src/__tests__/app/CraftingPage.test.tsx
@@ -49,6 +49,7 @@ jest.mock("@/lib/api", () => ({
       refine: jest.fn(),
       schedule: jest.fn(),
       postToX: jest.fn(),
+      enqueue: jest.fn(),
     },
     analytics: {
       summary: jest.fn(),
@@ -84,6 +85,7 @@ const mockedApi = api as unknown as {
     refine: jest.Mock;
     schedule: jest.Mock;
     postToX: jest.Mock;
+    enqueue: jest.Mock;
   };
   analytics: {
     summary: jest.Mock;
@@ -124,6 +126,7 @@ describe("CraftingPage", () => {
     mockedApi.drafts.refine.mockReset();
     mockedApi.drafts.schedule.mockReset();
     mockedApi.drafts.postToX.mockReset();
+    mockedApi.drafts.enqueue.mockReset();
     mockedApi.auth.x.status.mockReset();
     mockedApi.auth.x.authorize.mockReset();
     mockedApi.analytics.summary.mockReset();
@@ -509,5 +512,69 @@ describe("CraftingPage", () => {
     await screen.findByRole("textbox", { name: "Generated draft" });
 
     expect(screen.queryByRole("button", { name: "Schedule" })).not.toBeInTheDocument();
+  });
+
+  it("shows multi-angle button after pasting substantial text and opens panel on click", async () => {
+    render(<CraftingPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a tweet idea or link…"), {
+      target: { value: "a".repeat(600) },
+    });
+
+    const multiAngleButton = await screen.findByRole("button", {
+      name: "Generate Multi-Angle Tweets",
+    });
+    expect(multiAngleButton).toBeInTheDocument();
+
+    mockedApi.drafts.generate.mockResolvedValue({ draft: createDraft() });
+
+    fireEvent.click(multiAngleButton);
+
+    await waitFor(() =>
+      expect(screen.getByText("Multi-Angle Tweets")).toBeInTheDocument()
+    );
+  });
+
+  it("batch approves multi-angle drafts and refreshes the sidebar", async () => {
+    render(<CraftingPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a tweet idea or link…"), {
+      target: { value: "a".repeat(600) },
+    });
+
+    const multiAngleButton = await screen.findByRole("button", {
+      name: "Generate Multi-Angle Tweets",
+    });
+
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", content: "Angle draft content" }),
+    });
+    mockedApi.drafts.update.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", status: "APPROVED" }),
+    });
+    mockedApi.drafts.enqueue.mockResolvedValue({
+      draft: createDraft({ id: "draft-angle-1", status: "APPROVED" }),
+    });
+
+    fireEvent.click(multiAngleButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Angle draft content").length).toBeGreaterThan(0)
+    );
+
+    const batchApproveButton = screen.getByRole("button", {
+      name: "Approve 5 to Queue",
+    });
+    fireEvent.click(batchApproveButton);
+
+    await waitFor(() =>
+      expect(mockedApi.drafts.update).toHaveBeenCalledWith(
+        "draft-angle-1",
+        expect.objectContaining({ status: "APPROVED" })
+      )
+    );
+    await waitFor(() =>
+      expect(mockedApi.drafts.enqueue).toHaveBeenCalledWith("draft-angle-1")
+    );
   });
 });

--- a/src/__tests__/components/crafting/MultiAnglePanel.test.tsx
+++ b/src/__tests__/components/crafting/MultiAnglePanel.test.tsx
@@ -1,0 +1,162 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MultiAnglePanel } from "@/components/crafting/MultiAnglePanel";
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    drafts: {
+      generate: jest.fn(),
+      update: jest.fn(),
+      enqueue: jest.fn(),
+    },
+  },
+}));
+
+const { api } = require("@/lib/api");
+const mockedApi = api as unknown as {
+  drafts: {
+    generate: jest.Mock;
+    update: jest.Mock;
+    enqueue: jest.Mock;
+  };
+};
+
+function createDraft(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `draft-${Math.random().toString(36).slice(2)}`,
+    content: "Generated draft content",
+    version: 1,
+    status: "DRAFT",
+    createdAt: "2026-04-03T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("MultiAnglePanel", () => {
+  beforeEach(() => {
+    mockedApi.drafts.generate.mockReset();
+    mockedApi.drafts.update.mockReset();
+    mockedApi.drafts.enqueue.mockReset();
+  });
+
+  it("generates 5 angles on mount and renders them in a grid", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft(),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Some report content that is long enough"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Contrarian")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Bullish")).toBeInTheDocument();
+    expect(screen.getByText("Educational")).toBeInTheDocument();
+    expect(screen.getByText("Data-led")).toBeInTheDocument();
+    expect(screen.getByText("Narrative")).toBeInTheDocument();
+  });
+
+  it("allows editing draft content", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ content: "Original angle content" }),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByDisplayValue("Original angle content").length).toBeGreaterThan(0)
+    );
+
+    const textarea = screen.getAllByDisplayValue("Original angle content")[0];
+    fireEvent.change(textarea, { target: { value: "Edited angle content" } });
+    fireEvent.blur(textarea);
+
+    expect(textarea).toHaveValue("Edited angle content");
+  });
+
+  it("batch approves selected drafts and calls update + enqueue", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", content: "Angle one" }),
+    });
+    mockedApi.drafts.update.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", status: "APPROVED" }),
+    });
+    mockedApi.drafts.enqueue.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", status: "APPROVED" }),
+    });
+
+    const onDraftsCreated = jest.fn();
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+        onDraftsCreated={onDraftsCreated}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Approve 5 to Queue" })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve 5 to Queue" }));
+
+    await waitFor(() =>
+      expect(mockedApi.drafts.update).toHaveBeenCalledTimes(5)
+    );
+    await waitFor(() =>
+      expect(mockedApi.drafts.enqueue).toHaveBeenCalledTimes(5)
+    );
+
+    expect(onDraftsCreated).toHaveBeenCalled();
+  });
+
+  it("allows discarding a draft and removes it from selection", async () => {
+    mockedApi.drafts.generate.mockResolvedValue({
+      draft: createDraft({ id: "draft-1", content: "Angle one" }),
+    });
+
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByLabelText("Discard draft").length).toBeGreaterThan(0)
+    );
+
+    const discardButtons = screen.getAllByLabelText("Discard draft");
+    fireEvent.click(discardButtons[0]);
+
+    await waitFor(() =>
+      expect(screen.getByText(/4 angles ready/i)).toBeInTheDocument()
+    );
+  });
+
+  it("calls onError when generation fails", async () => {
+    mockedApi.drafts.generate.mockRejectedValue(new Error("Generation failed"));
+
+    const onError = jest.fn();
+    render(
+      <MultiAnglePanel
+        sourceContent="Report text"
+        sourceType="REPORT"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith("Generation failed")
+    );
+  });
+});

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -54,6 +54,7 @@ import { hasCalibratedVoiceDimensions } from "@/lib/voice-profile-dimensions";
 import OracleWidget from "@/components/oracle/OracleWidget";
 import OracleCraftingHints from "@/components/oracle/OracleCraftingHints";
 import OracleInspector from "@/components/oracle/OracleInspector";
+import { MultiAnglePanel } from "@/components/crafting/MultiAnglePanel";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
 import { useToast } from "@/components/ui/Toast";
 import { SchedulePopover } from "@/components/ui/SchedulePopover";
@@ -304,6 +305,11 @@ function CraftingPage() {
   const [urlPreview, setUrlPreview] = useState<{
     title?: string;
     url: string;
+  } | null>(null);
+  const [showMultiAngle, setShowMultiAngle] = useState(false);
+  const [multiAngleSource, setMultiAngleSource] = useState<{
+    content: string;
+    sourceType: DraftSourceType;
   } | null>(null);
   const activeDraftInitialized = useRef(false);
   const copyResetTimeoutRef = useRef<number | null>(null);
@@ -669,7 +675,13 @@ function CraftingPage() {
     if (sourceError && trimmedText) {
       setSourceError("");
     }
-  }, [contentError, sourceError]);
+
+    if (activeMode === "new_post" && trimmedText.length > 500) {
+      setMultiAngleSource({ content: text, sourceType: "MANUAL" });
+    } else if (activeMode === "new_post" && !trimmedText) {
+      setMultiAngleSource(null);
+    }
+  }, [activeMode, contentError, sourceError]);
   handleDraftTextChangeRef.current = handleDraftTextChange;
 
   const createDraftFromSource = useCallback(async (
@@ -795,6 +807,14 @@ function CraftingPage() {
 
       setError(null);
       handleDraftTextChange(text);
+      // Auto-trigger multi-angle for PDFs; for other files only if substantial text
+      const isPdf = file.type === "application/pdf" || file.name.endsWith(".pdf");
+      if (isPdf && activeMode === "new_post") {
+        setMultiAngleSource({ content: text, sourceType: "REPORT" });
+        setShowMultiAngle(true);
+      } else if (text.length > 500 && activeMode === "new_post") {
+        setMultiAngleSource({ content: text, sourceType: "MANUAL" });
+      }
     } catch (fileDropError: unknown) {
       console.error("Failed to process file:", fileDropError);
       setError(
@@ -803,7 +823,7 @@ function CraftingPage() {
           : "Failed to process file. Try pasting the content instead."
       );
     }
-  }, [handleDraftTextChange]);
+  }, [handleDraftTextChange, activeMode]);
 
   const handleFileDrop = useCallback(async (files: FileList) => {
     if (files.length === 0) {
@@ -1636,6 +1656,17 @@ function CraftingPage() {
                       Craft with Atlas
                     </button>
                   )}
+                  {activeMode === "new_post" && multiAngleSource && !showMultiAngle && (
+                    <button
+                      type="button"
+                      onClick={() => setShowMultiAngle(true)}
+                      disabled={creating || isVoiceCalibrationBlocked}
+                      className="mt-2 w-full inline-flex items-center justify-center gap-2 rounded-xl border border-atlas-teal/20 bg-atlas-teal/5 px-4 py-2.5 text-sm font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/10 hover:border-atlas-teal/40 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      Generate Multi-Angle Tweets
+                    </button>
+                  )}
                   {error ? (
                     <div
                       role="alert"
@@ -1657,6 +1688,22 @@ function CraftingPage() {
                       <span>{blendWarning}</span>
                       <button type="button" onClick={() => setBlendWarning(null)} aria-label="Dismiss" className="ml-2 hover:text-atlas-text"><X className="h-3.5 w-3.5" aria-hidden="true" /></button>
                     </div>
+                  )}
+                  {showMultiAngle && multiAngleSource && (
+                    <MultiAnglePanel
+                      sourceContent={multiAngleSource.content}
+                      sourceType={multiAngleSource.sourceType}
+                      blendId={selectedBlendId}
+                      disabled={creating || isVoiceCalibrationBlocked}
+                      onDraftsCreated={() => {
+                        void loadDrafts();
+                      }}
+                      onError={(message) => setError(message)}
+                      onClose={() => {
+                        setShowMultiAngle(false);
+                        setMultiAngleSource(null);
+                      }}
+                    />
                   )}
                 </div>
               </div>

--- a/src/components/crafting/MultiAnglePanel.tsx
+++ b/src/components/crafting/MultiAnglePanel.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState } from "react";
+import { Loader2, X, CheckCircle2, Sparkles } from "lucide-react";
+import { api, type TweetDraft } from "@/lib/api";
+import { TweetAngleCard, type AngleDraftItem } from "./TweetAngleCard";
+
+const ANGLE_CONFIGS = [
+  {
+    label: "Contrarian",
+    instruction:
+      "Write a contrarian take that challenges the main narrative or consensus view in this report. Be sharp but credible.",
+  },
+  {
+    label: "Bullish",
+    instruction:
+      "Write a bullish, optimistic take highlighting opportunities, upside, or positive implications from this report.",
+  },
+  {
+    label: "Educational",
+    instruction:
+      "Write an educational tweet that explains the most important concept from this report simply and clearly.",
+  },
+  {
+    label: "Data-led",
+    instruction:
+      "Write a data-led tweet focusing on the key numbers, statistics, or metrics from this report.",
+  },
+  {
+    label: "Narrative",
+    instruction:
+      "Write a narrative-driven tweet that tells the story or human impact behind this report.",
+  },
+];
+
+interface MultiAnglePanelProps {
+  sourceContent: string;
+  sourceType: string;
+  blendId?: string | null;
+  disabled?: boolean;
+  onDraftsCreated?: () => void;
+  onError?: (message: string) => void;
+  onClose?: () => void;
+}
+
+export function MultiAnglePanel({
+  sourceContent,
+  sourceType,
+  blendId,
+  disabled = false,
+  onDraftsCreated,
+  onError,
+  onClose,
+}: MultiAnglePanelProps) {
+  const [items, setItems] = useState<AngleDraftItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchApproving, setBatchApproving] = useState(false);
+  const [successCount, setSuccessCount] = useState<number | null>(null);
+  const titleId = useId();
+
+  const generateAngles = useCallback(async () => {
+    if (!sourceContent.trim()) return;
+
+    setLoading(true);
+    setSuccessCount(null);
+    setItems([]);
+    setSelectedIds(new Set());
+
+    try {
+      const results = await Promise.all(
+        ANGLE_CONFIGS.map(async (config) => {
+          const { draft } = await api.drafts.generate({
+            sourceContent,
+            sourceType,
+            blendId: blendId || undefined,
+            angleInstruction: config.instruction,
+          });
+          return {
+            id: `${config.label}-${draft.id}`,
+            draft,
+            angleLabel: config.label,
+            discarded: false,
+          } as AngleDraftItem;
+        })
+      );
+      setItems(results);
+      // Auto-select all by default
+      setSelectedIds(new Set(results.map((r) => r.id)));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to generate angle drafts";
+      onError?.(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sourceContent, sourceType, blendId, onError]);
+
+  useEffect(() => {
+    void generateAngles();
+  }, [generateAngles]);
+
+  const activeItems = items.filter((i) => !i.discarded);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setSelectedIds(new Set(activeItems.map((i) => i.id)));
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
+  };
+
+  const updateItemContent = (id: string, content: string) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, draft: { ...item.draft, content } } : item
+      )
+    );
+  };
+
+  const discardItem = (id: string) => {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, discarded: true } : item))
+    );
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const approveItem = async (id: string) => {
+    const item = items.find((i) => i.id === id);
+    if (!item) return;
+
+    try {
+      await api.drafts.update(item.draft.id, {
+        content: item.draft.content,
+        status: "APPROVED",
+      });
+      await api.drafts.enqueue(item.draft.id);
+      setItems((prev) =>
+        prev.map((i) => (i.id === id ? { ...i, discarded: true } : i))
+      );
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to approve draft";
+      onError?.(message);
+    }
+  };
+
+  const handleBatchApprove = async () => {
+    if (selectedIds.size === 0) return;
+
+    setBatchApproving(true);
+    let approved = 0;
+
+    try {
+      const toApprove = items.filter(
+        (i) => selectedIds.has(i.id) && !i.discarded
+      );
+      await Promise.all(
+        toApprove.map(async (item) => {
+          await api.drafts.update(item.draft.id, {
+            content: item.draft.content,
+            status: "APPROVED",
+          });
+          await api.drafts.enqueue(item.draft.id);
+          approved++;
+        })
+      );
+
+      setItems((prev) =>
+        prev.map((i) =>
+          selectedIds.has(i.id) ? { ...i, discarded: true } : i
+        )
+      );
+      setSelectedIds(new Set());
+      setSuccessCount(approved);
+      onDraftsCreated?.();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Batch approval failed";
+      onError?.(message);
+    } finally {
+      setBatchApproving(false);
+    }
+  };
+
+  const allSelected =
+    activeItems.length > 0 && activeItems.every((i) => selectedIds.has(i.id));
+
+  return (
+    <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface p-5 sm:p-6">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 id={titleId} className="font-heading text-lg font-bold text-atlas-text">
+            Multi-Angle Tweets
+          </h3>
+          <p className="text-sm text-atlas-text-secondary">
+            {loading
+              ? "Generating 5 different angles from your report…"
+              : activeItems.length > 0
+                ? `${activeItems.length} angle${activeItems.length !== 1 ? "s" : ""} ready. Edit, select, and approve.`
+                : items.length > 0
+                  ? "All drafts have been handled."
+                  : "No angles generated yet."}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {!loading && activeItems.length > 0 && (
+            <label className="flex cursor-pointer items-center gap-1.5 text-xs text-atlas-text-muted hover:text-atlas-text-secondary">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={() => (allSelected ? clearSelection() : selectAll())}
+                className="h-4 w-4 accent-atlas-teal"
+              />
+              Select all
+            </label>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-text"
+            aria-label="Close panel"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {successCount !== null && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-atlas-teal/30 bg-atlas-teal/10 px-3 py-2 text-sm text-atlas-teal">
+          <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+          {successCount} draft{successCount !== 1 ? "s" : ""} approved and added to queue.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {ANGLE_CONFIGS.map((config) => (
+            <div
+              key={config.label}
+              className="h-48 animate-pulse rounded-2xl border border-glass-border bg-atlas-surface/50"
+              aria-hidden="true"
+            >
+              <div className="p-5">
+                <div className="mb-3 h-5 w-20 rounded bg-atlas-nav" />
+                <div className="space-y-2">
+                  <div className="h-3 w-full rounded bg-atlas-nav" />
+                  <div className="h-3 w-5/6 rounded bg-atlas-nav" />
+                  <div className="h-3 w-4/6 rounded bg-atlas-nav" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => (
+            <TweetAngleCard
+              key={item.id}
+              item={item}
+              selected={selectedIds.has(item.id)}
+              disabled={disabled || batchApproving}
+              isApproving={batchApproving}
+              onToggleSelect={() => toggleSelect(item.id)}
+              onChangeContent={(content) => updateItemContent(item.id, content)}
+              onApprove={() => void approveItem(item.id)}
+              onDiscard={() => discardItem(item.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && activeItems.length === 0 && items.length > 0 && (
+        <div className="mt-6 text-center text-sm text-atlas-text-secondary">
+          All angles approved or discarded.
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-2 text-atlas-teal hover:underline"
+          >
+            Close panel
+          </button>
+        </div>
+      )}
+
+      {/* Floating batch action bar */}
+      {selectedIds.size > 0 && !loading && (
+        <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-2xl border border-glass-border bg-atlas-nav/95 px-5 py-3 shadow-xl backdrop-blur-xl">
+          <Sparkles className="h-4 w-4 text-atlas-teal" aria-hidden="true" />
+          <span className="text-sm text-atlas-text">
+            {selectedIds.size} selected
+          </span>
+          <button
+            type="button"
+            onClick={() => void handleBatchApprove()}
+            disabled={batchApproving || disabled}
+            className="rounded-lg bg-atlas-teal px-4 py-2 text-sm font-semibold text-atlas-bg transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {batchApproving ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                Approving…
+              </span>
+            ) : (
+              `Approve ${selectedIds.size} to Queue`
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={clearSelection}
+            disabled={batchApproving}
+            className="rounded-lg border border-glass-border px-3 py-2 text-xs text-atlas-text-muted transition-colors hover:text-atlas-text disabled:opacity-50"
+            aria-label="Clear selection"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/crafting/TweetAngleCard.tsx
+++ b/src/components/crafting/TweetAngleCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Loader2, Trash2, CheckCircle2 } from "lucide-react";
+import type { TweetDraft } from "@/lib/api";
+
+export interface AngleDraftItem {
+  id: string;
+  draft: TweetDraft;
+  angleLabel: string;
+  discarded: boolean;
+}
+
+interface TweetAngleCardProps {
+  item: AngleDraftItem;
+  selected: boolean;
+  disabled: boolean;
+  isApproving: boolean;
+  onToggleSelect: () => void;
+  onChangeContent: (content: string) => void;
+  onApprove: () => void;
+  onDiscard: () => void;
+}
+
+const ANGLE_COLORS: Record<string, string> = {
+  Contrarian: "bg-orange-500/15 text-orange-300 border-orange-500/25",
+  Bullish: "bg-emerald-500/15 text-emerald-300 border-emerald-500/25",
+  Educational: "bg-violet-500/15 text-violet-300 border-violet-500/25",
+  "Data-led": "bg-blue-500/15 text-blue-300 border-blue-500/25",
+  Narrative: "bg-teal-500/15 text-teal-300 border-teal-500/25",
+};
+
+export function TweetAngleCard({
+  item,
+  selected,
+  disabled,
+  isApproving,
+  onToggleSelect,
+  onChangeContent,
+  onApprove,
+  onDiscard,
+}: TweetAngleCardProps) {
+  const [localContent, setLocalContent] = useState(item.draft.content);
+  const angleClass =
+    ANGLE_COLORS[item.angleLabel] ??
+    "bg-atlas-text-muted/15 text-atlas-text-muted border-atlas-text-muted/25";
+
+  const charCount = localContent.length;
+  const isOverLimit = charCount > 280;
+
+  const handleBlur = () => {
+    if (localContent !== item.draft.content) {
+      onChangeContent(localContent);
+    }
+  };
+
+  if (item.discarded) {
+    return null;
+  }
+
+  return (
+    <div className="relative rounded-2xl border border-glass-border bg-glass p-5 backdrop-blur-xl transition-colors hover:border-atlas-teal/20">
+      {/* Header: checkbox + badge + actions */}
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex flex-1 items-center gap-2 flex-wrap">
+          <button
+            type="button"
+            onClick={onToggleSelect}
+            disabled={disabled}
+            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors ${
+              selected
+                ? "border-atlas-teal bg-atlas-teal"
+                : "border-white/20 bg-transparent hover:border-white/40"
+            } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+            aria-label={selected ? "Deselect draft" : "Select draft"}
+          >
+            {selected && (
+              <Check className="h-3.5 w-3.5 text-white" aria-hidden="true" />
+            )}
+          </button>
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${angleClass}`}
+          >
+            {item.angleLabel}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onApprove}
+            disabled={disabled || isApproving}
+            className="inline-flex items-center gap-1 rounded-lg border border-atlas-teal/30 px-2.5 py-1 text-[11px] font-medium text-atlas-teal transition-colors hover:bg-atlas-teal/10 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Approve to queue"
+          >
+            {isApproving ? (
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+            )}
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={disabled}
+            className="rounded-lg p-1.5 text-atlas-text-muted transition-colors hover:text-atlas-error disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Discard draft"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Editable content */}
+      <textarea
+        value={localContent}
+        onChange={(e) => setLocalContent(e.target.value)}
+        onBlur={handleBlur}
+        disabled={disabled}
+        rows={5}
+        className="w-full resize-none rounded-lg border border-glass-border bg-atlas-surface/60 px-3 py-2.5 text-sm leading-relaxed text-atlas-text placeholder:text-atlas-text-muted focus:border-atlas-teal focus:outline-none disabled:opacity-60"
+      />
+
+      {/* Footer: char count */}
+      <div className="mt-2 flex items-center justify-between">
+        <span
+          className={`text-xs font-mono ${
+            isOverLimit
+              ? "text-atlas-error"
+              : charCount > 250
+                ? "text-atlas-warning"
+                : "text-atlas-text-muted"
+          }`}
+        >
+          {charCount}/280
+        </span>
+        {isOverLimit && (
+          <span className="text-xs text-atlas-error">
+            {charCount - 280} over limit
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add MultiAnglePanel and TweetAngleCard components
- Generate 5 parallel drafts (contrarian, bullish, educational, data-led, narrative)
- Show editable grid with per-card and batch-approve-to-queue actions
- Integrate into Crafting page triggered by PDF upload or substantial text paste
- Add tests for MultiAnglePanel and CraftingPage integration
