### PR TITLE
fix(oracle): cancel race in createTextStream (onboarding/dashboard crash fix)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,11 @@
 process.env.NEXT_PUBLIC_API_URL = "http://localhost:3001";
 
+// Polyfill ReadableStream for jsdom (Node 18+)
+if (typeof ReadableStream === "undefined") {
+  const { ReadableStream } = require("node:stream/web");
+  global.ReadableStream = ReadableStream;
+}
+
 // Polyfill HTMLDialogElement methods for jsdom
 if (typeof HTMLDialogElement !== "undefined") {
   if (!HTMLDialogElement.prototype.showModal) {

--- a/src/lib/__tests__/oracle-stream.test.ts
+++ b/src/lib/__tests__/oracle-stream.test.ts
@@ -53,3 +53,37 @@ test("AbortController abort during stream stops further yields", async () => {
   // After abort, the stream errors so subsequent reads reject.
   await expect(r.read()).rejects.toThrow();
 });
+
+test("AbortController before first yield of async iterator yields nothing", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const s = createTextStream("a b c", 10, controller.signal);
+  const chunks: string[] = [];
+  for await (const chunk of s as unknown as AsyncIterable<string>) {
+    chunks.push(chunk);
+  }
+  expect(chunks).toEqual([]);
+});
+
+test("reader.cancel then AbortController.abort is idempotent", async () => {
+  const controller = new AbortController();
+  const s = createTextStream("a b c d e f g h", 10, controller.signal);
+  const r = s.getReader();
+  await r.read();
+  await r.cancel();
+  controller.abort();
+  await new Promise((res) => setTimeout(res, 100));
+  expect(true).toBe(true);
+});
+
+test("AbortController.abort then reader.cancel is idempotent", async () => {
+  const controller = new AbortController();
+  const s = createTextStream("a b c d e f g h", 10, controller.signal);
+  const r = s.getReader();
+  await r.read();
+  controller.abort();
+  // reader.cancel() on an already-errored stream may reject; swallow it.
+  await r.cancel().catch(() => {});
+  await new Promise((res) => setTimeout(res, 100));
+  expect(true).toBe(true);
+});

--- a/src/lib/__tests__/oracle-stream.test.ts
+++ b/src/lib/__tests__/oracle-stream.test.ts
@@ -1,0 +1,9 @@
+import { createTextStream } from "../oracle";
+
+test("cancel clears pending timer, no enqueue-after-close throw", async () => {
+  const s = createTextStream("a b c d e f g h", 10);
+  const r = s.getReader();
+  await r.read();
+  await r.cancel();
+  await new Promise((res) => setTimeout(res, 100));
+});

--- a/src/lib/__tests__/oracle-stream.test.ts
+++ b/src/lib/__tests__/oracle-stream.test.ts
@@ -7,3 +7,49 @@ test("cancel clears pending timer, no enqueue-after-close throw", async () => {
   await r.cancel();
   await new Promise((res) => setTimeout(res, 100));
 });
+
+test("double cancel is idempotent", async () => {
+  const s = createTextStream("a b c", 10);
+  const r = s.getReader();
+  await r.read();
+  await r.cancel();
+  await r.cancel();
+  await new Promise((res) => setTimeout(res, 50));
+});
+
+test("breaking out of async iteration triggers cancel cleanly", async () => {
+  const s = createTextStream("a b c d e f g h", 10);
+  const reader = s.getReader();
+  let count = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    count++;
+    if (count === 2) {
+      await reader.cancel();
+      break;
+    }
+  }
+  await new Promise((res) => setTimeout(res, 100));
+  expect(count).toBe(2);
+});
+
+test("AbortController before first read yields nothing", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const s = createTextStream("a b c", 10, controller.signal);
+  const r = s.getReader();
+  const { done } = await r.read();
+  expect(done).toBe(true);
+});
+
+test("AbortController abort during stream stops further yields", async () => {
+  const controller = new AbortController();
+  const s = createTextStream("a b c d e f g h", 10, controller.signal);
+  const r = s.getReader();
+  const first = await r.read();
+  expect(first.done).toBe(false);
+  controller.abort();
+  // After abort, the stream errors so subsequent reads reject.
+  await expect(r.read()).rejects.toThrow();
+});

--- a/src/lib/oracle.ts
+++ b/src/lib/oracle.ts
@@ -271,12 +271,36 @@ export function oracleReducer(
   }
 }
 
-export function createTextStream(text: string, wordDelayMs = 30): ReadableStream<string> {
+export function createTextStream(
+  text: string,
+  wordDelayMs = 30,
+  signal?: AbortSignal
+): ReadableStream<string> {
   const tokens = text.split(/(\s+)/);
   let timer: ReturnType<typeof setTimeout> | null = null;
   let cancelled = false;
+
+  const cleanup = () => {
+    cancelled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
   return new ReadableStream<string>({
     start(controller) {
+      if (signal?.aborted) {
+        try { controller.close(); } catch {}
+        cleanup();
+        return;
+      }
+
+      signal?.addEventListener("abort", () => {
+        cleanup();
+        try { controller.error(signal.reason); } catch {}
+      }, { once: true });
+
       let i = 0;
       function push() {
         timer = null;
@@ -293,8 +317,7 @@ export function createTextStream(text: string, wordDelayMs = 30): ReadableStream
       push();
     },
     cancel() {
-      cancelled = true;
-      if (timer) { clearTimeout(timer); timer = null; }
+      cleanup();
     },
   });
 }

--- a/src/lib/oracle.ts
+++ b/src/lib/oracle.ts
@@ -270,3 +270,31 @@ export function oracleReducer(
       return state;
   }
 }
+
+export function createTextStream(text: string, wordDelayMs = 30): ReadableStream<string> {
+  const tokens = text.split(/(\s+)/);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let cancelled = false;
+  return new ReadableStream<string>({
+    start(controller) {
+      let i = 0;
+      function push() {
+        timer = null;
+        if (cancelled) return;
+        if (i >= tokens.length) {
+          try { controller.close(); } catch {}
+          return;
+        }
+        if (controller.desiredSize === null) return;
+        try { controller.enqueue(tokens[i]); } catch { return; }
+        i++;
+        timer = setTimeout(push, wordDelayMs);
+      }
+      push();
+    },
+    cancel() {
+      cancelled = true;
+      if (timer) { clearTimeout(timer); timer = null; }
+    },
+  });
+}


### PR DESCRIPTION
Clear timer on cancel to prevent enqueue-after-close race in createTextStream.