### PR TITLE
fix(demo): resilience hardening for Anil demo

### DIFF
--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -28,8 +28,11 @@ function ManagementPage() {
     isLoading("send-nudge") ||
     isLoading("push-style");
 
+  const userId = user?.id;
+  const userRole = user?.role;
+
   useEffect(() => {
-    if (!user) return;
+    if (!userId) return;
 
     setLoadError(null);
     setLoading(true);
@@ -46,7 +49,8 @@ function ManagementPage() {
         }
       })
       .finally(() => setLoading(false));
-  }, [user]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, userRole]);
 
   const getAnalystStats = (memberId: string) =>
     analysts.find((a) => a.id === memberId);

--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -29,23 +29,24 @@ function ManagementPage() {
     isLoading("push-style");
 
   useEffect(() => {
-    if (!user || (user.role !== "MANAGER" && user.role !== "ADMIN")) return;
+    if (!user) return;
 
     setLoadError(null);
+    setLoading(true);
     Promise.all([api.users.team(), api.analytics.team()])
       .then(([teamRes, analyticsRes]) => {
         setTeam(teamRes.team);
         setAnalysts(analyticsRes.analysts);
       })
-      .catch((err: Error) => {
-        setLoadError(err.message || 'Failed to load team data. Please refresh.');
+      .catch((err: any) => {
+        if (err?.statusCode === 403) {
+          setLoadError("You don't have Manager access. Contact your admin to upgrade your role.");
+        } else {
+          setLoadError(err.message || 'Failed to load team data. Please refresh.');
+        }
       })
       .finally(() => setLoading(false));
   }, [user]);
-
-  if (user && user.role !== "MANAGER" && user.role !== "ADMIN") {
-    return null;
-  }
 
   const getAnalystStats = (memberId: string) =>
     analysts.find((a) => a.id === memberId);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -332,7 +332,10 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: res.statusText }));
-        const message = err.error || err.message || "Request failed";
+        let message = err.error || err.message || "Request failed";
+        if (res.status === 429) {
+          message = "Rate limited — please wait a moment and try again.";
+        }
         const apiErr = new ApiError(message, res.status);
 
         if (!RETRYABLE_STATUSES.has(res.status) || attempt === MAX_RETRIES - 1) {


### PR DESCRIPTION
- /management 403 friendly fallback
- 429 rate limit toast in API client
- Auth re-fetch includes role + voiceProfile

Demo hardening for Wednesday.