### PR TITLE
feat(crafting): wave1 — activeVoice name visible + onApprove queue toast

### DIFF
--- a/src/app/crafting/page.tsx
+++ b/src/app/crafting/page.tsx
@@ -1055,6 +1055,15 @@ function CraftingPage() {
       const sourceUrl = extractSourceUrl(activeDraft);
       const { draft } = await api.drafts.update(activeDraft.id, { status });
       syncDraftReferences(draft, sourceUrl ?? undefined);
+      if (status === "APPROVED") {
+        try {
+          await api.drafts.enqueue(activeDraft.id);
+          toast("Draft approved and added to queue", "success");
+        } catch (enqueueError: unknown) {
+          console.warn("Failed to enqueue approved draft:", enqueueError);
+          toast("Draft approved, but failed to add to queue", "warning");
+        }
+      }
     } catch (statusError: unknown) {
       console.error(`Failed to update draft status to ${status}:`, statusError);
       setError(
@@ -1849,13 +1858,23 @@ function CraftingPage() {
                   const activeBlend = blends.find((b) => b.id === selectedBlendId);
                   if (!activeBlend) return null;
                   return (
-                    <VoicePillBar
-                      voices={activeBlend.voices.map((voice) => ({
-                        handle: voice.label,
-                        avatarUrl: voice.referenceVoice?.avatarUrl || undefined,
-                        pct: voice.percentage,
-                      }))}
-                    />
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-medium text-atlas-text-secondary">
+                          Active voice
+                        </span>
+                        <span className="text-sm font-semibold text-atlas-teal">
+                          {activeBlend.name ?? "Untitled blend"}
+                        </span>
+                      </div>
+                      <VoicePillBar
+                        voices={activeBlend.voices.map((voice) => ({
+                          handle: voice.label,
+                          avatarUrl: voice.referenceVoice?.avatarUrl || undefined,
+                          pct: voice.percentage,
+                        }))}
+                      />
+                    </div>
                   );
                 })()}
               </div>


### PR DESCRIPTION
Wave 1 portal blockers: (1) active blend name visible in voice selector, (2) Approve button adds draft to queue and shows toast.