### PR TITLE
fix(voice): contain slider hover glow, increase row gap

### DIFF
--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -33,7 +33,7 @@ export default function DimensionBar({
           {valueLabel ?? `${clampedPercentage}%`}
         </span>
       </div>
-      <div className="relative flex h-8 items-center">
+      <div className="relative flex h-10 items-center">
         <div className="pointer-events-none absolute inset-x-0 h-1 rounded-full bg-atlas-text-secondary/30" />
         <div
           className="pointer-events-none absolute left-0 h-1 rounded-full bg-gradient-to-r from-atlas-teal to-atlas-teal transition-all duration-300"
@@ -76,8 +76,8 @@ export default function DimensionBar({
               [&::-moz-range-thumb]:shadow-md
               [&::-moz-range-thumb]:transition-shadow
               [&::-moz-range-thumb]:duration-200
-              hover:[&::-webkit-slider-thumb]:shadow-[0_0_8px_rgba(78,205,196,0.5)]
-              hover:[&::-moz-range-thumb]:shadow-[0_0_8px_rgba(78,205,196,0.5)]"
+              hover:[&::-webkit-slider-thumb]:shadow-[0_0_0_2px_rgba(78,205,196,0.4)]
+              hover:[&::-moz-range-thumb]:shadow-[0_0_0_2px_rgba(78,205,196,0.4)]"
           />
         ) : (
           <div

--- a/src/components/voice-profiles/VoiceDimensionSections.tsx
+++ b/src/components/voice-profiles/VoiceDimensionSections.tsx
@@ -50,7 +50,7 @@ export default function VoiceDimensionSections({
             </p>
           </div>
 
-          <div className="space-y-4">
+          <div className="space-y-6">
             {section.dimensions.map((dimension) =>
               loading ? (
                 <div key={dimension.field} className="flex items-center gap-4">


### PR DESCRIPTION
## What changed
- contain the slider hover glow inside `DimensionBar` by switching to a contained shadow treatment and increasing the bar height from `h-8` to `h-10`
- increase spacing between voice dimension rows in `VoiceDimensionSections` from `space-y-4` to `space-y-6`

## Why
- the previous hover glow could bleed into neighboring rows and visually overlap adjacent sliders
- the tighter row spacing made that overlap more noticeable in the voice configuration UI

## Impact
- slider hover feedback stays visually contained within its own row
- the voice profile dimension list has more separation and reads more cleanly

## Root cause
- the glow effect extended beyond the slider bounds while the vertical gap between rows was too small to absorb it

## Validation
- `tsc --noEmit -p tsconfig.json`