### PR TITLE
fix(voice-lab): guard premature tweet gen + add comparison preview

### DIFF
--- a/e2e/oracle.spec.ts
+++ b/e2e/oracle.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test, type Route } from "@playwright/test";
+import { type Route } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 const AUTH_COOKIES = (hostname: string) => [
   { name: "atlas_session", value: "1", domain: hostname, path: "/" },

--- a/e2e/performance/perf.spec.ts
+++ b/e2e/performance/perf.spec.ts
@@ -23,7 +23,10 @@ test.describe("Performance — no console errors", () => {
     const errors: string[] = [];
     authedPage.on("pageerror", (err) => errors.push(err.message));
 
-    await authedPage.goto("/dashboard", { waitUntil: "networkidle" });
+    // domcontentloaded, not networkidle: the dashboard polls continuously,
+    // so networkidle never fires against a live preview and the goto times
+    // out. The settle wait below gives late errors time to surface.
+    await authedPage.goto("/dashboard", { waitUntil: "domcontentloaded" });
     await authedPage.waitForTimeout(2000);
 
     expect(errors, `Console errors on dashboard: ${errors.join(", ")}`).toHaveLength(0);
@@ -44,7 +47,10 @@ test.describe("Performance — bundle size checks", () => {
       }
     });
 
-    await authedPage.goto("/dashboard", { waitUntil: "networkidle" });
+    // "load" waits for initial resources (the chunks this test measures)
+    // without requiring network silence the polling dashboard never gives.
+    await authedPage.goto("/dashboard", { waitUntil: "load" });
+    await authedPage.waitForTimeout(2000);
 
     const oversized = resources.filter((r) => r.size > 500_000);
     if (oversized.length > 0) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { resolveVercelBypassHeaders } from "./e2e/playwright-env";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -14,6 +15,10 @@ export default defineConfig({
     baseURL:
       process.env.PLAYWRIGHT_BASE_URL ||
       "https://staging-delphi-atlas.vercel.app",
+    // Vercel deployment protection returns 401 without the bypass header;
+    // playwright-e2e.config.ts has had this since protection was enabled,
+    // this config never did (152/203 failures against any protected preview).
+    extraHTTPHeaders: resolveVercelBypassHeaders(),
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     actionTimeout: 10000,

--- a/src/app/voice-profiles/page.tsx
+++ b/src/app/voice-profiles/page.tsx
@@ -185,6 +185,13 @@ export default function VoiceProfilesPage() {
     blend: { text: string | null; error: string | null; label: string };
   } | null>(null);
   const [compareVsMineLoading, setCompareVsMineLoading] = useState(false);
+  const [originalVsStyledLoading, setOriginalVsStyledLoading] = useState(false);
+  const [originalVsStyledResult, setOriginalVsStyledResult] = useState<{
+    label: string;
+    original: string;
+    text: string | null;
+    error: string | null;
+  } | null>(null);
   const comparisonSectionRef = useRef<HTMLDivElement>(null);
   const [calibrateHandle, setCalibrateHandle] = useState("");
   const [blendSelectMode, setBlendSelectMode] = useState(false);
@@ -286,6 +293,14 @@ export default function VoiceProfilesPage() {
     [profile]
   );
 
+  // calibration_complete gate: no tweet generation may fire until the user's
+  // voice profile is calibrated — generating against the default 50/50
+  // dimensions produces tone-less drafts that look like a broken product.
+  const calibrationComplete = useMemo(
+    () => hasCalibratedVoiceDimensions(profile),
+    [profile]
+  );
+
   const recipeCards = useMemo(
     () =>
       blends.map((blend) => {
@@ -330,6 +345,15 @@ export default function VoiceProfilesPage() {
   const handlePreviewBlend = useCallback(
     async (blend: SavedBlend, dimensions: VoiceDimensions) => {
       if (previewingBlendId) {
+        return;
+      }
+
+      if (!calibrationComplete) {
+        setBlendPreviewErrors((current) => ({
+          ...current,
+          [blend.id]:
+            "Calibrate your voice first — sample tweets unlock after calibration.",
+        }));
         return;
       }
 
@@ -379,11 +403,11 @@ export default function VoiceProfilesPage() {
         );
       }
     },
-    [previewingBlendId]
+    [calibrationComplete, previewingBlendId]
   );
 
   const handleCompareAll = useCallback(async () => {
-    if (compareAllLoading || !compareAllTopic.trim()) return;
+    if (compareAllLoading || !calibrationComplete || !compareAllTopic.trim()) return;
     const topic = compareAllTopic.trim();
     const voiceTargets = [
       { id: PERSONAL_VOICE_ID, label: "Personal Voice", blendId: undefined as string | undefined },
@@ -413,11 +437,11 @@ export default function VoiceProfilesPage() {
       })
     );
     setCompareAllLoading(false);
-  }, [blends, compareAllLoading, compareAllTopic]);
+  }, [blends, calibrationComplete, compareAllLoading, compareAllTopic]);
 
   const handleCompareVsMine = useCallback(
     async (blendId: string) => {
-      if (compareVsMineLoading) return;
+      if (compareVsMineLoading || !calibrationComplete) return;
       const blend = blends.find((b) => b.id === blendId);
       if (!blend) return;
 
@@ -476,8 +500,43 @@ export default function VoiceProfilesPage() {
         comparisonSectionRef.current?.scrollIntoView({ behavior: "smooth" });
       }, 100);
     },
-    [blends, compareAllTopic, compareVsMineLoading]
+    [blends, calibrationComplete, compareAllTopic, compareVsMineLoading]
   );
+
+  const handlePreviewOriginalVsStyled = useCallback(async () => {
+    if (originalVsStyledLoading || !calibrationComplete || !selectedBlend) return;
+    const topic = compareAllTopic.trim();
+    if (!topic) return;
+
+    setOriginalVsStyledLoading(true);
+    setOriginalVsStyledResult(null);
+
+    try {
+      const response = await api.drafts.generate({
+        sourceContent: topic,
+        sourceType: "MANUAL",
+        blendId: selectedBlend.id,
+      });
+      setOriginalVsStyledResult({
+        label: selectedBlend.name,
+        original: topic,
+        text: response.draft.content,
+        error: null,
+      });
+    } catch (previewError: unknown) {
+      setOriginalVsStyledResult({
+        label: selectedBlend.name,
+        original: topic,
+        text: null,
+        error:
+          previewError instanceof Error
+            ? previewError.message
+            : "Generation failed",
+      });
+    } finally {
+      setOriginalVsStyledLoading(false);
+    }
+  }, [calibrationComplete, compareAllTopic, originalVsStyledLoading, selectedBlend]);
 
   const handleUseVoice = (voiceId: string) => {
     setActiveVoiceId(voiceId);
@@ -963,6 +1022,15 @@ export default function VoiceProfilesPage() {
               saved voice simultaneously so you can pick the version that lands
               best.
             </p>
+            {!calibrationComplete && (
+              <p
+                role="status"
+                className="mt-3 rounded-lg border border-atlas-warning/30 bg-atlas-warning/10 px-3 py-2 text-xs font-medium text-atlas-warning"
+              >
+                Finish voice calibration to unlock tweet generation — previews
+                and comparisons stay disabled until your voice is calibrated.
+              </p>
+            )}
           </div>
 
           <div className="mt-5 space-y-3">
@@ -979,26 +1047,117 @@ export default function VoiceProfilesPage() {
               <span className="text-xs text-atlas-text-muted">
                 {compareAllTopic.length}/1000
               </span>
-              <button
-                type="button"
-                onClick={() => void handleCompareAll()}
-                disabled={compareAllLoading || !compareAllTopic.trim()}
-                className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-atlas-teal to-atlas-teal/60 px-5 py-2.5 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {compareAllLoading ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-                    Generating…
-                  </>
-                ) : (
-                  <>
-                    <Wand2 className="h-3.5 w-3.5" aria-hidden="true" />
-                    Generate in all voices
-                  </>
+              <div className="flex items-center gap-3">
+                {selectedBlend && (
+                  <button
+                    type="button"
+                    onClick={() => void handlePreviewOriginalVsStyled()}
+                    disabled={
+                      originalVsStyledLoading ||
+                      !calibrationComplete ||
+                      !compareAllTopic.trim()
+                    }
+                    className="flex items-center gap-2 rounded-lg border border-atlas-teal/30 bg-atlas-teal/10 px-5 py-2.5 text-sm font-semibold text-atlas-teal transition-colors hover:bg-atlas-teal/15 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {originalVsStyledLoading ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                        Generating…
+                      </>
+                    ) : (
+                      <>Original vs {selectedBlend.name}</>
+                    )}
+                  </button>
                 )}
-              </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCompareAll()}
+                  disabled={
+                    compareAllLoading ||
+                    !calibrationComplete ||
+                    !compareAllTopic.trim()
+                  }
+                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-atlas-teal to-atlas-teal/60 px-5 py-2.5 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {compareAllLoading ? (
+                    <>
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                      Generating…
+                    </>
+                  ) : (
+                    <>
+                      <Wand2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      Generate in all voices
+                    </>
+                  )}
+                </button>
+              </div>
             </div>
           </div>
+
+          {/* Original vs styled — raw source text next to the voice-styled output */}
+          {(originalVsStyledLoading || originalVsStyledResult) && (
+            <div className="mt-6 rounded-2xl border border-atlas-teal/20 bg-atlas-teal/5 p-5">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-atlas-text">
+                  Before / after:{" "}
+                  <span className="text-atlas-text-secondary">
+                    Original vs.{" "}
+                    {originalVsStyledResult?.label ?? selectedBlend?.name ?? "Voice"}
+                  </span>
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOriginalVsStyledResult(null);
+                    setOriginalVsStyledLoading(false);
+                  }}
+                  aria-label="Dismiss original vs styled preview"
+                  className="rounded-lg p-1 text-atlas-text-muted transition-colors hover:bg-atlas-surface/60 hover:text-atlas-text"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {originalVsStyledLoading ? (
+                <div className="mt-4 flex items-center justify-center gap-2 py-8 text-sm text-atlas-text-muted">
+                  <Loader2 className="h-4 w-4 animate-spin text-atlas-teal" />
+                  Generating styled version...
+                </div>
+              ) : originalVsStyledResult ? (
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div
+                    className="rounded-2xl border border-glass-border bg-atlas-surface/60 p-4"
+                    aria-label="Original text"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-wider text-atlas-text-muted">
+                      Original
+                    </p>
+                    <p className="mt-3 text-sm leading-6 text-atlas-text">
+                      {originalVsStyledResult.original}
+                    </p>
+                  </div>
+                  <div
+                    className="rounded-2xl border border-atlas-teal/30 bg-atlas-surface/60 p-4"
+                    aria-label={`With ${originalVsStyledResult.label}`}
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-wider text-atlas-teal">
+                      With {originalVsStyledResult.label}
+                    </p>
+                    {originalVsStyledResult.error ? (
+                      <p role="alert" className="mt-3 text-xs text-atlas-error">
+                        {originalVsStyledResult.error}
+                      </p>
+                    ) : originalVsStyledResult.text ? (
+                      <p className="mt-3 text-sm leading-6 text-atlas-text">
+                        {originalVsStyledResult.text}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
 
           {/* Compare vs Mine — focused 2-column comparison */}
           {(compareVsMineLoading || compareVsMineResults) && (


### PR DESCRIPTION
## What

- **Premature tweet generation killed**: every generation path on `/voice-profiles` (blend sample preview, *Generate in all voices*, *Compare vs mine*) is now gated behind `calibration_complete` — i.e. `hasCalibratedVoiceDimensions(profile)`. Uncalibrated profiles were firing `drafts.generate`/`oracle.chat` against the default 50/50 dimension fingerprint, producing tone-less drafts mid-calibration.
- Trigger buttons disable while uncalibrated, with a warning notice in the Voice Comparison section; the per-blend preview surface explains the lock if invoked.
- **Comparison preview added**: with a voice selected, *Original vs [name]* renders a side-by-side — left column the raw topic text, right column the voice-styled output from the existing blend API (`drafts.generate` with `blendId`).

## Acceptance criteria

- [x] No tweet generation fires before `calibration_complete` is true (all three callbacks early-return + buttons disabled)
- [x] Comparison preview renders side-by-side (original vs voice-styled) after profile selection
- [x] No TypeScript errors — `tsc --noEmit` clean, `next build` passes
- [x] PR open to staging

Dispatch task 2100024 (SAGE Execution Prompt — Voice Lab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)