### PR TITLE
fix(voice-profiles): skip-card animates left (not right)

### DIFF
--- a/src/components/tweet-tinder/TweetCard.tsx
+++ b/src/components/tweet-tinder/TweetCard.tsx
@@ -18,9 +18,16 @@ interface TweetCardProps {
   onSwipe: (direction: "left" | "right") => void;
   isTop: boolean;
   stackIndex: number;
+  exitDirection?: "left" | "right";
 }
 
-export default function TweetCard({ tweet, onSwipe, isTop, stackIndex }: TweetCardProps) {
+export default function TweetCard({
+  tweet,
+  onSwipe,
+  isTop,
+  stackIndex,
+  exitDirection = "right",
+}: TweetCardProps) {
   const x = useMotionValue(0);
   const rotate = useTransform(x, [-200, 0, 200], [-12, 0, 12]);
   const likeOpacity = useTransform(x, [0, 80], [0, 1]);
@@ -60,9 +67,9 @@ export default function TweetCard({ tweet, onSwipe, isTop, stackIndex }: TweetCa
         dragElastic={0.8}
         onDragEnd={isTop ? handleDragEnd : undefined}
         exit={{
-          x: 400,
+          x: exitDirection === "right" ? 400 : -400,
           opacity: 0,
-          rotate: 15,
+          rotate: exitDirection === "right" ? 15 : -15,
           transition: { type: "spring", stiffness: 200, damping: 25 },
         }}
       >

--- a/src/components/tweet-tinder/TweetDeck.tsx
+++ b/src/components/tweet-tinder/TweetDeck.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
-import { AnimatePresence, useAnimation } from "framer-motion";
+import { useState, useCallback } from "react";
+import { AnimatePresence } from "framer-motion";
 import { CheckCircle } from "lucide-react";
 import TweetCard, { type TwitterLike } from "./TweetCard";
 import SwipeActions from "./SwipeActions";
@@ -17,55 +17,18 @@ export default function TweetDeck({ tweets }: TweetDeckProps) {
   const [phase, setPhase] = useState<"swiping" | "complete">("swiping");
   const [isAnimating, setIsAnimating] = useState(false);
   const [blendSent, setBlendSent] = useState(false);
-  const controls = useAnimation();
-  const directionRef = useRef<"left" | "right">("right");
+  const [exitDirection, setExitDirection] = useState<"left" | "right">("right");
 
   const handleSwipe = useCallback(
     (direction: "left" | "right") => {
       if (isAnimating || currentIndex >= tweets.length) return;
       setIsAnimating(true);
-      directionRef.current = direction;
-
-      const exitX = direction === "right" ? 400 : -400;
-      const exitRotate = direction === "right" ? 15 : -15;
-
-      controls
-        .start({
-          x: exitX,
-          opacity: 0,
-          rotate: exitRotate,
-          transition: { type: "spring", stiffness: 200, damping: 25 },
-        })
-        .then(() => {
-          if (direction === "right") {
-            setLikedTweets((prev) => [...prev, tweets[currentIndex]]);
-          }
-
-          const nextIndex = currentIndex + 1;
-          setCurrentIndex(nextIndex);
-
-          if (nextIndex >= tweets.length) {
-            setPhase("complete");
-          }
-
-          controls.set({ x: 0, opacity: 1, rotate: 0 });
-          setIsAnimating(false);
-        });
-    },
-    [isAnimating, currentIndex, tweets, controls]
-  );
-
-  const handleCardSwipe = useCallback(
-    (direction: "left" | "right") => {
-      if (isAnimating || currentIndex >= tweets.length) return;
-
+      setExitDirection(direction);
       if (direction === "right") {
         setLikedTweets((prev) => [...prev, tweets[currentIndex]]);
       }
-
       const nextIndex = currentIndex + 1;
       setCurrentIndex(nextIndex);
-
       if (nextIndex >= tweets.length) {
         setPhase("complete");
       }
@@ -126,15 +89,16 @@ export default function TweetDeck({ tweets }: TweetDeckProps) {
     <div className="space-y-6">
       {/* Card stack */}
       <div className="relative mx-auto h-80 w-full max-w-md">
-        <AnimatePresence>
+        <AnimatePresence onExitComplete={() => setIsAnimating(false)}>
           {visibleCards
             .map((tweet, i) => (
               <TweetCard
                 key={tweet.id}
                 tweet={tweet}
-                onSwipe={handleCardSwipe}
+                onSwipe={handleSwipe}
                 isTop={i === 0}
                 stackIndex={i}
+                exitDirection={exitDirection}
               />
             ))
             .reverse()}


### PR DESCRIPTION
Skip button (red X) was animating the card right instead of left. Hardcoded exit={x:400,rotate:15} in TweetCard fired on AnimatePresence removal regardless of swipe direction; dead useAnimation controls in TweetDeck never wired to card. Fix: lift exitDirection into TweetDeck state, pass to TweetCard, parameterize exit.x/rotate.