### PR TITLE
fix(onboarding): range sliders draggable — touch-none prevents scroll intercept

### DIFF
--- a/src/components/ui/DimensionBar.tsx
+++ b/src/components/ui/DimensionBar.tsx
@@ -48,7 +48,7 @@ export default function DimensionBar({
             value={clampedPercentage}
             onChange={(event) => onChange?.(Number(event.target.value))}
             aria-label={label}
-            className="relative z-10 h-6 w-full appearance-none bg-transparent focus:outline-none
+            className="relative z-10 h-6 w-full touch-none appearance-none bg-transparent focus:outline-none
               [&::-webkit-slider-runnable-track]:h-1
               [&::-webkit-slider-runnable-track]:rounded-full
               [&::-webkit-slider-runnable-track]:bg-transparent


### PR DESCRIPTION
## Problem
Voice calibration sliders on /onboarding (Humor, Formality, Brevity, Contrarian, Directness) couldn't be dragged — page scrolled instead.

## Root cause
`DimensionBar` range inputs sit inside OracleChat's `overflow-y-auto` scroll container (line 963). On touch devices, the browser interprets drag gestures as scroll events before the range input can handle them.

## Fix
Add `touch-action: none` (`touch-none` Tailwind) to the range input in `DimensionBar`. This tells the browser to pass all touch events directly to the element instead of handling scroll/pan.

**Change:** `src/components/ui/DimensionBar.tsx` — one class added to line 51.

## Test
1. Go to delphi-atlas.vercel.app/onboarding
2. Complete X connect → reach the dimension sliders step
3. Drag any slider on mobile/touch — should drag, not scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)