### PR TITLE
fix(onboarding): guard against all-zero voice calibration output

### DIFF
--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -361,9 +361,13 @@ export default function OracleChat() {
           tweetsAnalyzed: calibration.tweetsAnalyzed,
         },
       });
+      const calibratedDimensions = pickVoiceDimensions(profile);
+      // Guard against degenerate all-zero AI output (renders as 0/10 on every slider).
+      // Falls back to sensible defaults so the user sees a usable starting point.
+      const isAllZero = Object.values(calibratedDimensions).every((v) => v <= 4);
       dispatch({
         type: "SET_DIMENSIONS",
-        dimensions: pickVoiceDimensions(profile),
+        dimensions: isAllZero ? TRACK_A_INITIAL_DIMENSIONS : calibratedDimensions,
       });
     },
     []


### PR DESCRIPTION
When Claude AI returns degenerate all-zero dimension values (e.g., for a throwaway account), sliders show 0/10 across the board. This adds a sanity check: if all 12 values <= 4, fall back to TRACK_A_INITIAL_DIMENSIONS so the user sees a usable starting point rather than a broken UI.