### PR TITLE
fix(profile): X avatar fallback + X badge next to @handle

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -161,7 +161,15 @@ export default function ProfilePage() {
   }, [saveState]);
 
   const currentUser = profileUser ?? authUser;
-  const sourceAvatarUrl = currentUser?.xAvatarUrl ?? currentUser?.avatarUrl ?? null;
+  const xFallbackAvatarUrl =
+    currentUser?.twitterId && currentUser?.handle
+      ? `https://unavatar.io/twitter/${currentUser.handle}`
+      : null;
+  const sourceAvatarUrl =
+    currentUser?.xAvatarUrl ??
+    currentUser?.avatarUrl ??
+    xFallbackAvatarUrl ??
+    null;
 
   useEffect(() => {
     setAvatarFailed(false);
@@ -291,7 +299,16 @@ export default function ProfilePage() {
                 <h1 className="mt-3 font-heading text-3xl font-bold tracking-tight text-atlas-text">
                   {currentUser.displayName || currentUser.handle}
                 </h1>
-                <p className="mt-1 text-sm text-atlas-text-secondary">
+                <p className="mt-1 inline-flex items-center gap-1.5 text-sm text-atlas-text-secondary">
+                  {isXConnected && (
+                    <span
+                      aria-label="Connected via X"
+                      title="X (formerly Twitter) handle"
+                      className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-atlas-text/90 text-[10px] font-bold leading-none text-atlas-surface"
+                    >
+                      𝕏
+                    </span>
+                  )}
                   @{currentUser.handle}
                 </p>
               </div>


### PR DESCRIPTION
Bug: /profile showed initials instead of X avatar when backend hadn't synced x_avatar_url; no visual indicator that @e2e/mocks/api-handlers.ts is an X username. Adds unavatar.io/twitter/{handle} as third-tier avatar fallback (CSP now permits — #418). Adds small 𝕏 badge next to @e2e/mocks/api-handlers.ts when user is X-connected.