### PR TITLE
fix(audit): middleware PUBLIC_PATHS + OracleChat cancellation flag (v1.0 pre-ship)

### DIFF
--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -155,19 +155,20 @@ export default function OracleChat() {
       return;
     }
 
+    let cancelled = false;
     api.auth.x
       .status()
       .then((res) => {
-        if (!res.linked) {
-          return;
-        }
-
+        if (cancelled || !res.linked) return;
         if (res.xHandle) {
           dispatch({ type: "SET_HANDLE", handle: res.xHandle.replace(/^@/, "") });
         }
         dispatch({ type: "SET_X_CONNECTED", connected: true });
       })
       .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [state.currentStep, state.xConnected, state.xHandle]);
 
   // Auto-advance from CONNECT_X when connected

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { publicOrigins } from "@/lib/public-urls";
 
 // Public routes that don't require authentication
-const PUBLIC_PATHS = new Set(["/", "/auth/x/callback", "/auth/callback", "/onboarding"]);
+const PUBLIC_PATHS = new Set(["/", "/auth/x/callback", "/auth/callback"]);
 
 function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.has(pathname) || pathname.startsWith("/onboarding") || pathname.startsWith("/_next") || pathname.startsWith("/api") || pathname === "/style-tile.html";


### PR DESCRIPTION
## Summary
Two surgical fixes from the v1.0-anil-release pre-ship Opus sandwich audit:

- **Item 1**: Remove redundant `"/onboarding"` from `PUBLIC_PATHS` Set in `middleware.ts`. The `startsWith("/onboarding")` guard on line 9 is the real policy — the Set entry was dead code.
- **Item 9**: Add `cancelled` flag + cleanup return to the X-status `useEffect` in `OracleChat.tsx`. Prevents stale dispatch on unmounted component if user navigates away during onboarding.

## Audit context
Items 2, 3, 8 confirmed false positives by Opus (guards already exist in code). These 2 are the only real changes needed before tagging `v1.0-anil-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)