### PR TITLE
feat(nav): pin Admin + Report Bug at top of nav for Alex

### DIFF
--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -70,7 +70,8 @@ export function getVisibleNavLinks(role?: string): typeof navLinks {
     (link) => CORE_NAV_HREFS.has(link.href) || (isManager && MANAGER_NAV_HREFS.has(link.href))
   );
   if (isAdmin) {
-    links.push({ label: "Admin", href: "/admin", icon: Settings });
+    links.unshift({ label: "Report Bug", href: "/admin/bugs?action=report", icon: Bug });
+    links.unshift({ label: "Admin", href: "/admin", icon: Settings });
   }
   return links;
 }


### PR DESCRIPTION
## Summary
- Pins **Admin** and **Report Bug** links at the top of the nav (before all other tabs) for ADMIN users
- Uses `unshift` instead of `push` so they appear first, not last
- Gates on existing `role === "ADMIN"` check — no new auth logic
- `Bug` icon already imported; zero new dependencies

## Files changed
- `src/components/ui/NavBar.tsx` — 2-line change in `getVisibleNavLinks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)