### PR TITLE
feat(onboarding): pole labels on voice calibration sliders

### DIFF
--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -7,6 +7,8 @@ export interface DimensionBarProps {
   onChange?: (value: number) => void;
   step?: number;
   valueLabel?: string;
+  minLabel?: string;
+  maxLabel?: string;
 }
 
 export default function DimensionBar({
@@ -16,6 +18,8 @@ export default function DimensionBar({
   onChange,
   step = 1,
   valueLabel,
+  minLabel,
+  maxLabel,
 }: DimensionBarProps) {
   const clampedPercentage = Math.min(100, Math.max(0, percentage));
 
@@ -82,6 +86,15 @@ export default function DimensionBar({
           />
         )}
       </div>
+      {(minLabel || maxLabel) && (
+        <div
+          aria-hidden="true"
+          className="mt-1 flex justify-between text-[11px] uppercase tracking-[0.12em] text-atlas-text-muted"
+        >
+          <span>{minLabel}</span>
+          <span>{maxLabel}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/voice-profiles/VoiceDimensionSections.tsx
+++ b/src/components/voice-profiles/VoiceDimensionSections.tsx
@@ -69,6 +69,8 @@ export default function VoiceDimensionSections({
                   valueLabel={formatVoiceDimensionValue(
                     resolvedValues[dimension.field] ?? 50
                   )}
+                  minLabel={dimension.minLabel}
+                  maxLabel={dimension.maxLabel}
                 />
               )
             )}

--- a/src/lib/voice-profile-dimensions.ts
+++ b/src/lib/voice-profile-dimensions.ts
@@ -23,6 +23,8 @@ export interface VoiceDimensionSection {
   dimensions: Array<{
     field: VoiceDimensionField;
     label: string;
+    minLabel: string;
+    maxLabel: string;
   }>;
 }
 
@@ -62,30 +64,30 @@ export const VOICE_DIMENSION_SECTIONS: VoiceDimensionSection[] = [
     title: "Core Voice",
     description: "The high-level signals that shape the overall tone of every post.",
     dimensions: [
-      { field: "humor", label: "Humor" },
-      { field: "formality", label: "Formality" },
-      { field: "brevity", label: "Brevity" },
-      { field: "contrarianTone", label: "Contrarian tone" },
+      { field: "humor", label: "Humor", minLabel: "Serious", maxLabel: "Playful" },
+      { field: "formality", label: "Formality", minLabel: "Casual", maxLabel: "Formal" },
+      { field: "brevity", label: "Brevity", minLabel: "Wordy", maxLabel: "Punchy" },
+      { field: "contrarianTone", label: "Contrarian tone", minLabel: "Consensus", maxLabel: "Contrarian" },
     ],
   },
   {
     title: "Communication Style",
     description: "How the voice sounds in delivery, confidence, and complexity.",
     dimensions: [
-      { field: "directness", label: "Directness" },
-      { field: "warmth", label: "Warmth" },
-      { field: "technicalDepth", label: "Technical depth" },
-      { field: "confidence", label: "Confidence" },
+      { field: "directness", label: "Directness", minLabel: "Diplomatic", maxLabel: "Blunt" },
+      { field: "warmth", label: "Warmth", minLabel: "Cool", maxLabel: "Warm" },
+      { field: "technicalDepth", label: "Technical depth", minLabel: "Plain", maxLabel: "Technical" },
+      { field: "confidence", label: "Confidence", minLabel: "Tentative", maxLabel: "Assertive" },
     ],
   },
   {
     title: "Content Approach",
     description: "What the writing optimizes for when it makes a point.",
     dimensions: [
-      { field: "evidenceOrientation", label: "Evidence orientation" },
-      { field: "solutionOrientation", label: "Solution orientation" },
-      { field: "socialPosture", label: "Social posture" },
-      { field: "selfPromotionalIntensity", label: "Self-promotional intensity" },
+      { field: "evidenceOrientation", label: "Evidence orientation", minLabel: "Intuitive", maxLabel: "Data-driven" },
+      { field: "solutionOrientation", label: "Solution orientation", minLabel: "Problem-framing", maxLabel: "Solution-focused" },
+      { field: "socialPosture", label: "Social posture", minLabel: "Reserved", maxLabel: "Outgoing" },
+      { field: "selfPromotionalIntensity", label: "Self-promotional intensity", minLabel: "Humble", maxLabel: "Promotional" },
     ],
   },
 ];


### PR DESCRIPTION
Adds Serious↔Playful etc. pole labels under every slider. Backwards compatible. Touches 3 files.