### PR TITLE
fix(nav): pin Admin + Feedback always visible for ADMIN role

### DIFF
--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -202,21 +202,42 @@ export default function NavBar({ variant }: NavBarProps) {
           )}
           {variant === "app" && user && (
             <>
-              <Link
-                href="/admin/bugs?action=report"
-                className="hidden sm:flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-atlas-teal hover:bg-atlas-surface transition-colors border border-glass-border"
-              >
-                <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
-                Feedback
-              </Link>
-              {(user.role === "ADMIN" || user.role === "MANAGER") && (
-                <Link
-                  href="/admin/bugs"
-                  className="hidden sm:flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-amber-400 hover:bg-atlas-surface transition-colors border border-glass-border"
-                >
-                  <Shield className="w-3.5 h-3.5" aria-hidden="true" />
-                  Admin
-                </Link>
+              {user.role === "ADMIN" ? (
+                <>
+                  <Link
+                    href="/admin/bugs"
+                    className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-amber-400 hover:bg-atlas-surface transition-colors border border-glass-border"
+                  >
+                    <Shield className="w-3.5 h-3.5" aria-hidden="true" />
+                    Admin
+                  </Link>
+                  <Link
+                    href="/admin/bugs?action=report"
+                    className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-atlas-teal hover:bg-atlas-surface transition-colors border border-glass-border"
+                  >
+                    <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
+                    Feedback
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/admin/bugs?action=report"
+                    className="hidden sm:flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-atlas-teal hover:bg-atlas-surface transition-colors border border-glass-border"
+                  >
+                    <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
+                    Feedback
+                  </Link>
+                  {user.role === "MANAGER" && (
+                    <Link
+                      href="/admin/bugs"
+                      className="hidden sm:flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-atlas-text-secondary hover:text-amber-400 hover:bg-atlas-surface transition-colors border border-glass-border"
+                    >
+                      <Shield className="w-3.5 h-3.5" aria-hidden="true" />
+                      Admin
+                    </Link>
+                  )}
+                </>
               )}
               <TourToggle />
               <DemoModeToggle />


### PR DESCRIPTION
## What
For ADMIN users: **Admin** link (→ /admin/bugs) and **Feedback** link (→ /admin/bugs?action=report) are always visible in the top nav — no `hidden sm:` prefix.

Admin appears first, Feedback second (swapped from current order).

For MANAGER users: keeps existing `hidden sm:flex` behavior.
For all other roles: unchanged.

## Why
Alex (ADMIN) needs one-tap access to admin + bug reporting from any page on any screen size.

## Token Matrix
Dispatched to MiniMax (surgical single-file), applied by CC (thin).