### PR TITLE
fix(voice): Twitter profile photos for blend avatars

### DIFF
--- a/src/__tests__/components/voice-profiles/RecipeCard.test.tsx
+++ b/src/__tests__/components/voice-profiles/RecipeCard.test.tsx
@@ -214,12 +214,12 @@ describe("RecipeCard", () => {
     expect(unavatarImg).toBeDefined();
   });
 
-  it("renders initials fallback when voice has no URL and no user handle", () => {
+  it("renders initials fallback when self voice has no URL and no user handle", () => {
     const blend = makeBlend({
       voices: [
         {
           id: "v1",
-          label: "Zeta",
+          label: "My voice",
           percentage: 100,
           referenceVoice: null,
           referenceVoiceId: null,
@@ -227,17 +227,17 @@ describe("RecipeCard", () => {
       ],
     });
     renderCard({ blend, userHandle: undefined });
-    // Initials span with "Z" should appear (aria-hidden, but still in DOM)
-    const initialSpans = screen.getAllByText("Z");
+    // Initials span with "M" should appear (aria-hidden, but still in DOM)
+    const initialSpans = screen.getAllByText("M");
     expect(initialSpans.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("uses userHandle for unavatar when voice has no referenceVoice", () => {
+  it("uses userHandle for unavatar when self voice has no referenceVoice", () => {
     const blend = makeBlend({
       voices: [
         {
           id: "v1",
-          label: "Own Voice",
+          label: "My voice",
           percentage: 100,
           referenceVoice: null,
           referenceVoiceId: null,

--- a/src/__tests__/lib/voice-avatar.test.ts
+++ b/src/__tests__/lib/voice-avatar.test.ts
@@ -13,8 +13,11 @@ describe("isSelfVoice", () => {
   it("true when explicit isSelf flag", () => {
     expect(isSelfVoice(makeVoice({ isSelf: true, referenceVoiceId: "x" }))).toBe(true);
   });
-  it("true when no referenceVoice and no referenceVoiceId", () => {
-    expect(isSelfVoice(makeVoice({ label: "whatever" }))).toBe(true);
+  it("true when no referenceVoice and no referenceVoiceId with self-like label", () => {
+    expect(isSelfVoice(makeVoice({ label: "My voice" }))).toBe(true);
+  });
+  it("false when no referenceVoice and no referenceVoiceId but non-self label (missing-link inspiration)", () => {
+    expect(isSelfVoice(makeVoice({ label: "cobie" }))).toBe(false);
   });
   it("true when label is 'My voice' even with referenceVoice attached (defensive)", () => {
     expect(
@@ -27,6 +30,13 @@ describe("isSelfVoice", () => {
     expect(
       isSelfVoice(
         makeVoice({ label: "Hosseeb", referenceVoiceId: "r1", referenceVoice: { id: "r1", name: "Hosseeb", handle: "hosseeb", avatarUrl: "http://a" } })
+      )
+    ).toBe(false);
+  });
+  it("false for inspiration with synthetic self fallback (backend fallback bug)", () => {
+    expect(
+      isSelfVoice(
+        makeVoice({ label: "cobie", referenceVoiceId: null, referenceVoice: { id: "self:user-123", name: "cobie", handle: "alex", avatarUrl: "http://me" } })
       )
     ).toBe(false);
   });
@@ -73,6 +83,26 @@ describe("resolveVoiceAvatar", () => {
       referenceVoice: { id: "r2", name: "Naval", handle: "naval" },
     });
     expect(resolveVoiceAvatar(v, { handle: "alex" })).toBe("https://unavatar.io/twitter/naval");
+  });
+  it("inspiration with synthetic self fallback → ignores user avatar and uses label handle for unavatar", () => {
+    const v = makeVoice({
+      label: "cobie",
+      referenceVoiceId: null,
+      referenceVoice: { id: "self:user-123", name: "cobie", handle: "alex", avatarUrl: "https://cdn/me.png" },
+    });
+    expect(resolveVoiceAvatar(v, { avatarUrl: "https://cdn/me.png", handle: "alex" })).toBe(
+      "https://unavatar.io/twitter/cobie"
+    );
+  });
+  it("inspiration with synthetic self fallback and @-prefixed label → strips @ for unavatar", () => {
+    const v = makeVoice({
+      label: "@blknoiz06",
+      referenceVoiceId: null,
+      referenceVoice: { id: "self:user-123", name: "@blknoiz06", handle: "alex", avatarUrl: "https://cdn/me.png" },
+    });
+    expect(resolveVoiceAvatar(v, { avatarUrl: "https://cdn/me.png", handle: "alex" })).toBe(
+      "https://unavatar.io/twitter/blknoiz06"
+    );
   });
 });
 

--- a/src/lib/voice-avatar.ts
+++ b/src/lib/voice-avatar.ts
@@ -8,12 +8,24 @@ export interface MinimalUser {
 }
 
 /**
+ * The backend's `withSafeReferenceVoice` creates a synthetic fallback
+ * referenceVoice when the real one is missing. It uses the user's own
+ * data (handle, avatarUrl) and sets an id like `self:${userId}`.
+ * We detect this so we don't show the user's avatar for inspiration accounts.
+ */
+function isSyntheticSelfFallback(
+  referenceVoice: { id?: string } | null | undefined
+): boolean {
+  return !!referenceVoice?.id?.startsWith("self:");
+}
+
+/**
  * True when this BlendVoice represents the authoring user themselves,
  * not an inspiration/reference account.
  *
  * Rules (in priority order):
  *   1. Explicit `isSelf` flag on the voice (future-proofing).
- *   2. No referenceVoiceId AND no referenceVoice object.
+ *   2. No referenceVoiceId AND (no referenceVoice OR synthetic self fallback).
  *   3. Label matches "My voice" / "Me" / "You" (case-insensitive, trimmed) —
  *      defensive against backend rows that mistakenly attach a referenceVoice
  *      to the user's own slot.
@@ -22,9 +34,28 @@ export function isSelfVoice(
   voice: Pick<BlendVoice, "label" | "referenceVoice" | "referenceVoiceId"> & { isSelf?: boolean }
 ): boolean {
   if (voice.isSelf === true) return true;
-  if (!voice.referenceVoiceId && !voice.referenceVoice) return true;
   const label = (voice.label ?? "").trim().toLowerCase();
-  if (label === "my voice" || label === "me" || label === "you") return true;
+
+  // Known self labels always indicate the user's own voice
+  if (label === "my voice" || label === "me" || label === "you" || label === "your voice" || label === "own voice") {
+    return true;
+  }
+
+  const realRef =
+    voice.referenceVoice && !isSyntheticSelfFallback(voice.referenceVoice)
+      ? voice.referenceVoice
+      : null;
+
+  // A real linked reference voice means it's an inspiration account
+  if (voice.referenceVoiceId && realRef) return false;
+
+  // No reference link at all: empty label defaults to self,
+  // anything else is treated as an inspiration account with a missing DB link.
+  if (!voice.referenceVoiceId && !realRef) {
+    if (!label) return true;
+    return false;
+  }
+
   return false;
 }
 
@@ -41,10 +72,24 @@ export function resolveVoiceAvatar(
     if (user?.handle) return getTwitterAvatarUrl(user.handle) ?? "";
     return "";
   }
-  if (voice.referenceVoice?.avatarUrl) return voice.referenceVoice.avatarUrl;
-  if (voice.referenceVoice?.handle) {
-    return getTwitterAvatarUrl(voice.referenceVoice.handle) ?? "";
+
+  const realRef =
+    voice.referenceVoice && !isSyntheticSelfFallback(voice.referenceVoice)
+      ? voice.referenceVoice
+      : null;
+
+  if (realRef?.avatarUrl) return realRef.avatarUrl;
+  if (realRef?.handle) {
+    return getTwitterAvatarUrl(realRef.handle) ?? "";
   }
+
+  // Fallback: if the backend didn't link a real reference voice but the label
+  // looks like a handle (e.g. "cobie" or "@cobie"), derive the avatar from it.
+  const labelHandle = voice.label?.replace(/^@/, "").trim();
+  if (labelHandle) {
+    return getTwitterAvatarUrl(labelHandle) ?? "";
+  }
+
   return "";
 }
 


### PR DESCRIPTION
## Summary
- `voice-avatar.ts`: fetches Twitter profile photo URL for blend reference voices
- Replaces static placeholder with real avatar from `avatarUrl` field

## Note
Cherry-picked from the stale #457 branch (which included many already-merged commits).

## Test plan
- [ ] Create a blend on Voice Profiles
- [ ] Blend avatar chips show Twitter profile photos where available
- [ ] Falls back gracefully when no avatar URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)