### PR TITLE
feat: VoicePillBar in crafting + RecipeCard in TeamLibrary (BUG-37 recovery)

### DIFF
--- a/src/__tests__/app/TeamLibraryPage.test.tsx
+++ b/src/__tests__/app/TeamLibraryPage.test.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 
 const mockUseAuth = jest.fn();
-const mockTeam = jest.fn();
-const mockList = jest.fn();
+const mockUsersTeam = jest.fn();
+const mockRecipeCard = jest.fn();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
@@ -20,11 +20,18 @@ jest.mock("@/components/layout/AppShell", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
+jest.mock("@/components/voice-profiles/RecipeCard", () => ({
+  __esModule: true,
+  default: (props: unknown) => {
+    mockRecipeCard(props);
+    return <div data-testid="recipe-card" />;
+  },
+}));
+
 jest.mock("@/lib/api", () => ({
   api: {
-    drafts: {
-      team: (...args: unknown[]) => mockTeam(...args),
-      list: (...args: unknown[]) => mockList(...args),
+    users: {
+      team: (...args: unknown[]) => mockUsersTeam(...args),
     },
   },
 }));
@@ -44,55 +51,79 @@ describe("TeamLibraryPage", () => {
       loading: false,
     });
 
-    mockTeam.mockResolvedValue({
-      drafts: [
+    mockUsersTeam.mockResolvedValue({
+      team: [
         {
-          id: "d1",
-          content: "Bitcoin is showing strong support at 65k",
-          version: 1,
-          status: "APPROVED",
-          confidence: 0.85,
-          actualEngagement: 120,
-          createdAt: "2026-04-01T12:00:00Z",
-          blendName: "Research Mode",
-          user: { handle: "alice", displayName: "Alice", avatarUrl: null },
+          id: "u2",
+          handle: "alice",
+          displayName: "Alice",
+          role: "ANALYST",
+          voiceProfile: {
+            humor: 60,
+            formality: 40,
+            brevity: 70,
+            contrarianTone: 50,
+            directness: 55,
+            warmth: 45,
+            technicalDepth: 65,
+            confidence: 50,
+            evidenceOrientation: 55,
+            solutionOrientation: 50,
+            socialPosture: 45,
+            selfPromotionalIntensity: 40,
+            maturity: "INTERMEDIATE",
+            tweetsAnalyzed: 42,
+          },
+          _count: { tweetDrafts: 10, sessions: 5 },
         },
-      ],
-      total: 1,
-    });
-
-    mockList.mockResolvedValue({
-      drafts: [
         {
-          id: "d1",
-          content: "Bitcoin is showing strong support at 65k",
-          version: 1,
-          status: "APPROVED",
-          confidence: 0.85,
-          actualEngagement: 120,
-          createdAt: "2026-04-01T12:00:00Z",
+          id: "u3",
+          handle: "bob",
+          displayName: "Bob",
+          role: "ANALYST",
+          voiceProfile: null,
+          _count: { tweetDrafts: 0, sessions: 0 },
         },
       ],
     });
   });
 
-  it("renders library items", async () => {
+  it("renders team voice recipes", async () => {
     render(<TeamLibraryPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/bitcoin/i)).toBeInTheDocument();
+      expect(screen.getAllByTestId("recipe-card").length).toBeGreaterThan(0);
     });
+
+    expect(mockRecipeCard).toHaveBeenCalledTimes(1);
+    const call = mockRecipeCard.mock.calls[0][0];
+    expect(call.blend.id).toBe("u2");
+    expect(call.blend.voices[0].label).toBe("Alice");
+    expect(call.isActive).toBe(false);
   });
 
-  it("shows author info", async () => {
+  it("shows empty state when no team members have voice profiles", async () => {
+    mockUsersTeam.mockResolvedValue({
+      team: [
+        {
+          id: "u3",
+          handle: "bob",
+          displayName: "Bob",
+          role: "ANALYST",
+          voiceProfile: null,
+          _count: { tweetDrafts: 0, sessions: 0 },
+        },
+      ],
+    });
+
     render(<TeamLibraryPage />);
 
-    const authorName = await screen.findByText("Alice");
-    const avatar = authorName.previousElementSibling;
-
-    expect(authorName).toBeInTheDocument();
-    expect(avatar).toHaveTextContent("A");
-    expect(avatar).toHaveClass("rounded-full");
-    expect(screen.getByText("via Research Mode")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /No team voice recipes yet\. Team members need to calibrate their voice profiles before they appear here\./i
+        )
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/useVoiceGate";
 import { MultiAnglePanel } from "@/components/crafting/MultiAnglePanel";
 import { SchedulePopover } from "@/components/ui/SchedulePopover";
+import VoicePillBar from "@/components/ui/VoicePillBar";
 
 const CRAFTING_MODES = [
   { id: "new_post", label: "New Post" },
@@ -1842,6 +1843,23 @@ function CraftingPage() {
                 );
               })}
             </div>
+            {selectedBlendId && (
+              <div className="w-full">
+                {(() => {
+                  const activeBlend = blends.find((b) => b.id === selectedBlendId);
+                  if (!activeBlend) return null;
+                  return (
+                    <VoicePillBar
+                      voices={activeBlend.voices.map((voice) => ({
+                        handle: voice.label,
+                        avatarUrl: voice.referenceVoice?.avatarUrl || undefined,
+                        pct: voice.percentage,
+                      }))}
+                    />
+                  );
+                })()}
+              </div>
+            )}
             <div className="flex w-full flex-col gap-2 sm:min-w-[200px] sm:flex-1 sm:flex-row sm:items-center sm:gap-3">
               <span
                 id={blendIntensityLabelId}

--- a/src/app/team-library/page.tsx
+++ b/src/app/team-library/page.tsx
@@ -2,33 +2,36 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Check, ChevronDown, ChevronUp, Copy, Sparkles } from "lucide-react";
 import AppShell from "@/components/layout/AppShell";
 import FeatureGate from "@/components/ui/FeatureGate";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useAuth } from "@/lib/auth";
-import { api, TeamDraft } from "@/lib/api";
+import { api, TeamMember } from "@/lib/api";
+import RecipeCard from "@/components/voice-profiles/RecipeCard";
+import {
+  pickVoiceDimensions,
+  generateVoiceProfileName,
+} from "@/lib/voice-profile-dimensions";
+import { getNotableVoiceDimensions } from "@/lib/voice-recipes";
+import { Sparkles } from "lucide-react";
 
 function TeamLibraryPage() {
   const { user } = useAuth();
   const router = useRouter();
-  const [libraryItems, setLibraryItems] = useState<TeamDraft[]>([]);
+  const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
   const [loading, setLoading] = useState(false);
-  const [totalCount, setTotalCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState("recent");
-  const [filterBy, setFilterBy] = useState("all");
-  const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
-    if (!user) { setLoading(false); return; }
+    if (!user) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
-      const draftsRes = await api.drafts.team(6);
-      setLibraryItems(draftsRes.drafts);
-      setTotalCount(draftsRes.total);
+      const { team } = await api.users.team();
+      setTeamMembers(team);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load team library");
     } finally {
@@ -36,96 +39,54 @@ function TeamLibraryPage() {
     }
   }, [user]);
 
-  useEffect(() => { loadData(); }, [loadData]);
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
-  const sortedItems = useMemo(() => {
-    const items = [...(libraryItems ?? [])];
-    if (sortBy === "engagement") items.sort((a, b) => (b.actualEngagement ?? 0) - (a.actualEngagement ?? 0));
-    if (sortBy === "confidence") items.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
-    if (sortBy === "recent") items.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-    return items;
-  }, [libraryItems, sortBy]);
+  const membersWithProfiles = useMemo(
+    () => teamMembers.filter((m) => m.voiceProfile),
+    [teamMembers]
+  );
 
-  const visibleItems = useMemo(() => {
-    if (filterBy === "with-engagement") {
-      return sortedItems.filter((item) => (item.actualEngagement ?? 0) > 0);
-    }
-    if (filterBy === "with-confidence") {
-      return sortedItems.filter((item) => (item.confidence ?? 0) > 0);
-    }
-    return sortedItems;
-  }, [filterBy, sortedItems]);
-
-  function formatEngagement(item: TeamDraft) {
-    const engagement = item.predictedEngagement ?? item.actualEngagement;
-    if (engagement == null || engagement === 0) return "—";
-    if (engagement >= 1000) return `${(engagement / 1000).toFixed(1)}k`;
-    return String(Math.round(engagement));
-  }
-
-  const handleCopy = async (item: TeamDraft) => {
-    await navigator.clipboard.writeText(item.content);
-    setCopiedId(item.id);
-    setTimeout(() => setCopiedId(null), 2000);
-  };
-
-  const handleUseStyle = (item: TeamDraft) => {
-    // Navigate to crafting with the draft content pre-loaded as inspiration
-    const params = new URLSearchParams({ source: item.content });
-    if (item.blendName) params.set("blend", item.blendName);
+  const handleUse = (memberId: string) => {
+    const member = teamMembers.find((m) => m.id === memberId);
+    if (!member) return;
+    const params = new URLSearchParams({ voice: member.handle });
     router.push(`/crafting?${params.toString()}`);
   };
 
   return (
     <AppShell>
       {error && (
-        <div role="alert" className="mb-6 px-4 py-3 bg-atlas-error/10 border border-atlas-error/30 rounded-xl text-atlas-error text-sm">
+        <div
+          role="alert"
+          className="mb-6 rounded-xl border border-atlas-error/30 bg-atlas-error/10 px-4 py-3 text-sm text-atlas-error"
+        >
           {error}
         </div>
       )}
 
       {/* Header */}
       <div className="mb-6">
-        <h1 className="font-heading font-bold tracking-tight text-2xl text-atlas-text">
+        <h1 className="font-heading text-2xl font-bold tracking-tight text-atlas-text">
           Team Style Library
         </h1>
-        <p className="text-sm text-atlas-text-secondary mt-2">
-          Browse and remix approved styles from across the team.
+        <p className="mt-2 text-sm text-atlas-text-secondary">
+          Browse and remix voice recipes from across the team.
         </p>
       </div>
 
-      {/* Filter Bar */}
-      <div className="flex flex-wrap gap-4 mb-8">
-        <select
-          aria-label="Sort team library styles"
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          className="bg-atlas-surface rounded-lg text-atlas-text-secondary px-3 py-2 text-sm border border-glass-border focus:outline-none focus:border-atlas-teal"
-        >
-          <option value="recent">Most Recent</option>
-          <option value="engagement">Highest Engagement</option>
-          <option value="confidence">Highest Confidence</option>
-        </select>
-        <select
-          aria-label="Filter team library styles"
-          value={filterBy}
-          onChange={(e) => setFilterBy(e.target.value)}
-          className="bg-atlas-surface rounded-lg text-atlas-text-secondary px-3 py-2 text-sm border border-glass-border focus:outline-none focus:border-atlas-teal"
-        >
-          <option value="all">All Styles</option>
-          <option value="with-engagement">With Engagement</option>
-          <option value="with-confidence">With Confidence</option>
-        </select>
-      </div>
-
-      {/* Masonry Grid */}
+      {/* Loading state */}
       {loading && (
-        <div className="columns-1 md:columns-2 gap-6 space-y-6 mb-8">
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="break-inside-avoid bg-atlas-surface border border-glass-border rounded-2xl p-8 space-y-3">
+            <div
+              key={i}
+              className="break-inside-avoid rounded-2xl border border-glass-border bg-atlas-surface p-6 space-y-4"
+            >
+              <Skeleton className="h-5 w-1/3" />
+              <Skeleton className="h-8 w-2/3" />
               <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-5/6" />
-              <Skeleton className="h-4 w-3/4" />
               <div className="pt-4 border-t border-glass-border space-y-2">
                 <Skeleton className="h-3 w-24" />
                 <Skeleton className="h-3 w-16" />
@@ -134,115 +95,59 @@ function TeamLibraryPage() {
           ))}
         </div>
       )}
-      {visibleItems.length === 0 && !loading && (
-        <div className="bg-atlas-surface border border-glass-border rounded-2xl p-12 text-center mb-8">
-          <p className="text-sm text-atlas-text-secondary">No approved styles yet. Approve drafts in the Crafting Station and they will show up here for the team to reference.</p>
+
+      {/* Empty state */}
+      {!loading && membersWithProfiles.length === 0 && (
+        <div className="rounded-2xl border border-glass-border bg-atlas-surface p-12 text-center">
+          <p className="text-sm text-atlas-text-secondary">
+            No team voice recipes yet. Team members need to calibrate their voice profiles before they appear here.
+          </p>
         </div>
       )}
-      <div className="columns-1 md:columns-2 gap-6 space-y-6">
-        {visibleItems.map((item) => {
-          const isCopied = copiedId === item.id;
-          const isExpanded = expandedId === item.id;
 
-          return (
-            <div
-              key={item.id}
-              className="flex flex-col rounded-2xl border border-glass-border bg-atlas-surface p-8 break-inside-avoid transition-colors hover:border-atlas-teal/30"
-            >
-              <p className="text-lg text-atlas-text leading-relaxed">{item.content}</p>
-              {item.feedback && (
-                <p className="text-sm text-atlas-text-secondary mt-3 italic">&ldquo;{item.feedback}&rdquo;</p>
-              )}
+      {/* Recipe cards grid */}
+      {!loading && membersWithProfiles.length > 0 && (
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {membersWithProfiles.map((member) => {
+            const dimensions = pickVoiceDimensions(member.voiceProfile);
+            const notableDimensions = getNotableVoiceDimensions(dimensions);
+            const blend = {
+              id: member.id,
+              name:
+                generateVoiceProfileName(dimensions, [member.handle]) ||
+                member.displayName ||
+                member.handle,
+              voices: [
+                {
+                  id: member.id,
+                  label: member.displayName || member.handle,
+                  percentage: 100,
+                  referenceVoiceId: null,
+                  referenceVoice: null,
+                },
+              ],
+            };
 
-              <div className="mt-auto pt-4 border-t border-glass-border">
-                <div className="flex items-center gap-2 mt-3">
-                  <div className="h-6 w-6 rounded-full bg-gradient-to-r from-delphi-blue-500 to-atlas-teal flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0">
-                    {item.user?.handle?.[0]?.toUpperCase() || item.user?.displayName?.[0]?.toUpperCase() || "?"}
-                  </div>
-                  <span className="text-xs text-atlas-text-secondary truncate">
-                    {item.user?.displayName || item.user?.handle || "Unknown"}
-                  </span>
-                </div>
-                {item.blendName && (
-                  <span className="text-[10px] text-atlas-teal">
-                    via {item.blendName}
-                  </span>
-                )}
-                <p className="text-sm text-atlas-text-secondary font-medium">Team voice</p>
-                <p className="text-xs text-atlas-teal font-bold mt-1">{formatEngagement(item)} Engagement</p>
-              </div>
-
-              {/* Expanded preview */}
-              {isExpanded && (
-                <div className="mt-4 rounded-xl border border-glass-border/50 bg-atlas-bg/50 p-4 space-y-2">
-                  <p className="text-[10px] uppercase tracking-wide text-atlas-text-muted font-semibold">Draft Details</p>
-                  <div className="grid grid-cols-2 gap-2 text-xs">
-                    <div>
-                      <span className="text-atlas-text-muted">Status:</span>{" "}
-                      <span className="text-atlas-text">{item.status}</span>
-                    </div>
-                    <div>
-                      <span className="text-atlas-text-muted">Length:</span>{" "}
-                      <span className="text-atlas-text">{item.content.length}/280</span>
-                    </div>
-                    {item.confidence != null && (
-                      <div>
-                        <span className="text-atlas-text-muted">Confidence:</span>{" "}
-                        <span className="text-atlas-text">{Math.round(item.confidence * 100)}%</span>
-                      </div>
-                    )}
-                    {item.sourceType && (
-                      <div>
-                        <span className="text-atlas-text-muted">Source:</span>{" "}
-                        <span className="text-atlas-text">{item.sourceType.replace(/_/g, " ")}</span>
-                      </div>
-                    )}
-                  </div>
-                  {item.blendName && (
-                    <p className="text-xs text-atlas-teal">Voice blend: {item.blendName}</p>
-                  )}
-                  <p className="text-[10px] text-atlas-text-muted">
-                    Created {new Date(item.createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
-                  </p>
-                </div>
-              )}
-
-              {/* Actions */}
-              <div className="mt-3 flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => handleUseStyle(item)}
-                  className="flex items-center gap-1.5 text-xs font-bold text-atlas-teal transition-colors hover:text-atlas-text"
-                >
-                  <Sparkles className="h-3.5 w-3.5" />
-                  Use this style
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleCopy(item)}
-                  className="flex items-center gap-1.5 text-xs font-bold text-atlas-text-secondary transition-colors hover:text-atlas-teal"
-                >
-                  {isCopied ? <Check className="h-3.5 w-3.5 text-atlas-success" /> : <Copy className="h-3.5 w-3.5" />}
-                  {isCopied ? "Copied!" : "Copy"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setExpandedId(isExpanded ? null : item.id)}
-                  className="flex items-center gap-1 text-xs font-bold text-atlas-text-secondary transition-colors hover:text-atlas-teal"
-                >
-                  {isExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-                  {isExpanded ? "Less" : "Preview"}
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Footer count */}
-      <p className="text-sm text-atlas-text-secondary mt-6 text-center">
-        {totalCount > 0 ? `${visibleItems.length} of ${totalCount} styles` : `${visibleItems.length} styles`}
-      </p>
+            return (
+              <RecipeCard
+                key={member.id}
+                blend={blend}
+                dimensions={dimensions}
+                fingerprintDescription={`${member.displayName || member.handle}'s calibrated voice profile.`}
+                notableDimensions={notableDimensions}
+                isActive={false}
+                onUse={() => handleUse(member.id)}
+                onPreviewSample={() => {}}
+                user={{
+                  handle: member.handle,
+                  displayName: member.displayName || null,
+                  avatarUrl: null,
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
     </AppShell>
   );
 }

--- a/src/components/ui/VoicePillBar.tsx
+++ b/src/components/ui/VoicePillBar.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { getTwitterAvatarUrl } from "@/lib/public-urls";
+
+export interface VoicePillBarVoice {
+  handle: string;
+  avatarUrl?: string;
+  pct: number;
+}
+
+interface VoicePillBarProps {
+  voices: VoicePillBarVoice[];
+  className?: string;
+}
+
+const SEGMENT_STYLES = [
+  {
+    bar: "bg-atlas-teal",
+    pill: "border-atlas-teal/30 bg-atlas-teal/10 text-atlas-teal",
+  },
+  {
+    bar: "bg-delphi-blue-500",
+    pill: "border-delphi-blue-500/30 bg-delphi-blue-500/10 text-delphi-blue-300",
+  },
+  {
+    bar: "bg-delphi-blue-400",
+    pill: "border-delphi-blue-400/30 bg-delphi-blue-400/10 text-delphi-blue-300",
+  },
+  {
+    bar: "bg-atlas-success",
+    pill: "border-atlas-success/30 bg-atlas-success/10 text-atlas-success",
+  },
+  {
+    bar: "bg-atlas-warning",
+    pill: "border-atlas-warning/30 bg-atlas-warning/10 text-atlas-warning",
+  },
+  {
+    bar: "bg-atlas-error",
+    pill: "border-atlas-error/30 bg-atlas-error/10 text-atlas-error",
+  },
+] as const;
+
+function VoiceAvatar({
+  url,
+  handle,
+  size = 20,
+  className = "",
+}: {
+  url?: string;
+  handle: string;
+  size?: number;
+  className?: string;
+}) {
+  const initials = handle.trim().charAt(0).toUpperCase() || "?";
+
+  if (!url) {
+    return (
+      <span
+        className={`flex shrink-0 items-center justify-center rounded-full border border-glass-border bg-atlas-surface text-[10px] font-bold text-atlas-text-muted ${className}`}
+        style={{ width: size, height: size }}
+        aria-hidden="true"
+      >
+        {initials}
+      </span>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={handle}
+      width={size}
+      height={size}
+      className={`shrink-0 rounded-full object-cover ${className}`}
+      style={{ width: size, height: size }}
+      onError={(event) => {
+        event.currentTarget.style.display = "none";
+      }}
+    />
+  );
+}
+
+export default function VoicePillBar({ voices, className = "" }: VoicePillBarProps) {
+  if (!voices || voices.length === 0) return null;
+
+  const totalWeight = voices.reduce((sum, voice) => sum + voice.pct, 0) || 1;
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-atlas-text-muted">
+          Composition
+        </p>
+        <p className="text-xs text-atlas-text-secondary">
+          {voices.map((voice) => `${Math.round((voice.pct / totalWeight) * 100)}% ${voice.handle}`).join(" + ")}
+        </p>
+      </div>
+      <div className="mt-3 overflow-hidden rounded-full border border-glass-border bg-atlas-bg/70">
+        <div className="flex h-4">
+          {voices.map((voice, index) => (
+            <div
+              key={`${voice.handle}-${index}`}
+              aria-hidden="true"
+              className={SEGMENT_STYLES[index % SEGMENT_STYLES.length].bar}
+              style={{ width: `${(voice.pct / totalWeight) * 100}%` }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {voices.map((voice, index) => (
+          <span
+            key={`${voice.handle}-${index}-pill`}
+            className={`inline-flex items-center gap-1.5 rounded-full border py-1 pl-1 pr-3 text-xs font-medium ${SEGMENT_STYLES[index % SEGMENT_STYLES.length].pill}`}
+          >
+            <VoiceAvatar
+              url={voice.avatarUrl || getTwitterAvatarUrl(voice.handle) || undefined}
+              handle={voice.handle}
+              size={20}
+            />
+            {Math.round((voice.pct / totalWeight) * 100)}% {voice.handle}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -10,6 +10,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import DimensionBar from "@/components/ui/DimensionBar";
+import VoicePillBar from "@/components/ui/VoicePillBar";
 import VoicePreviewPlayer from "./VoicePreviewPlayer";
 import type { BlendVoice, SavedBlend } from "@/lib/api";
 import type { VoiceDimensionSnapshot } from "@/lib/voice-recipes";
@@ -195,39 +196,14 @@ export default function RecipeCard({
         </div>
       </div>
 
-      <div className="mt-6">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-atlas-text-muted">
-            Composition
-          </p>
-          <p className="text-xs text-atlas-text-secondary">
-            {blend.voices.map((voice) => `${Math.round((voice.percentage / totalWeight) * 100)}% ${voice.label}`).join(" + ")}
-          </p>
-        </div>
-        <div className="mt-3 overflow-hidden rounded-full border border-glass-border bg-atlas-bg/70">
-          <div className="flex h-4">
-            {blend.voices.map((voice, index) => (
-              <div
-                key={`${blend.id}-${voice.label}`}
-                aria-hidden="true"
-                className={SEGMENT_STYLES[index % SEGMENT_STYLES.length].bar}
-                style={{ width: `${(voice.percentage / totalWeight) * 100}%` }}
-              />
-            ))}
-          </div>
-        </div>
-        <div className="mt-3 flex flex-wrap gap-2">
-          {blend.voices.map((voice, index) => (
-            <span
-              key={`${blend.id}-${voice.label}-pill`}
-              className={`inline-flex items-center gap-1.5 rounded-full border py-1 pl-1 pr-3 text-xs font-medium ${SEGMENT_STYLES[index % SEGMENT_STYLES.length].pill}`}
-            >
-              <VoiceAvatar voice={voice} user={user} size={20} />
-              {Math.round((voice.percentage / totalWeight) * 100)}% {voice.label}
-            </span>
-          ))}
-        </div>
-      </div>
+      <VoicePillBar
+        className="mt-6"
+        voices={blend.voices.map((voice) => ({
+          handle: voice.label,
+          avatarUrl: resolveVoiceAvatar(voice, user),
+          pct: voice.percentage,
+        }))}
+      />
 
       <div className="mt-6 rounded-2xl border border-glass-border bg-atlas-surface/40 p-4">
         <div className="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Summary
- Extracts VoicePillBar as standalone shared component from RecipeCard
- Wires VoicePillBar into crafting station (shows active voice blend while drafting)
- Replaces legacy TeamLibrary post list with RecipeCard (fulfills "faces not handles" + voice recipes requirements)

## Audit context
BUG-37/38 recovery — PR #430 was closed without merge. Backend voice routes already support this (ReferenceVoice + SavedBlend models).

## Test plan
- [ ] Crafting station shows pill bar with active voice blend
- [ ] Team Library renders RecipeCard per member
- [ ] npx tsc --noEmit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)