### PR TITLE
ci: post-deploy smoke + env contract gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm run lint
       - run: npm test
+      - run: npm run env:check
       - run: npm run build
 
   resolve-preview:

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,13 @@
+name: Post-Deploy Smoke
+
+on:
+  deployment_status:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run post-deploy smoke tests
+        run: bash scripts/smoke.sh "${{ github.event.deployment_status.target_url }}"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:e2e:extended": "playwright test --config=playwright-e2e.config.ts",
     "test:e2e:a11y": "playwright test --config=playwright-e2e.config.ts --project=a11y",
     "test:e2e:visual": "playwright test --config=playwright-e2e.config.ts --project=visual",
-    "test:e2e:visual:update": "playwright test --config=playwright-e2e.config.ts --project=visual --project=responsive --update-snapshots"
+    "test:e2e:visual:update": "playwright test --config=playwright-e2e.config.ts --project=visual --project=responsive --update-snapshots",
+    "smoke": "bash scripts/smoke.sh",
+    "env:check": "node scripts/env-contract.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/env-contract.mjs
+++ b/scripts/env-contract.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * env-contract.mjs
+ *
+ * Asserts that public/backend API URLs do not contain private/internal
+ * hostnames that would leak at build time or fail in the browser.
+ *
+ * Incident context: DNS_HOSTNAME_RESOLVED_PRIVATE — Apr 15 2026
+ */
+
+const VIOLATIONS = [];
+
+function check(name, value) {
+  if (!value) return;
+  const lower = value.toLowerCase();
+  if (lower.includes(".railway.internal")) {
+    VIOLATIONS.push(`${name} contains .railway.internal: ${value}`);
+  }
+  if (lower.includes("localhost")) {
+    VIOLATIONS.push(`${name} contains localhost: ${value}`);
+  }
+}
+
+check("NEXT_PUBLIC_API_URL", process.env.NEXT_PUBLIC_API_URL);
+check("BACKEND_API_URL", process.env.BACKEND_API_URL);
+
+if (VIOLATIONS.length > 0) {
+  console.error("ENV CONTRACT VIOLATION:");
+  for (const v of VIOLATIONS) {
+    console.error("  - " + v);
+  }
+  process.exit(1);
+}
+
+console.log("ENV CONTRACT OK");
+process.exit(0);

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SMOKE_URL="${1:-https://delphi-atlas.vercel.app}"
+SMOKE_URL="${SMOKE_URL%/}"
+
+FAILED=0
+
+check_route() {
+  local path="$1"
+  local expected="$2"
+  local url="${SMOKE_URL}${path}"
+
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
+
+  case "$expected" in
+    exact-200)
+      if [ "$status" -eq 200 ]; then
+        echo "PASS  $path  ($status)"
+      else
+        echo "FAIL  $path  ($status)"
+        FAILED=1
+      fi
+      ;;
+    200-or-redirect)
+      if [ "$status" -eq 200 ] || [ "$status" -eq 301 ] || [ "$status" -eq 302 ] || [ "$status" -eq 307 ] || [ "$status" -eq 308 ]; then
+        echo "PASS  $path  ($status)"
+      else
+        echo "FAIL  $path  ($status)"
+        FAILED=1
+      fi
+      ;;
+    auth-login)
+      if [ "$status" -eq 200 ] || [ "$status" -eq 301 ] || [ "$status" -eq 302 ] || [ "$status" -eq 307 ] || [ "$status" -eq 308 ]; then
+        echo "PASS  $path  ($status)"
+      else
+        echo "FAIL  $path  ($status)"
+        FAILED=1
+      fi
+      ;;
+    health)
+      if [ "$status" -eq 200 ]; then
+        echo "PASS  $path  ($status)"
+      elif [ "$status" -eq 404 ]; then
+        echo "PASS  $path  ($status) — skipped (not deployed)"
+      else
+        echo "FAIL  $path  ($status)"
+        FAILED=1
+      fi
+      ;;
+    oracle-session)
+      if [ "$status" -eq 200 ] || [ "$status" -eq 401 ]; then
+        echo "PASS  $path  ($status)"
+      else
+        echo "FAIL  $path  ($status)"
+        FAILED=1
+      fi
+      ;;
+    *)
+      echo "FAIL  $path  (unknown expectation: $expected)"
+      FAILED=1
+      ;;
+  esac
+}
+
+echo "Smoking $SMOKE_URL ..."
+echo ""
+
+check_route "/"                    exact-200
+check_route "/dashboard"           200-or-redirect
+check_route "/voice"               200-or-redirect
+check_route "/analytics"           200-or-redirect
+check_route "/admin/bugs"          200-or-redirect
+check_route "/api/auth/x/login"    auth-login
+check_route "/api/health"          health
+check_route "/api/oracle/session"  oracle-session
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "SMOKE PASSED"
+  exit 0
+else
+  echo "SMOKE FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds a post-deploy smoke suite and a build-time env-contract gate to prevent private/internal hostnames from leaking into production builds.

## Routes covered

| Route | Expected |
|-------|----------|
| `/` | 200 |
| `/dashboard` | 200 or redirect |
| `/voice` | 200 or redirect |
| `/analytics` | 200 or redirect |
| `/admin/bugs` | 200 or redirect |
| `/api/auth/x/login` | 302 or 200 (NEVER 404/500) |
| `/api/health` | 200 if exists; skip if 404 |
| `/api/oracle/session` | 200 or 401 (500 = fail) |

## Why

On 2026-04-15 we hit a `DNS_HOSTNAME_RESOLVED_PRIVATE` incident on Vercel because `NEXT_PUBLIC_API_URL` contained a `.railway.internal` hostname. This caused all `/api/*` rewrites to 404 in production. The new smoke test runs automatically after every successful Production deployment and will catch this class of failure immediately. The `env-contract.mjs` gate asserts at build time that `NEXT_PUBLIC_API_URL` and `BACKEND_API_URL` never contain `.railway.internal` or `localhost`.

## Changes
- `scripts/smoke.sh` — curl-based smoke suite (exit 1 on any failure)
- `scripts/env-contract.mjs` — Node env validator (runs in CI pre-build)
- `.github/workflows/post-deploy-smoke.yml` — `deployment_status` trigger for Production
- `.github/workflows/ci.yml` — adds `npm run env:check` before build