### PR TITLE
feat(queue): add Smart Queue Ranking with lightweight engagement scorer

### DIFF
--- a/src/__tests__/lib/queue-rank.test.ts
+++ b/src/__tests__/lib/queue-rank.test.ts
@@ -1,0 +1,100 @@
+import { computeQueueRank, rankQueue } from "@/lib/queue-rank";
+import type { QueuedDraft } from "@/lib/api";
+
+function makeDraft(
+  overrides: Partial<QueuedDraft> = {}
+): QueuedDraft {
+  const now = new Date();
+  return {
+    id: "d1",
+    content: "Test draft",
+    version: 1,
+    status: "DRAFT",
+    confidence: 0.8,
+    predictedEngagement: 10,
+    actualEngagement: undefined,
+    sourceType: "MANUAL",
+    createdAt: now.toISOString(),
+    _score: 0,
+    suggestedAt: now.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("computeQueueRank", () => {
+  it("returns empty array for empty input", () => {
+    expect(computeQueueRank([])).toEqual([]);
+  });
+
+  it("assigns higher rank score to higher confidence drafts", () => {
+    const low = makeDraft({ id: "low", confidence: 0.2 });
+    const high = makeDraft({ id: "high", confidence: 0.95 });
+    const ranked = computeQueueRank([low, high]);
+    const lowScore = ranked.find((d) => d.id === "low")!._rankScore;
+    const highScore = ranked.find((d) => d.id === "high")!._rankScore;
+    expect(highScore).toBeGreaterThan(lowScore);
+  });
+
+  it("assigns higher rank score to peak-hour drafts", () => {
+    const now = new Date();
+    const offPeak = makeDraft({
+      id: "off",
+      suggestedAt: new Date(now.setHours(3, 0, 0, 0)).toISOString(),
+    });
+    const peak = makeDraft({
+      id: "peak",
+      suggestedAt: new Date(now.setHours(14, 0, 0, 0)).toISOString(),
+    });
+    const ranked = computeQueueRank([offPeak, peak]);
+    const offScore = ranked.find((d) => d.id === "off")!._rankBreakdown.timeliness;
+    const peakScore = ranked.find((d) => d.id === "peak")!._rankBreakdown.timeliness;
+    expect(peakScore).toBeGreaterThan(offScore);
+  });
+
+  it("uses actualEngagement over predictedEngagement when available", () => {
+    const predictedOnly = makeDraft({
+      id: "pred",
+      predictedEngagement: 5,
+      actualEngagement: undefined,
+    });
+    const withActual = makeDraft({
+      id: "actual",
+      predictedEngagement: 5,
+      actualEngagement: 50,
+    });
+    const ranked = computeQueueRank([predictedOnly, withActual]);
+    const predPerf = ranked.find((d) => d.id === "pred")!._rankBreakdown.performance;
+    const actualPerf = ranked.find((d) => d.id === "actual")!._rankBreakdown.performance;
+    expect(actualPerf).toBeGreaterThan(predPerf);
+  });
+
+  it("normalizes _score to 0-1 range", () => {
+    const draft = makeDraft({ confidence: 1, predictedEngagement: 100 });
+    const ranked = computeQueueRank([draft]);
+    expect(ranked[0]._score).toBeGreaterThan(0);
+    expect(ranked[0]._score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("rankQueue", () => {
+  it("sorts drafts by descending rank score", () => {
+    const now = new Date();
+    const a = makeDraft({
+      id: "a",
+      confidence: 0.2,
+      predictedEngagement: 1,
+      createdAt: new Date(now.getTime() - 48 * 3600000).toISOString(),
+      suggestedAt: new Date(now.setHours(3, 0, 0, 0)).toISOString(),
+    });
+    const b = makeDraft({
+      id: "b",
+      confidence: 0.95,
+      predictedEngagement: 100,
+      createdAt: now.toISOString(),
+      suggestedAt: new Date(now.setHours(14, 0, 0, 0)).toISOString(),
+    });
+    const ranked = rankQueue([a, b]);
+    expect(ranked[0].id).toBe("b");
+    expect(ranked[1].id).toBe("a");
+  });
+});

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
   X,
   Send,
+  Sparkles,
 } from "lucide-react";
 import {
   DndContext,
@@ -38,6 +39,7 @@ import OracleInspector from "@/components/oracle/OracleInspector";
 import type { InspectableEntity } from "@/lib/oracle-agent-types";
 import { api, QueuedDraft } from "@/lib/api";
 import { SchedulePopover } from "@/components/ui/SchedulePopover";
+import { rankQueue } from "@/lib/queue-rank";
 
 type FilterKey = "all" | "draft" | "scheduled" | "posted" | "archived";
 
@@ -429,6 +431,17 @@ function QueuePage() {
     }
   }, []);
 
+  const handleRank = useCallback(async () => {
+    const ranked = rankQueue(queue);
+    setQueue(ranked);
+    setIsManualOrder(true);
+    try {
+      await api.drafts.reorderQueue(ranked.map((d) => d.id));
+    } catch (err) {
+      console.error("Failed to persist ranked order:", err);
+    }
+  }, [queue]);
+
   // Filter logic — "all" and "scheduled" use the ranked queue, every other
   // status pulls from the full draft list so users can manage the entire pipeline.
   const filteredQueue = useMemo(() => {
@@ -541,6 +554,17 @@ function QueuePage() {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {/* Smart Rank */}
+          {draggable && (
+            <button
+              onClick={() => void handleRank()}
+              className="flex items-center gap-1 rounded-full border border-glass-border px-3 py-1 text-xs font-medium text-atlas-text-muted transition-colors hover:border-atlas-teal hover:text-atlas-teal"
+              aria-label="Rank queue by predicted engagement"
+            >
+              <Sparkles className="h-3 w-3" />
+              Rank
+            </button>
+          )}
           {/* Reset to Auto */}
           {isManualOrder && draggable && (
             <button

--- a/src/lib/queue-rank.ts
+++ b/src/lib/queue-rank.ts
@@ -1,0 +1,62 @@
+import { QueuedDraft } from "./api";
+
+const PEAK_HOURS = [9, 10, 13, 14, 19, 20];
+
+export interface RankedDraft extends QueuedDraft {
+  _rankScore: number;
+  _rankBreakdown: {
+    voiceFit: number;
+    timeliness: number;
+    performance: number;
+  };
+}
+
+export function computeQueueRank(drafts: QueuedDraft[]): RankedDraft[] {
+  if (drafts.length === 0) return [];
+
+  const engagements = drafts.map(
+    (d) => d.actualEngagement ?? d.predictedEngagement ?? 0
+  );
+  const maxEngagement = Math.max(...engagements, 1);
+  const now = Date.now();
+
+  return drafts.map((draft) => {
+    const suggested = new Date(draft.suggestedAt);
+    const hour = suggested.getHours();
+    const isPeak = PEAK_HOURS.includes(hour);
+
+    // Voice fit: confidence (0-1) scaled to 0-35 pts
+    const voiceFit = (draft.confidence ?? 0.5) * 35;
+
+    // Timeliness: peak-hour bonus + recency decay -> 0-35 pts
+    const peakBonus = isPeak ? 20 : 0;
+    const ageHours = Math.max(
+      0,
+      (now - new Date(draft.createdAt).getTime()) / 36e5
+    );
+    const recencyBonus = Math.max(0, 15 - ageHours * 0.5);
+    const timeliness = Math.min(35, peakBonus + recencyBonus);
+
+    // Performance: normalized engagement vs batch max -> 0-30 pts
+    const engagement = draft.actualEngagement ?? draft.predictedEngagement ?? 0;
+    const performance = Math.min(30, (engagement / maxEngagement) * 30);
+
+    const total = voiceFit + timeliness + performance;
+
+    return {
+      ...draft,
+      _score: total / 100,
+      _rankScore: total,
+      _rankBreakdown: {
+        voiceFit,
+        timeliness,
+        performance,
+      },
+    };
+  });
+}
+
+export function rankQueue(drafts: QueuedDraft[]): RankedDraft[] {
+  const ranked = computeQueueRank(drafts);
+  return ranked.sort((a, b) => b._rankScore - a._rankScore);
+}


### PR DESCRIPTION
- Add computeQueueRank/rankQueue utility scoring by voice fit,
  topic timeliness (peak hours + recency), and past performance
- Add Rank button to /queue page to sort drafts by predicted engagement
- Persist reordered queue to backend after ranking
- Include unit tests for scoring logic
