### PR TITLE
fix(voice): trifecta-v2 — blend names, avatar chips, My Voice pill

### DIFF
--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -815,6 +815,8 @@ export default function VoiceProfilesPage() {
               isSelected={selectedVoiceId === blend.id}
               notableDimensions={notableDimensions}
               userHandle={user?.handle}
+              voices={blend.voices}
+              user={user}
               onSelect={() => setSelectedVoiceId(blend.id)}
               onUse={() => handleUseVoice(blend.id)}
               onBlend={

--- a/src/components/voice-profiles/RecipeCard.tsx
+++ b/src/components/voice-profiles/RecipeCard.tsx
@@ -16,10 +16,13 @@ import type { BlendVoice, SavedBlend } from "@/lib/api";
 import type { VoiceDimensionSnapshot } from "@/lib/voice-recipes";
 import {
   formatVoiceDimensionValue,
-  generateVoiceProfileName,
   type VoiceDimensions,
   VOICE_DIMENSION_SECTIONS,
 } from "@/lib/voice-profile-dimensions";
+import {
+  shouldGenerateVoiceProfileName,
+  generateVoiceProfileName,
+} from "@/lib/voice-naming";
 import { resolveVoiceAvatar, voiceInitials, type MinimalUser } from "@/lib/voice-avatar";
 
 interface RecipeCardProps {
@@ -153,24 +156,36 @@ export default function RecipeCard({
             )}
           </div>
           <h3 className="mt-4 font-heading text-2xl font-semibold tracking-tight text-atlas-text">
-            {blend.name ||
-              generateVoiceProfileName(
-                dimensions,
-                blend.voices
-                  .map((v) => v.referenceVoice?.handle)
-                  .filter(Boolean) as string[]
-              )}
+            {shouldGenerateVoiceProfileName(blend.name)
+              ? generateVoiceProfileName(
+                  dimensions,
+                  blend.voices.map((voice) => ({
+                    handle: voice.referenceVoice?.handle,
+                    percentage: voice.percentage,
+                    label: voice.label,
+                  }))
+                )
+              : blend.name}
           </h3>
           <div className="mt-3 flex items-center gap-3">
             <div className="flex flex-row-reverse items-center">
-              {[...blend.voices].reverse().map((voice, reverseIndex) => (
+              {blend.voices.length > 3 && (
+                <span
+                  className="flex shrink-0 items-center justify-center rounded-full border-2 border-atlas-bg bg-atlas-surface text-[10px] font-medium text-atlas-text-secondary -ml-2"
+                  style={{ width: 28, height: 28 }}
+                  aria-hidden="true"
+                >
+                  +{blend.voices.length - 3}
+                </span>
+              )}
+              {[...blend.voices].slice(0, 3).reverse().map((voice, reverseIndex) => (
                 <VoiceAvatar
                   key={`${blend.id}-${voice.id ?? voice.label}-cluster`}
                   voice={voice}
                   user={user}
                   size={28}
                   className={`border-2 border-atlas-bg ring-0 ${
-                    reverseIndex === blend.voices.length - 1 ? "" : "-ml-2"
+                    reverseIndex === 0 ? "" : "-ml-2"
                   }`}
                 />
               ))}

--- a/src/components/voice-profiles/VoiceCard.tsx
+++ b/src/components/voice-profiles/VoiceCard.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useMemo, useState } from "react";
 import { GitMerge, Loader2, Sparkles } from "lucide-react";
 import VoicePreviewPlayer from "./VoicePreviewPlayer";
-import { api } from "@/lib/api";
+import { api, type BlendVoice } from "@/lib/api";
 import {
   getNotableVoiceDimensions,
   type VoiceDimensionSnapshot,
 } from "@/lib/voice-recipes";
 import type { VoiceDimensions } from "@/lib/voice-profile-dimensions";
+import { resolveVoiceAvatar, voiceInitials, type MinimalUser } from "@/lib/voice-avatar";
 
 interface VoiceCardProps {
   name: string;
@@ -19,6 +20,8 @@ interface VoiceCardProps {
   /** @deprecated Prefer notableDimensions. Kept for backwards compat. */
   dimensions?: VoiceDimensions;
   userHandle?: string;
+  voices?: BlendVoice[];
+  user?: MinimalUser | null;
   onSelect: () => void;
   onUse: () => void;
   onBlend?: () => void;
@@ -54,6 +57,87 @@ function toRecipePills(snapshots: VoiceDimensionSnapshot[] | undefined): RecipeP
   });
 }
 
+function AvatarChip({
+  voice,
+  user,
+  className = "",
+  style,
+}: {
+  voice: BlendVoice;
+  user?: MinimalUser | null;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const url = resolveVoiceAvatar(voice, user);
+  const initials = voiceInitials(voice, user);
+
+  if (!url) {
+    return (
+      <span
+        className={`flex shrink-0 items-center justify-center rounded-full border border-glass-border bg-atlas-surface text-[10px] font-bold text-atlas-text-muted ${className}`}
+        style={style}
+        aria-hidden="true"
+      >
+        {initials}
+      </span>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={voice.label}
+      className={`shrink-0 rounded-full object-cover ${className}`}
+      style={style}
+      onError={(event) => {
+        event.currentTarget.style.display = "none";
+      }}
+    />
+  );
+}
+
+function AvatarStack({
+  voices,
+  user,
+  size = 20,
+}: {
+  voices: BlendVoice[];
+  user?: MinimalUser | null;
+  size?: number;
+}) {
+  const maxVisible = 3;
+  const visible = voices.slice(0, maxVisible);
+  const remaining = voices.length - maxVisible;
+
+  return (
+    <div className="flex flex-row-reverse items-center">
+      {remaining > 0 && (
+        <span
+          className="flex shrink-0 items-center justify-center rounded-full border border-glass-border bg-atlas-surface text-[10px] font-medium text-atlas-text-secondary"
+          style={{ width: size, height: size, marginLeft: -size / 3 }}
+          aria-hidden="true"
+        >
+          +{remaining}
+        </span>
+      )}
+      {[...visible].reverse().map((voice, index) => (
+        <AvatarChip
+          key={`${voice.id ?? voice.label}-chip`}
+          voice={voice}
+          user={user}
+          className="border-2 border-atlas-bg ring-0"
+          style={{
+            width: size,
+            height: size,
+            marginLeft: index === 0 ? 0 : -size / 3,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}
+
 export default function VoiceCard({
   name,
   isActive,
@@ -62,6 +146,8 @@ export default function VoiceCard({
   notableDimensions,
   dimensions,
   userHandle: _userHandle,
+  voices,
+  user,
   onSelect,
   onUse,
   onBlend,
@@ -178,6 +264,12 @@ export default function VoiceCard({
         className="absolute inset-0 rounded-2xl focus:outline-none focus:ring-2 focus:ring-atlas-teal focus:ring-inset"
       />
 
+      {isActive && (
+        <span className="absolute right-3 top-3 z-10 rounded-full border border-atlas-teal/30 bg-atlas-teal/10 px-2 py-0.5 text-[10px] font-semibold text-atlas-teal">
+          My Voice
+        </span>
+      )}
+
       <div className="relative z-10 flex items-start justify-between gap-2">
         <span
           className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
@@ -203,6 +295,15 @@ export default function VoiceCard({
       </div>
 
       <p className="relative z-10 mt-2 truncate font-heading text-sm font-semibold text-atlas-text">{name}</p>
+
+      {voices && voices.length > 0 && (
+        <div className="relative z-10 mt-2 flex items-center gap-2">
+          <AvatarStack voices={voices} user={user} size={20} />
+          <span className="text-[10px] text-atlas-text-muted">
+            {voices.length} voice{voices.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      )}
 
       <div className="relative z-10 mt-3">
         <button


### PR DESCRIPTION
## Changes

- **RecipeCard.tsx**: Normalizes blend names using `voice-naming.ts` helpers (`shouldGenerateVoiceProfileName` + `generateVoiceProfileName` with rich handle objects) instead of the older `voice-profile-dimensions` fallback. Also caps avatar stack to 3 chips with `+N more`.
- **VoiceCard.tsx**: Adds stacked avatar chips for blend component voices (max 3 + `+N more`) and a teal `My Voice` pill badge when `isActive=true`.
- **voice-profiles/page.tsx**: Passes `voices` and `user` props to `VoiceCard` so avatar chips can render.

## Checklist
- [x] Tests pass
- [x] TypeScript compiles