### PR TITLE
fix(onboarding+oracle): scan spinner un-sticks + briefing error surfacing

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -114,7 +114,7 @@ const searchParams = useSearchParams();
               .then((r) => {
                 if (!cancelled) setBriefingText(r.text);
               })
-              .catch(() => null)
+              .catch((err: unknown) => { if (!cancelled) setBriefingText(null); console.warn('[Oracle] briefing failed:', (err as Error)?.message); })
               .finally(() => {
                 if (!cancelled) setBriefingLoading(false);
               });

--- a/src/components/onboarding/OracleChat.tsx
+++ b/src/components/onboarding/OracleChat.tsx
@@ -421,6 +421,19 @@ export default function OracleChat() {
     setScanLoading(true);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
+    const slowMessageId = setTimeout(() => {
+      dispatch({
+        type: "ENQUEUE_MESSAGES",
+        messages: [
+          {
+            id: `calibration-slow-${Date.now()}`,
+            role: "system" as const,
+            content: "Still scanning... this can take up to 30 seconds.",
+            timestamp: Date.now(),
+          },
+        ],
+      });
+    }, 12_000);
 
     (async () => {
       try {
@@ -456,7 +469,8 @@ export default function OracleChat() {
             dimensions: calibratedDimensions,
           },
         });
-        await refreshUser();
+        // Fire-and-forget so a slow /auth/me call can't stall the spinner
+        refreshUser().catch(() => {});
         const profileDimensions = {
           humor: profile.humor ?? 50,
           formality: profile.formality ?? 50,
@@ -528,6 +542,7 @@ export default function OracleChat() {
           ],
         });
       } finally {
+        clearTimeout(slowMessageId);
         setScanLoading(false);
         calibratingRef.current = false;
       }
@@ -535,6 +550,7 @@ export default function OracleChat() {
 
     return () => {
       clearTimeout(timeoutId);
+      clearTimeout(slowMessageId);
       controller.abort();
     };
   }, [state.currentStep, state.xHandle, state.calibrationResult]);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -359,6 +359,8 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
       }
     } catch (e) {
       if (e instanceof ApiError && !RETRYABLE_STATUSES.has(e.statusCode)) throw e;
+      // Don't retry intentional aborts/timeouts — retrying an aborted signal wastes time
+      if (e instanceof DOMException && e.name === "AbortError") throw e;
       if (attempt === MAX_RETRIES - 1) throw e;
       // Network errors and retryable status codes fall through to retry
     }


### PR DESCRIPTION
## Summary
- **`OracleChat.tsx`**: Prevent AbortError retries that froze scan spinner for 30s+; add slow-scan message at 12s mark; make `refreshUser()` fire-and-forget so slow `/auth/me` can't stall post-calibration UI
- **`api.ts`**: Skip retry loop on AbortError signal
- **`dashboard/page.tsx`**: Replace silent `.catch(() => null)` with error logging so Oracle briefing failures surface in console (no UX change)

## Test plan
- [ ] Go through onboarding Track A → connect X → scan completes without freezing
- [ ] Slow connection: see "Still scanning..." message at ~12s
- [ ] Dashboard Oracle: open console → any briefing error now logs warning instead of silent null

🤖 Generated with [Claude Code](https://claude.com/claude-code)