### PR TITLE
fix(dashboard): surface oracle briefing errors to console

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -114,7 +114,7 @@ const searchParams = useSearchParams();
               .then((r) => {
                 if (!cancelled) setBriefingText(r.text);
               })
-              .catch(() => null)
+              .catch((err: unknown) => { if (!cancelled) setBriefingText(null); console.warn('[Oracle] briefing failed:', (err as Error)?.message); })
               .finally(() => {
                 if (!cancelled) setBriefingLoading(false);
               });


### PR DESCRIPTION
## Summary
- Replace `.catch(() => null)` with explicit error logging in oracle briefing fetch
- Fallback UX unchanged — widget still shows static message on failure
- Adds `console.warn('[Oracle] briefing failed:', ...)` for debugging visibility during demo

## Test plan
- [ ] Dashboard loads normally — briefing generates as usual
- [ ] If oracle.chat fails, widget shows fallback message (not blank)
- [ ] Console shows `[Oracle] briefing failed:` on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)