### PR TITLE
fix(csp): fallback Supabase origin in connect-src if env var missing

### DIFF
--- a/src/lib/public-urls.ts
+++ b/src/lib/public-urls.ts
@@ -45,7 +45,7 @@ function getHost(value: string) {
 export const publicUrls = {
   apiUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_API_URL ?? ""),
   appUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_APP_URL ?? ""),
-  supabaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""),
+  supabaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://zoirudjyqfqvpxsrxepr.supabase.co"),
   xBaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_X_BASE_URL ?? ""),
   unavatarOrigin: stripTrailingSlash(
     process.env.NEXT_PUBLIC_UNAVATAR_ORIGIN ?? "https://unavatar.io"


### PR DESCRIPTION
## Summary
- Adds hardcoded fallback for `NEXT_PUBLIC_SUPABASE_URL` in `src/lib/public-urls.ts`
- Prevents `connect-src` from silently dropping the Supabase SSE domain if the env var is missing in Vercel
- Fixes Forge-Audit watch item: Oracle chat SSE blocked by CSP in prod

## Change
```ts
// Before
supabaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""),

// After
supabaseUrl: stripTrailingSlash(process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://zoirudjyqfqvpxsrxepr.supabase.co"),
```

## Test plan
- [ ] CI passes
- [ ] CSP header in prod includes Supabase origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)